### PR TITLE
Add option to choose IP version

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1633,7 +1633,7 @@ class BlenderKitAddonPreferences(AddonPreferences):
             ("1234", "1234", ""),
         ),
         default="62485",
-        update=timer.cancel_all_tasks,
+        update=timer.save_prefs_cancel_all_tasks_and_restart_daemon,
     )
 
     project_subdir: StringProperty(
@@ -1673,6 +1673,21 @@ class BlenderKitAddonPreferences(AddonPreferences):
         default='2048',
     )
 
+    ip_version: EnumProperty(
+        name="IP version",
+        items=(
+            ('BOTH', 'Use both IPv4 and IPv6',
+             'Add-on will use both IPv4 and IPv6 families of addresses for connections'),
+            ('IPv4', 'Use only IPv4',
+             'Add-on will use only IPv4 family of addresses for connections. This might fix connection issues on some systems connected to only IPv4 networks'),
+            ('IPv6', 'Use only IPv6',
+             'Add-on will use only IPv6 families of addresses for connections. Not recommended'),
+        ),
+        description="Which address family add-on should use for connections - IPv4, IPv6 or both protocols.",
+        default="BOTH",
+        update=timer.save_prefs_cancel_all_tasks_and_restart_daemon
+    )
+
     proxy_which: EnumProperty(
         name="Proxy",
         items=(
@@ -1688,8 +1703,7 @@ class BlenderKitAddonPreferences(AddonPreferences):
         ),
         description="Which directories will be used for storing downloaded data",
         default="SYSTEM",
-        update=utils.save_prefs
-
+        update=timer.save_prefs_cancel_all_tasks_and_restart_daemon
     )
 
     proxy_address: StringProperty(
@@ -1700,7 +1714,7 @@ If you use simple HTTP proxy, set in format http://ip:port, or http://username:p
 
 If you use HTTPS proxy, set in format https://ip:port, or https://username:password@ip:port if your HTTPS proxy requires authentication. For HTTPS proxies you might also need to specify Proxy CA certificates path so the addon can verify the encrypted connection to your HTTPS proxy server""",
         default="",
-        update=utils.save_prefs
+        update=timer.save_prefs_cancel_all_tasks_and_restart_daemon
     )
 
     proxy_ca_certs: StringProperty(
@@ -1713,7 +1727,7 @@ If you use HTTPS proxy, set in format https://ip:port, or https://username:passw
             "When set, please shutdown the daemon server on address: http:localhost:port/shutdown so the daemon reloads new CA certificates.",
         default="",
         subtype='DIR_PATH',
-        update=utils.save_prefs
+        update=timer.save_prefs_cancel_all_tasks_and_restart_daemon
     )
 
     directory_behaviour: EnumProperty(
@@ -1901,6 +1915,7 @@ If you use HTTPS proxy, set in format https://ip:port, or https://username:passw
         layout.prop(self, "search_in_header")
         layout.prop(self, "thumbnail_use_gpu")
         layout.prop(self, "daemon_port")
+        layout.prop(self, "ip_version")
         layout.prop(self, "proxy_which")
         if self.proxy_which == 'CUSTOM':
             layout.prop(self, "proxy_address")

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import logging
 import os
+import socket
 import ssl
 import time
 import uuid
@@ -239,16 +240,16 @@ async def persistent_sessions(app):
   else:
     trust_env = False
 
-  conn_api_requests = aiohttp.TCPConnector(ssl=sslcontext, limit=64)
+  conn_api_requests = aiohttp.TCPConnector(ssl=sslcontext, limit=64, family=socket.AF_INET)
   app['SESSION_API_REQUESTS'] = session_api_requests = aiohttp.ClientSession(connector=conn_api_requests, trust_env=trust_env)
 
-  conn_small_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=16)
+  conn_small_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=16, family=socket.AF_INET)
   app['SESSION_SMALL_THUMBS'] = session_small_thumbs = aiohttp.ClientSession(connector=conn_small_thumbs, trust_env=trust_env)
   
-  conn_big_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=8)
+  conn_big_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=8, family=socket.AF_INET)
   app['SESSION_BIG_THUMBS'] = session_big_thumbs = aiohttp.ClientSession(connector=conn_big_thumbs, trust_env=trust_env)
 
-  conn_assets = aiohttp.TCPConnector(ssl=sslcontext, limit=4)
+  conn_assets = aiohttp.TCPConnector(ssl=sslcontext, limit=4, family=socket.AF_INET)
   app['SESSION_ASSETS'] = session_assets = aiohttp.ClientSession(connector=conn_assets, trust_env=trust_env)
 
   yield

--- a/daemon/globals.py
+++ b/daemon/globals.py
@@ -13,6 +13,7 @@ TIMEOUT: int = 300
 PORT: int = -1
 OAUTH_CLIENT_ID: str = 'IdFRwa3SGA8eMpzhRVFMg5Ts8sPK93xBjif93x0F'
 SERVER = None
+IP_VERSION = None
 SYSTEM_ID = None
 VERSION = None
 

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -139,7 +139,7 @@ def report_blender_quit():
 
 
 def kill_daemon_server():
-  ''' Request to restart the daemon server.'''
+  '''Request to restart the daemon server.'''
   address = get_address()
   with requests.Session() as session:
     url = address + "/shutdown"
@@ -227,10 +227,11 @@ def start_daemon_server():
           '-u', daemon_path,
           '--port', get_port(),
           '--server', global_vars.SERVER,
-          '--proxy-which', global_vars.PREFS.get('proxy_which'),
-          '--proxy-address', global_vars.PREFS.get('proxy_address'),
-          '--proxy-ca-certs', global_vars.PREFS.get('proxy_ca_certs'),
-          '--system-id', bpy.context.preferences.addons['blenderkit'].preferences.system_id,
+          '--proxy_which', global_vars.PREFS.get('proxy_which'),
+          '--proxy_address', global_vars.PREFS.get('proxy_address'),
+          '--proxy_ca_certs', global_vars.PREFS.get('proxy_ca_certs'),
+          '--ip_version', global_vars.PREFS.get('ip_version'),
+          '--system_id', bpy.context.preferences.addons['blenderkit'].preferences.system_id,
           '--version', f'{global_vars.VERSION[0]}.{global_vars.VERSION[1]}.{global_vars.VERSION[2]}.{global_vars.VERSION[3]}',
         ],
         env           = env,

--- a/timer.py
+++ b/timer.py
@@ -58,6 +58,7 @@ def daemon_communication_timer():
     wm = bpy.context.window_manager
     try:
       results = daemon_lib.get_reports(app_id)
+      start_count = 0
     except Exception as e:
       global_vars.DAEMON_ACCESSIBLE = False
       
@@ -111,6 +112,18 @@ def timer_image_cleanup():
     if (i.name[:11] == '.thumbnail_' or i.filepath.find('bkit_g')>-1) and not i.has_data and i.users == 0:
       bpy.data.images.remove(i)
   return 60
+
+def save_prefs_cancel_all_tasks_and_restart_daemon(self, context):
+  """Save preferences, cancel all daemon tasks and shutdown the daemon.
+  The daemon_communication_timer will soon take care of starting the daemon again leading to a restart.
+  """
+  utils.save_prefs(self, context)
+  reports.add_report("Restarting daemon server", 5, "INFO")
+  try:
+    cancel_all_tasks(self, context)
+    daemon_lib.kill_daemon_server()
+  except Exception as e:
+    bk_logger.warning(str(e))
 
 def cancel_all_tasks(self, context):
   """Cancel all tasks."""

--- a/utils.py
+++ b/utils.py
@@ -394,6 +394,7 @@ def get_prefs_dir():
         'directory_behaviour': user_preferences.directory_behaviour,
         'is_saved': user_preferences.directory_behaviour,
         'app_id': os.getpid(),
+        'ip_version': user_preferences.ip_version,
         'proxy_which': user_preferences.proxy_which,
         'proxy_address': user_preferences.proxy_address,
         'proxy_ca_certs': user_preferences.proxy_ca_certs,


### PR DESCRIPTION
fixes #204

Aiohttp by default uses IPv4 and IPv6 for its connectors. When trying with DNS resolvers, I have faced errors with SSL which are quite the same as some users report and we thought it is about their proxy/firewall. It was fixed for me by defaulting aiohttp to only use IPv4. So I am trying to default to IPv4 in this PR and will send the build to the users with SSL problems, to see, how it works.