### PR TITLE
Add support for XDG Base directory

### DIFF
--- a/paths.py
+++ b/paths.py
@@ -99,8 +99,10 @@ def get_asset_gallery_url(asset_id):
 
 
 def default_global_dict():
-    from os.path import expanduser
-    home = expanduser("~")
+    home = os.path.expanduser("~")
+    data_home = os.environ.get('XDG_DATA_HOME')
+    if data_home != None:
+        home = data_home
     return home + os.sep + 'blenderkit_data'
 
 


### PR DESCRIPTION
Hello BlenderKit Devs,

First of all, thank you for BlenderKit!  Most free desktop OS follows
[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) which defines where files should be
looked for by defining one or more base directories relative to which files should be located.

BlenderKit defines a `Global Files Directory` in `$HOME/blenderkit_data`,
which according to aforementioned specification, should be in
`$XDG_DATA_HOME/blenderkit_data`.  Additionaly, `$XDG_DATA_HOME`
is a single base directory relative to which user-specific data files should be written.

Thank you.
