### PR TITLE
Do not set unused self.__image.name in set_image()

### DIFF
--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -42,7 +42,6 @@ class BL_UI_Image(BL_UI_Widget):
                     self.__image = img
                 else:
                     self.__image = bpy.data.images.load(rel_filepath, check_existing=True)
-                    self.__image.name = imgname
 
                 self.__image.gl_load()
 


### PR DESCRIPTION
fixes #159 

Please @vilemduha take a look. __image.name seems to be unused in the `bl_ui_widgets/bl_ui_image.py`. It is not set or get or mentioned anywhere in the file. Does it have any hidden function?

Removing it fixes the error printing to console and also search seems to work as expected.