### PR TITLE
Fix issue #217

### DIFF
--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -80,6 +80,7 @@ class BL_UI_Button(BL_UI_Widget):
             self.__image = None
 
     def set_image(self, rel_filepath):
+        #first try to access the image, for cases where it can get removed
         self.check_image_exists()
         try:
             if self.__image is None or self.__image.filepath != rel_filepath:

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -42,6 +42,7 @@ class BL_UI_Image(BL_UI_Widget):
                     self.__image = img
                 else:
                     self.__image = bpy.data.images.load(rel_filepath, check_existing=True)
+                    self.__image.name = imgname
 
                 self.__image.gl_load()
 


### PR DESCRIPTION
fixes #217 

The thumbnails need a dot (.thumbnailname.jpg) on the beginning of their name so they are invisible to casual user (unless he types a dot)
This behaviour was always default but got lost for one variant of loading images - we should deduplicate the code in the bl_ui_widgets library