### PR TITLE
Bumb up version and add warning info about update

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,11 +19,11 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy",
-    "version": (3, 1, 3),
+    "version": (3, 1, 4),
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",
-    "warning": "",
+    "warning": "If auto-update failed, or add-on behaves badly after auto-update, please: disable add-on, restart computer, remove add-on and install directly from .zip. Auto-update was fixed in 3.1.4, so update from 3.1.4 to future 3.1.5 will be OK. More at GitHub issue #131. Thank you for understanding.",
     "doc_url": "{BLENDER_MANUAL_URL}/addons/3d_view/blenderkit.html",
     "tracker_url": "https://github.com/BlenderKit/blenderkit/issues",
     "category": "3D View",


### PR DESCRIPTION
@vilemduha Bumping the version to 3.1.4. And also I realized, we can add warning to the bl_info, which gets parsed even though the auto-update fails and imports and everything is corrupted... Blender parses bl_info as string, so it will be shown. Please take a look on it in Blender GUI if it looks good and if wording is correct. I think this could provide needed information to the users.