### PR TITLE
Fix automap

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -796,10 +796,15 @@ def automap(target_object=None, target_slot=None, tex_size=1, bg_exception=False
                 tex_size = 1
 
             if not just_scale:
+                #compensate for the undocumented operator change in blender 3.2
+                if bpy.app.version>=(3,2,0):
+                    cube_size = scale *  (tex_size)
+                else:
+                    cube_size = scale * 2.0 / (tex_size)# it's * 2.0 because blender can't tell size of a unit cube :)
 
                 bpy.ops.uv.cube_project(
-                    cube_size=scale * 2.0 / (tex_size),
-                    correct_aspect=False)  # it's * 2.0 because blender can't tell size of a unit cube :)
+                    cube_size=cube_size,
+                    correct_aspect=False)
 
             bpy.ops.object.editmode_toggle()
             tob.data.uv_layers.active = tob.data.uv_layers['automap']


### PR DESCRIPTION
since blender 3.2 there was an undocumented api change -
cube mapping got inverted and fixed.