### PR TITLE
Add UUID token

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1586,6 +1586,14 @@ class BlenderKitAddonPreferences(AddonPreferences):
         default=0,
     )
 
+    uuid_token: StringProperty(
+        name='BlenderKit UUID token',
+        description='Identificator of the machine running the installation of BlenderKit',
+        default='',
+        subtype='PASSWORD',
+        update=utils.save_prefs
+    )
+
     login_attempt: BoolProperty(
         name="Login/Signup attempt",
         description="When this is on, BlenderKit is trying to connect and login",
@@ -1605,6 +1613,7 @@ class BlenderKitAddonPreferences(AddonPreferences):
         default=True,
         update=utils.save_prefs
     )
+
     search_in_header: BoolProperty(
         name="Show BlenderKit search in 3D view header",
         description="Show BlenderKit search in 3D view header",
@@ -2006,7 +2015,6 @@ def register():
     asset_bar_op.register()
     disclaimer_op.register()
 
-    user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
     if user_preferences.use_timers:
         timer.register_timers()
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy",
-    "version": (3, 2, 0, 220915), #X.Y.Z.yymmdd
+    "version": (3, 2, 0, 220919), #X.Y.Z.yymmdd
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",

--- a/__init__.py
+++ b/__init__.py
@@ -1586,9 +1586,9 @@ class BlenderKitAddonPreferences(AddonPreferences):
         default=0,
     )
 
-    uuid_token: StringProperty(
-        name='BlenderKit UUID token',
-        description='Identificator of the machine running the installation of BlenderKit',
+    system_uuid: StringProperty(
+        name='UUID of the system',
+        description='Identificator of the machine running the BlenderKit, is the same independently of BlenderKit or Blender versions',
         default='',
         subtype='PASSWORD',
         update=utils.save_prefs

--- a/timer.py
+++ b/timer.py
@@ -19,6 +19,7 @@ from . import (
     reports,
     search,
     tasks_queue,
+    utils,
 )
 from .daemon import tasks
 
@@ -202,6 +203,7 @@ def on_startup_timer():
   """Run once on the startup of add-on."""
 
   addon_updater_ops.check_for_update_background()
+  utils.ensure_UUID()
   return
 
 def on_startup_daemon_online_timer():

--- a/timer.py
+++ b/timer.py
@@ -203,7 +203,7 @@ def on_startup_timer():
   """Run once on the startup of add-on."""
 
   addon_updater_ops.check_for_update_background()
-  utils.ensure_UUID()
+  utils.ensure_system_UUID()
   return
 
 def on_startup_daemon_online_timer():

--- a/utils.py
+++ b/utils.py
@@ -388,6 +388,7 @@ def get_prefs_dir():
         'binary_path': bpy.app.binary_path,
         'api_key': user_preferences.api_key,
         'api_key_refresh': user_preferences.api_key_refresh,
+        'uuid_token': user_preferences.uuid_token,
         'global_dir': user_preferences.global_dir,
         'project_subdir': user_preferences.project_subdir,
         'directory_behaviour': user_preferences.directory_behaviour,
@@ -727,13 +728,19 @@ def requests_post_thread(url, json, headers):
 
 def get_headers(api_key):
     headers = {
-        "accept": "application/json",
-        "Platform-Version": platform.platform(),
+        'accept': 'application/json',
+        'Platform-Version': platform.platform(),
+        'uuid-token': bpy.context.preferences.addons['blenderkit'].preferences.uuid_token,
+        'addon-version': f'{global_vars.VERSION[0]}.{global_vars.VERSION[1]}.{global_vars.VERSION[2]}.{global_vars.VERSION[3]}',
     }
     if api_key != '':
         headers["Authorization"] = "Bearer %s" % api_key
     return headers
 
+def ensure_UUID():
+    preferences = bpy.context.preferences.addons['blenderkit'].preferences
+    if preferences.uuid_token == '':
+        preferences.uuid_token = str(uuid.UUID(int=uuid.getnode()))
 
 def scale_2d(v, s, p):
     '''scale a 2d vector with a pivot'''

--- a/utils.py
+++ b/utils.py
@@ -388,7 +388,7 @@ def get_prefs_dir():
         'binary_path': bpy.app.binary_path,
         'api_key': user_preferences.api_key,
         'api_key_refresh': user_preferences.api_key_refresh,
-        'uuid_token': user_preferences.uuid_token,
+        'system_uuid': user_preferences.system_uuid,
         'global_dir': user_preferences.global_dir,
         'project_subdir': user_preferences.project_subdir,
         'directory_behaviour': user_preferences.directory_behaviour,
@@ -730,17 +730,17 @@ def get_headers(api_key):
     headers = {
         'accept': 'application/json',
         'Platform-Version': platform.platform(),
-        'uuid-token': bpy.context.preferences.addons['blenderkit'].preferences.uuid_token,
+        'system-uuid': bpy.context.preferences.addons['blenderkit'].preferences.system_uuid,
         'addon-version': f'{global_vars.VERSION[0]}.{global_vars.VERSION[1]}.{global_vars.VERSION[2]}.{global_vars.VERSION[3]}',
     }
     if api_key != '':
         headers["Authorization"] = "Bearer %s" % api_key
     return headers
 
-def ensure_UUID():
+def ensure_system_UUID():
     preferences = bpy.context.preferences.addons['blenderkit'].preferences
-    if preferences.uuid_token == '':
-        preferences.uuid_token = str(uuid.UUID(int=uuid.getnode()))
+    if preferences.system_uuid == '':
+        preferences.system_uuid = str(uuid.UUID(int=uuid.getnode()))
 
 def scale_2d(v, s, p):
     '''scale a 2d vector with a pivot'''


### PR DESCRIPTION
- adds token_token into preferences
- passes the token in headers as `uuid-token`
- it is checked (and created if needed in the startup_timer)
- the UUID is generated via uuid.getnode() which should generate the same UUID for the same system, tried with several Blender versions and it works! https://docs.python.org/3/library/uuid.html#uuid.getnode

- passes the `addon-version` in headers in format `X.Y.Z.YYMMDD`