### PR TITLE
Add requirements.txt to build

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -30,7 +30,6 @@ def do_build(install_at=None):
     '.gitignore',
     'build.py',
     'README.md',
-    'requirements.txt',
     'setup.cfg'
   ]
 


### PR DESCRIPTION
In build process I have added requirements.txt into ignored files. But requirements.txt are used in fallback dependency installation so this PR adds the file back into the build zip. Installation can run without requirements.txt but it is better to first try fixed predefined versions from requirements.txt and then only if that fails try to make unconstrained install.