### PR TITLE
Bump up to version 3.1.6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,11 +19,11 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy",
-    "version": (3, 1, 5),
+    "version": (3, 1, 6),
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",
-    "warning": "If add-on behaves badly after auto-update from v3.1.3 or lower, please: disable add-on, restart computer, remove add-on and install from .zip.",
+    "warning": "If update failed: disable addon, restart PC, remove addon, install from ZIP.",
     "doc_url": "https://docs.blender.org/manual/en/3.1/addons/3d_view/blenderkit.html",
     "tracker_url": "https://github.com/BlenderKit/blenderkit/issues",
     "category": "3D View",


### PR DESCRIPTION
Increasing version to 3.1.6 and shortening warning message, so it is fully readable in preferences menu. It is kind of strange message due to restricted number of characters.

@vilemduha please confirm it is ok. We can then relase.

The zip is uploaded in Slack so team can test. If nothing is found, we can release tomorrow.