### PR TITLE
Issue #3 - Fix import path of sentry_sdk

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,8 +29,10 @@ bl_info = {
 }
 
 import sys
-sys.path.insert(0, './lib')
-import sentry_sdk
+from os import path
+lib = path.join(path.dirname(__file__), 'lib')
+sys.path.insert(0, lib)
+from .lib import sentry_sdk
 sentry_sdk.init(
     "https://d0c1619436104436999ef934ecba6393@o182975.ingest.sentry.io/6075237",
 

--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,7 @@ bl_info = {
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",
     "warning": "",
     "doc_url": "{BLENDER_MANUAL_URL}/addons/3d_view/blenderkit.html",
+    "tracker_url": "https://github.com/BlenderKit/blenderkit/issues",
     "category": "3D View",
 }
 


### PR DESCRIPTION
Fixes #3
Fixes #5 

Tested on blender-3.0.0-beta+v30.3844e9dbe771-linux.x86_64-release. Needs a test on Windows and if works properly if used outside the Blender.