### PR TITLE
Cleanup rating code:

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -456,9 +456,6 @@ class BlenderKitUIProps(PropertyGroup):
     rating_button_width: IntProperty(name="Rating Button Width", default=50 * ui_scale)
     rating_button_height: IntProperty(name="Rating Button Height", default=50 * ui_scale)
 
-    rating_x: IntProperty(name="Rating UI X", default=10)
-    rating_y: IntProperty(name="Rating UI Y", default=10)
-
     rating_ui_width: IntProperty(name="Rating UI Width", default=rating_ui_scale * 600)
     rating_ui_height: IntProperty(name="Rating UI Heightt", default=rating_ui_scale * 256)
 
@@ -784,47 +781,6 @@ class BlenderKitCommonUploadProps(object):
         name="Subcategory lvl2",
         description="Subcategory to put into",
         items=categories.get_subcategory1_enums
-    )
-
-
-class BlenderKitRatingProps(PropertyGroup):
-    rating_quality: IntProperty(name="Quality",
-                                description="quality of the material",
-                                default=0,
-                                min=-1, max=10,
-                                update=ratings_utils.update_ratings_quality)
-
-    # the following enum is only to ease interaction - enums support 'drag over' and enable to draw the stars easily.
-    rating_quality_ui: EnumProperty(name='rating_quality_ui',
-                                    items=ratings_utils.stars_enum_callback,
-                                    description='Rating stars 0 - 10',
-                                    default=None,
-                                    update=ratings_utils.update_quality_ui,
-                                    )
-
-    rating_work_hours: FloatProperty(name="Work Hours",
-                                     description="How many hours did this work take?",
-                                     default=0.00,
-                                     min=0.0, max=150, update=ratings_utils.update_ratings_work_hours
-                                     )
-
-    # rating_complexity: IntProperty(name="Complexity",
-    #                                description="Complexity is a number estimating how much work was spent on the asset.aaa",
-    #                                default=0, min=0, max=10)
-    # rating_virtual_price: FloatProperty(name="Virtual Price",
-    #                                     description="How much would you pay for this object if buing it?",
-    #                                     default=0, min=0, max=10000)
-    rating_problems: StringProperty(
-        name="Problems",
-        description="Problems found/ why did you take points down - this will be available for the author"
-                    " As short as possible",
-        default="",
-    )
-    rating_compliments: StringProperty(
-        name="Compliments",
-        description="Comliments - let the author know you like his work! "
-                    " As short as possible",
-        default="",
     )
 
 
@@ -2055,8 +2011,6 @@ classes = (
 
     BlenderKitBrushSearchProps,
     BlenderKitBrushUploadProps,
-
-    BlenderKitRatingProps,
 )
 
 
@@ -2075,45 +2029,37 @@ def register():
     bpy.types.WindowManager.blenderkitUI = PointerProperty(
         type=BlenderKitUIProps)
 
+    # bpy.types.WindowManager.blenderkit_ratings = PointerProperty(
+    #     type =  ratings_utils.RatingPropsCollection)
     # MODELS
     bpy.types.WindowManager.blenderkit_models = PointerProperty(
         type=BlenderKitModelSearchProps)
     bpy.types.Object.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitModelUploadProps)
-    bpy.types.Object.bkit_ratings = PointerProperty(  # for uploads, not now...
-        type=BlenderKitRatingProps)
 
     # SCENES
     bpy.types.WindowManager.blenderkit_scene = PointerProperty(
         type=BlenderKitSceneSearchProps)
     bpy.types.Scene.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitSceneUploadProps)
-    bpy.types.Scene.bkit_ratings = PointerProperty(  # for uploads, not now...
-        type=BlenderKitRatingProps)
 
     # HDRs
     bpy.types.WindowManager.blenderkit_HDR = PointerProperty(
         type=BlenderKitHDRSearchProps)
     bpy.types.Image.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitHDRUploadProps)
-    bpy.types.Image.bkit_ratings = PointerProperty(  # for uploads, not now...
-        type=BlenderKitRatingProps)
 
     # MATERIALS
     bpy.types.WindowManager.blenderkit_mat = PointerProperty(
         type=BlenderKitMaterialSearchProps)
     bpy.types.Material.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitMaterialUploadProps)
-    bpy.types.Material.bkit_ratings = PointerProperty(  # for uploads, not now...
-        type=BlenderKitRatingProps)
 
     # BRUSHES
     bpy.types.WindowManager.blenderkit_brush = PointerProperty(
         type=BlenderKitBrushSearchProps)
     bpy.types.Brush.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitBrushUploadProps)
-    bpy.types.Brush.bkit_ratings = PointerProperty(  # for uploads, not now...
-        type=BlenderKitRatingProps)
 
     user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
     global_vars.PREFS = utils.get_prefs_dir()

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -943,6 +943,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             self.draw_tooltip = False
             self.hide_tooltip()
             self.active_index = -1
+            ui_props = bpy.context.window_manager.blenderkitUI
+            ui_props.active_index = self.active_index
+            # print('exit')
         # popup asset card on mouse down
         # if utils.experimental_enabled():
         #     h = widget.get_area_height()

--- a/download.py
+++ b/download.py
@@ -32,6 +32,7 @@ from . import (
     daemon_lib,
     global_vars,
     paths,
+    ratings_utils,
     reports,
     rerequests,
     resolutions,
@@ -273,9 +274,9 @@ def report_usages():
         scene['assets used'][k] = assets[k]
 
     ###########check ratings herer too:
-    scene['assets rated'] = scene.get('assets rated', {})
     for k in assets.keys():
-        scene['assets rated'][k] = scene['assets rated'].get(k, False)
+        ratings_utils.store_rating_local_empty()
+
     thread = threading.Thread(target=utils.requests_post_thread, args=(url, usage_report, headers))
     thread.start()
     mt = time.time() - mt
@@ -293,10 +294,6 @@ def udpate_asset_data_in_dicts(asset_data):
     scene = bpy.context.scene
     scene['assets used'] = scene.get('assets used', {})
     scene['assets used'][asset_data['assetBaseId']] = asset_data.copy()
-
-    scene['assets rated'] = scene.get('assets rated', {})
-    id = asset_data['assetBaseId']
-    scene['assets rated'][id] = scene['assets rated'].get(id, False)
     sr = global_vars.DATA['search results']
     if not sr:
         return;

--- a/ratings.py
+++ b/ratings.py
@@ -20,28 +20,14 @@ import threading
 
 import bpy
 
-from . import (
-    global_vars,
-    icons,
-    paths,
-    ratings_utils,
-    rerequests,
-    ui,
-    ui_panels,
-    utils,
-)
+from . import global_vars, icons, paths, ratings_utils, rerequests, ui, ui_panels, utils
 
 
 bk_logger = logging.getLogger(__name__)
 
-from bpy.types import (
-    Operator,
-    Gizmo,
-    GizmoGroup,
-)
-
-
+from bpy.types import Gizmo, GizmoGroup, Operator
 from mathutils import Matrix
+
 
 def pretty_print_POST(req):
     """

--- a/ratings.py
+++ b/ratings.py
@@ -196,10 +196,14 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         return True;
 
     def draw(self, context):
+        #when rating gets recieved while the window is already open, we need to prefill.
+        self.prefill_ratings()
+
         layout = self.layout
         layout.label(text = f"Rating of the asset: {self.asset_data['name']}")
         draw_ratings_menu(self, context, layout)
         layout.template_icon(icon_value=self.img.preview.icon_id, scale=12)
+
 
     def execute(self, context):
         scene = bpy.context.scene
@@ -228,6 +232,7 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         self.img = ui.get_large_thumbnail_image(self.asset_data)
         utils.img_to_preview(self.img, copy_original=True)
 
+        ratings_utils.ensure_rating(self.asset_id)
         self.prefill_ratings()
 
         if self.asset_type in ('model', 'scene'):

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -73,6 +73,10 @@ def store_rating_local(asset_id, type='quality', value=0):
     ar   = global_vars.DATA['asset ratings']
     ar[asset_id] = ar.get(asset_id, {})
     ar[asset_id][type] = value
+    # for w in bpy.context.window_manager.windows:
+    #   for a in w.screen.areas:
+    #     a.tag_redraw()
+    #     print('redraw',a.type)
 
 
 def get_rating(asset_id, headers):
@@ -87,6 +91,8 @@ def get_rating(asset_id, headers):
     -------
     ratings - dict of type:value ratings
     '''
+    import time
+    t = time.time()
     url = paths.get_api_url() + 'assets/' + asset_id + '/rating/'
     params = {}
     r = rerequests.get(url, params=params, verify=True, headers=headers)
@@ -357,8 +363,11 @@ class RatingProperties(PropertyGroup):
         if not utils.user_logged_in():
           return
         ratings = get_rating_local(self.asset_id)
-        print('prefill ratings')
-        print(ratings)
+        if ratings in (None, {}):
+          return
+        if not self.rating_quality ==0:
+          #return if the rating was already filled
+          return
         if ratings and ratings.get('quality'):
             self.rating_quality = int(ratings['quality'])
         if ratings and ratings.get('working_hours'):
@@ -370,6 +379,6 @@ class RatingProperties(PropertyGroup):
                 self.rating_work_hours_ui_1_5 = whs
             if wh < 11 and wh in self.possible_wh_values_1_10:
                 self.rating_work_hours_ui_1_10 = whs
-
+        bpy.context.area.tag_redraw()
 # class RatingPropsCollection(PropertyGroup):
 #   ratings = CollectionProperty(type = RatingProperties)

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -22,7 +22,13 @@ import threading
 # mainly update functions and callbacks for ratings properties, here to avoid circular imports.
 import bpy
 import requests
-from bpy.props import EnumProperty, FloatProperty, IntProperty, StringProperty,CollectionProperty
+from bpy.props import (
+    CollectionProperty,
+    EnumProperty,
+    FloatProperty,
+    IntProperty,
+    StringProperty,
+)
 from bpy.types import PropertyGroup
 
 from . import global_vars, paths, rerequests, tasks_queue, utils

--- a/search.py
+++ b/search.py
@@ -135,7 +135,6 @@ def update_assets_data():  # updates assets data on scene load.
 
   dicts = [
     'assets used',
-    # 'assets rated',# assets rated stores only true/false, not asset data.
   ]
   for s in bpy.data.scenes:
     for bkdict in dicts:

--- a/tasks_queue.py
+++ b/tasks_queue.py
@@ -64,8 +64,11 @@ def queue_worker():
     # utils.p('start queue worker timer')
 
     #bk_logger.debug('timer queue worker')
-    time_step = 2.0
+    time_step = .3
     q = get_queue()
+    #save some performance by returning early
+    if q.empty():
+        return time_step
 
     back_to_queue = [] #delayed events
     stashed = {}
@@ -117,7 +120,7 @@ def queue_worker():
         q.put(task)
     # utils.p('end queue worker timer')
 
-    return 2.0
+    return time_step
 
 
 def register():

--- a/ui.py
+++ b/ui.py
@@ -142,42 +142,6 @@ def draw_bbox(location, rotation, bbox_min, bbox_max, progress=None, color=(0, 1
 
 
 
-def draw_ratings_bgl():
-    # return;
-    ui = bpy.context.window_manager.blenderkitUI
-
-    rating_possible, rated, asset, asset_data = is_rating_possible()
-    if rating_possible:  # (not rated or ui_props.rating_menu_on):
-        # print('rating is pssible', asset_data['name'])
-        bkit_ratings = asset.bkit_ratings
-
-        if ui.rating_button_on:
-            # print('should draw button')
-            img = utils.get_thumbnail('star_white.png')
-
-            ui_bgl.draw_image(ui.rating_x,
-                              ui.rating_y - ui.rating_button_width,
-                              ui.rating_button_width,
-                              ui.rating_button_width,
-                              img, 1)
-
-            # if ui_props.asset_type != 'BRUSH':
-            #     thumbnail_image = props.thumbnail
-            # else:
-            #     b = utils.get_active_brush()
-            #     thumbnail_image = b.icon_filepath
-
-            directory = paths.get_temp_dir('%s_search' % asset_data['assetType'])
-            tpath = os.path.join(directory, asset_data['thumbnail_small'])
-            img = utils.get_hidden_image(tpath, 'rating_preview')
-            ui_bgl.draw_image(ui.rating_x + ui.rating_button_width,
-                              ui.rating_y - ui.rating_button_width,
-                              ui.rating_button_width,
-                              ui.rating_button_width,
-                              img, 1)
-            return
-
-
 def draw_text_block(x=0, y=0, width=40, font_size=10, line_height=15, text='', color=colors.TEXT):
     lines = text.split('\n')
     nlines = []
@@ -428,13 +392,14 @@ def floor_raycast(context, mx, my):
 
 
 def is_rating_possible():
+    #TODO remove this, but first check and reuse the code for new rating system...
     ao = bpy.context.active_object
     ui = bpy.context.window_manager.blenderkitUI
     preferences = bpy.context.preferences.addons['blenderkit'].preferences
     # first test if user is logged in.
     if preferences.api_key == '':
         return False, False, None, None
-    if bpy.context.scene.get('assets rated') is not None and ui.down_up == 'SEARCH':
+    if global_vars.DATA.get('asset ratings') is not None and ui.down_up == 'SEARCH':
         if bpy.context.mode in ('SCULPT', 'PAINT_TEXTURE'):
             b = utils.get_active_brush()
             ad = b.get('asset_data')
@@ -519,9 +484,6 @@ def update_ui_size(area, region):
     else:
         ui.reports_y = ui.bar_y - ui.bar_height - 100
         ui.reports_x = ui.bar_x
-
-    ui.rating_x = ui.bar_x
-    ui.rating_y = ui.bar_y - ui.bar_height
 
 
 class ParticlesDropDialog(bpy.types.Operator):
@@ -1162,8 +1124,8 @@ def register_ui():
     # fast rating shortcut
     wm = bpy.context.window_manager
     km = wm.keyconfigs.addon.keymaps['Window']
-    # kmi = km.keymap_items.new(ratings.FastRateMenu.bl_idname, 'R', 'PRESS', ctrl=False, shift=False)
-    # addon_keymapitems.append(kmi)
+    kmi = km.keymap_items.new("wm.blenderkit_menu_rating_upload", 'R', 'PRESS', ctrl=False, shift=False)
+    addon_keymapitems.append(kmi)
     # kmi = km.keymap_items.new(upload.FastMetadata.bl_idname, 'F', 'PRESS', ctrl=True, shift=False)
     # addon_keymapitems.append(kmi)
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2301,6 +2301,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         if not utils.user_is_owner(asset_data=self.asset_data):
             # Draw ratings, but not for owners of assets - doesn't make sense.
             ratings_box = layout.box()
+            self.prefill_ratings()
             ratings.draw_ratings_menu(self, context, ratings_box)
         # else:
         #     ratings_box.label('Here you should find ratings, but you can not rate your own assets ;)')
@@ -2319,24 +2320,6 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                 if ui_props.reply_id == comment['id']:
                     self.draw_comment_response(context,layout,comment['id'])
 
-
-    def prefill_ratings(self):
-        # pre-fill ratings
-        if not utils.user_logged_in():
-            return
-
-        ratings = ratings_utils.get_rating_local(self.asset_id)
-        if ratings and ratings.get('quality'):
-            self.rating_quality = int(ratings['quality'])
-        if ratings and ratings.get('working_hours'):
-            wh = int(ratings['working_hours'])
-            whs = str(wh)
-            if wh in self.possible_wh_values:
-                self.rating_work_hours_ui = whs
-            if wh < 6 and wh in self.possible_wh_values_1_5:
-                self.rating_work_hours_ui_1_5 = whs
-            if wh < 11 and wh in self.possible_wh_values_1_10:
-                self.rating_work_hours_ui_1_10 = whs
 
     def execute(self, context):
         wm = context.window_manager
@@ -2366,6 +2349,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         self.tip = search.get_random_tip()
         self.tip = self.tip.replace('\n', '')
 
+        ratings_utils.ensure_rating(self.asset_id)
         # pre-fill ratings
         self.prefill_ratings()
         user_preferences = bpy.context.preferences.addons['blenderkit'].preferences


### PR DESCRIPTION
- remove obsolete bkit_ratings, so these aren't stored on datablocks anymore and aren't saved in the .blend file
- remove some unused bgl and panel drawing code too
- Fast rating (R) operator was fixed and also shows a thumbnail now
- Work on the separate ratings panel, is commented out still - needs to store ratings in some list of custom props and have better UI
- Experimental Star Button implemented as a gizmo directly in the 3d view, accessible only to validators right now
