### PR TITLE
Isolate blenderkit logging from exposed root logger

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,16 +32,15 @@ bl_info = {
 import sys
 from os import path
 
+from . import dependencies, log
+
+
+log.configure_loggers()
 
 sys.path.insert(0, path.join(path.dirname(__file__), 'daemon'))
-
-from . import dependencies
-
-
 dependencies.add_vendored()
 dependencies.add_fallback()
 dependencies.ensure_deps()
-
 
 
 # lib = path.join(path.dirname(__file__), 'lib')
@@ -162,10 +161,6 @@ from bpy.props import (
     StringProperty,
 )
 from bpy.types import AddonPreferences, PropertyGroup
-
-
-# logging.basicConfig(filename = 'blenderkit.log', level = logging.INFO,
-#                     format = '	%(asctime)s:%(filename)s:%(funcName)s:%(lineno)d:%(message)s')
 
 
 @persistent

--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -41,7 +41,7 @@ from .daemon import tasks
 
 CLIENT_ID = "IdFRwa3SGA8eMpzhRVFMg5Ts8sPK93xBjif93x0F"
 active_authenticator = None
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 
 def handle_login_task(task: tasks.Task):

--- a/categories.py
+++ b/categories.py
@@ -29,7 +29,7 @@ import bpy
 from . import colors, global_vars, paths, reports, rerequests, tasks_queue, utils
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 
 def count_to_parent(parent):

--- a/comments_utils.py
+++ b/comments_utils.py
@@ -25,7 +25,7 @@ import bpy
 from . import global_vars, paths, rerequests, search, tasks_queue, utils
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 
 def upload_comment_thread(asset_id, comment_id=0, comment='', api_key=None):

--- a/download.py
+++ b/download.py
@@ -43,7 +43,7 @@ from . import (
 from .daemon import tasks
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 import bpy
 from bpy.app.handlers import persistent

--- a/global_vars.py
+++ b/global_vars.py
@@ -1,8 +1,7 @@
 import logging
 
 
+DATA = { 'images available': {} }
+LOGGING_LEVEL_BLENDERKIT = logging.INFO
+LOGGING_LEVEL_IMPORTED = logging.WARN
 PREFS = {}
-DATA = {'images available':{}}
-
-log = logging.basicConfig(level=logging.INFO)
-browser = None

--- a/log.py
+++ b/log.py
@@ -1,0 +1,23 @@
+import logging
+
+from . import global_vars
+
+
+def configure_bk_logger():
+  logging.basicConfig(level=global_vars.LOGGING_LEVEL_BLENDERKIT)
+  bk_logger = logging.getLogger("blenderkit")
+  bk_logger.propagate = False
+  bk_log_handler = logging.StreamHandler()
+  bk_log_handler.setLevel(global_vars.LOGGING_LEVEL_BLENDERKIT)
+  bk_logger.addHandler(bk_log_handler)
+
+def configure_imported_loggers():
+  urllib3_logger = logging.getLogger("urllib3")
+  urllib3_logger.propagate = False
+  urllib3_handler = logging.StreamHandler()
+  urllib3_handler.setLevel(global_vars.LOGGING_LEVEL_IMPORTED)
+  urllib3_logger.addHandler(urllib3_handler)
+
+def configure_loggers():
+  configure_bk_logger()
+  configure_imported_loggers()

--- a/ratings.py
+++ b/ratings.py
@@ -32,7 +32,7 @@ from . import (
 )
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 from bpy.types import Operator
 

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -27,7 +27,7 @@ from bpy.props import EnumProperty, FloatProperty, IntProperty, StringProperty
 from . import global_vars, paths, rerequests, tasks_queue, utils
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 
 def upload_rating_thread(url, ratings, headers):

--- a/rerequests.py
+++ b/rerequests.py
@@ -25,7 +25,7 @@ import requests
 from . import bkit_oauth, global_vars, paths, reports, tasks_queue, utils
 
 
-bk_logger = logging.getLogger('rerequests')
+bk_logger = logging.getLogger(__name__)
 
 
 class FakeResponse():

--- a/search.py
+++ b/search.py
@@ -57,7 +57,7 @@ from . import (
 from .daemon import tasks
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 search_start_time = 0
 prev_time = 0

--- a/tasks_queue.py
+++ b/tasks_queue.py
@@ -27,7 +27,7 @@ from bpy.app.handlers import persistent
 from . import utils
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 @persistent
 def scene_load(context):

--- a/ui.py
+++ b/ui.py
@@ -44,7 +44,7 @@ from . import (
 draw_time = 0
 eval_time = 0
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 handler_2d = None
 handler_3d = None

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -44,7 +44,7 @@ from . import (
 )
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 
 #   this was moved to separate interface:

--- a/utils.py
+++ b/utils.py
@@ -34,7 +34,7 @@ from mathutils import Vector
 from . import global_vars, image_utils, paths, rerequests
 
 
-bk_logger = logging.getLogger('blenderkit')
+bk_logger = logging.getLogger(__name__)
 
 ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000
 BELOW_NORMAL_PRIORITY_CLASS = 0x00004000


### PR DESCRIPTION
fixes #182

By default all logs propagate from logger `blenderkit.modulename` to logger `blenderkit` to global logger `root`. The root logger's parameters can be changed from whatever add-on runs in the Blender. To isolate blenderkit from this this PR sets `bk_logger.propagate = False` so the logs do not propagate to root logger. They would disappear, so I set StreamHandler which takes logs with selected or higher priority and prints them to console.

Imported urllib3 library is handled this way also.

This PR also changes loggers in blenderkit submodules to use `__name__`, so they log into: `blenderkit.submodulename`, this way they follow the BlenderKit logger setup, but if it is needed, we can set in the submodule different log level which will enable them to log spammy messages while the rest of submodules will be printing only INFO messages.