### PR TITLE
Force category when uploading assets

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -138,14 +138,14 @@ def get_category(categories, cat_path=()):
 def update_category_enums(self, context):
     '''Fixes if lower level is empty - sets it to None, because enum value can be higher.'''
     enums = get_subcategory_enums(self, context)
-    if enums[0][0] == 'NONE' and self.subcategory != 'NONE':
+    if enums[0][0] == 'NONE' and (self.subcategory != 'NONE' and self.subcategory != 'EMPTY'):
         self.subcategory = 'NONE'
 
 
 def update_subcategory_enums(self, context):
     '''Fixes if lower level is empty - sets it to None, because enum value can be higher.'''
     enums = get_subcategory1_enums(self, context)
-    if enums[0][0] == 'NONE' and self.subcategory1 != 'NONE':
+    if enums[0][0] == 'NONE' and (self.subcategory1 != 'NONE' and self.subcategory1 != 'EMPTY'):
         self.subcategory1 = 'NONE'
 
 
@@ -158,7 +158,9 @@ def get_category_enums(self, context):
     for c in asset_categories['children']:
         items.append((c['slug'], c['name'], c['description']))
     if len(items) == 0:
-        items.append(('NONE', '', 'no categories on this level defined'))
+        items.append(('EMPTY', 'Empty', 'no categories on this level defined'))
+    else:
+        items.insert(0,('NONE', 'None', 'Default state, category not defined by user'),)
     return items
 
 
@@ -166,13 +168,15 @@ def get_subcategory_enums(self, context):
     props = bpy.context.window_manager.blenderkitUI
     asset_type = props.asset_type.lower()
     items = []
-    if self.category != '':
+    if self.category != 'None':
         asset_categories = get_category(global_vars.DATA['bkit_categories'], cat_path=(asset_type, self.category,))
-        for c in asset_categories['children']:
-            items.append((c['slug'], c['name'], c['description']))
+        if asset_categories is not None:
+            for c in asset_categories['children']:
+                items.append((c['slug'], c['name'], c['description']))
     if len(items) == 0:
-        items.append(('NONE', '', 'no categories on this level defined'))
-    # print('subcategory', items)
+        items.append(('EMPTY', 'Empty', 'no categories on this level defined'))
+    else:
+        items.insert(0, ('NONE', 'None', 'Default state, category not defined by user'), )
     return items
 
 
@@ -180,13 +184,16 @@ def get_subcategory1_enums(self, context):
     props = bpy.context.window_manager.blenderkitUI
     asset_type = props.asset_type.lower()
     items = []
-    if self.category != '' and self.subcategory != '':
+    if self.category != 'None' and self.subcategory != 'Empty':
         asset_categories = get_category(global_vars.DATA['bkit_categories'], cat_path=(asset_type, self.category, self.subcategory,))
-        if asset_categories:
+        if asset_categories is not None:
             for c in asset_categories['children']:
                 items.append((c['slug'], c['name'], c['description']))
     if len(items) == 0:
-        items.append(('NONE', '', 'no categories on this level defined'))
+        items.append(('EMPTY', 'Empty', 'no categories on this level defined'))
+    else:
+        items.insert(0, ('NONE', 'None', 'Default state, category not defined by user'), )
+
     return items
 
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -112,11 +112,21 @@ def draw_upload_common(layout, props, asset_type, context):
         # row = layout.row()
         # row.enabled = False
         # row.prop(props, 'id', icon='FILE_TICK')
-    layout.prop(props, 'category')
-    if props.category != 'NONE' and props.subcategory != 'NONE':
-        layout.prop(props, 'subcategory')
-    if props.subcategory != 'NONE' and props.subcategory1 != 'NONE':
-        layout.prop(props, 'subcategory1')
+    row = layout.row()
+    if props.category == 'NONE':
+        row.alert =True
+    row.prop(props, 'category')
+    if props.category != 'NONE' and props.subcategory != 'EMPTY':
+        row = layout.row()
+        if props.subcategory =='NONE':
+            row.alert = True
+        row.prop(props, 'subcategory')
+
+    if props.subcategory != 'NONE' and props.subcategory1 != 'EMPTY':
+        row = layout.row()
+        if props.subcategory1 == 'NONE':
+            row.alert = True
+        row.prop(props, 'subcategory1')
 
     layout.prop(props, 'is_private', expand=True)
     if props.is_private == 'PUBLIC':
@@ -975,7 +985,7 @@ def draw_login_buttons(layout, invoke=False):
             layout.operator_context = 'INVOKE_DEFAULT'
         else:
             layout.operator_context = 'EXEC_DEFAULT'
-        if user_preferences.api_key == '':
+        if not utils.user_logged_in():
             layout.operator("wm.blenderkit_login", text="Login",
                             icon='URL').signup = False
             layout.operator("wm.blenderkit_login", text="Sign up",

--- a/upload.py
+++ b/upload.py
@@ -149,6 +149,11 @@ def check_missing_data(asset_type, props):
     if len(props.name) > 40:
         write_to_report(props, f'The name is too long. maximum is 40 letters')
 
+    if props.category == 'NONE' or \
+        props.subcategory != 'EMPTY' and props.subcategory =='NONE' or \
+        props.subcategory1 != 'EMPTY' and props.subcategory1 == 'NONE':
+            write_to_report(props, "fill in the category, including subcategories. \n"
+                                   "Category can't be 'None'.")
     if props.is_private == 'PUBLIC':
 
         if len(props.description) < 20:
@@ -159,6 +164,8 @@ def check_missing_data(asset_type, props):
         if props.tags == '':
             write_to_report(props, 'Write at least 3 tags.\n'
                                    'Tags help to bring your asset up in relevant search results.')
+
+
 
     if asset_type == 'MODEL':
         check_missing_data_model(props)


### PR DESCRIPTION
fixes #193 

Ui is now red and there are now 'None' categories, which are default.
This forces setting category and avoids assets to accumulate in default architecture - building - commercial category.
Disadvantage is that the category setting on existing assets inside .blend gets changed(but that would change also if category is added or any changes in category system, since only index is stored)

![image](https://user-images.githubusercontent.com/6907354/183462023-a3e19c6a-a66c-430f-b7fa-fe6c00fe38e4.png)
