### PR TITLE
Fix broken search after 20 search requests

### DIFF
--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -106,7 +106,7 @@ def write_tokens(auth_token, refresh_token, oauth_response):
     # search.cleanup_search_results()
     history = global_vars.DATA['search history']
     if len(history)>0:
-        search.search(query = global_vars.DATA['search history'][-1])
+        search.search(query = history[-1])
     #categories.fetch_categories_thread(auth_token, force = False)
 
 

--- a/global_vars.py
+++ b/global_vars.py
@@ -1,8 +1,11 @@
+import collections
 import logging
 
 
-DATA = { 'images available': {} ,
-         'search history': []}
+DATA = {
+  'images available': {} ,
+  'search history': collections.deque(maxlen=20),
+}
 LOGGING_LEVEL_BLENDERKIT = logging.INFO
 LOGGING_LEVEL_IMPORTED = logging.WARN
 PREFS = {}

--- a/search.py
+++ b/search.py
@@ -1247,10 +1247,8 @@ def search(category='', get_next=False, query = None, author_id=''):
       profile = global_vars.DATA.get('bkit profile')
       if profile is not None:
         query['author_id'] = str(profile['user']['id'])
-    #write to search history and check hitory length
+    #write to search history and check history length
     global_vars.DATA['search history'].append(query)
-    if len(global_vars.DATA['search history'])>20:
-      global_vars.DATA['search history'].pop[0]
   # utils.p('searching')
   props.is_searching = True
 


### PR DESCRIPTION
fixes #219 

Instead of using lists, I have used collections.deque, which is optimized to be used as queue. Appends and pops does not move data in memory!

- I have specified history queue to be a fixed size of 20 things, we does not need to check it anywhere
- it prepends from right, from last element, as lists normally do
- it can be accessed as a list deque[-1]
