### PR TITLE
Circumvent autoupdater possible issues

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -42,6 +42,7 @@ def ensure_deps():
     tried = tried + 1
     try:
       import aiohttp
+      from aiohttp import web, web_request
       import certifi
       return
     except:

--- a/timer.py
+++ b/timer.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # pending tasks are tasks that were not parsed correclty and should be tried to be parsed later.
 pending_tasks = list()
 reader_loop = None
-ENABLE_ASYNC_LOOP =False
+ENABLE_ASYNC_LOOP =True
 
 reports_queue = queue.Queue()
 


### PR DESCRIPTION
aiohttp install might get screwed by autoupdater.
This prevents blender from getting stuck when trying to start daemon perpetually, by enabling async loop in timer.
by trying import from aiohttp sublibrary we can find out that aiohttp is actually installed wrongly.