### PR TITLE
Issue #301 - Add support for PCKE OAuth

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1372,7 +1372,7 @@ def register(bl_info):
     # updater.addon = # define at top of module, MUST be done first
 
     # Website for manual addon download, optional but recommended to set.
-    updater.website = "https://https://www.blenderkit.com/get-blenderkit/"
+    updater.website = "https://www.blenderkit.com/get-blenderkit/"
 
     # Addon subfolder path.
     # "sample/path/to/addon"

--- a/categories.py
+++ b/categories.py
@@ -217,7 +217,7 @@ def load_categories():
 
 
 def fetch_categories(API_key, force=False):
-    url = paths.get_api_url() + 'categories/'
+    url = paths.BLENDERKIT_API + '/categories/'
 
     headers = utils.get_headers(API_key)
 

--- a/comments_utils.py
+++ b/comments_utils.py
@@ -31,10 +31,10 @@ bk_logger = logging.getLogger(__name__)
 def upload_comment_thread(asset_id, comment_id=0, comment='', api_key=None):
   ''' Upload comment thread function / disconnected from blender data.'''
   headers = utils.get_headers(api_key)
-  url = f'{paths.get_api_url()}comments/asset-comment/{asset_id}/'
+  url = f'{paths.BLENDERKIT_API}/comments/asset-comment/{asset_id}/'
   r = rerequests.get(url, headers=headers)
   comment_data = r.json()
-  url = f'{paths.get_api_url()}comments/comment/'
+  url = f'{paths.BLENDERKIT_API}/comments/comment/'
   data = {
     "name": "",
     "email": "",
@@ -65,7 +65,7 @@ def upload_comment_flag_thread(asset_id='', comment_id='', flag='like', api_key=
     "comment": comment_id,
     "flag": flag,
   }
-  url = paths.get_api_url() + 'comments/feedback/'
+  url = paths.BLENDERKIT_API + '/comments/feedback/'
   r = rerequests.post(url, data=data, verify=True, headers=headers)
   bk_logger.info(f'{r.text}')
   # here it's important we read back, so likes are updated accordingly:
@@ -81,7 +81,7 @@ def upload_comment_is_private_thread(asset_id='', comment_id='', is_private=Fals
   data = {
     "is_private": is_private,
   }
-  url = f"{paths.get_api_url()}comments/is_private/{comment_id}/"
+  url = f"{paths.BLENDERKIT_API}/comments/is_private/{comment_id}/"
   r = rerequests.post(url, data=data, verify=True, headers=headers)
   bk_logger.debug(r.text)
   
@@ -97,7 +97,7 @@ def upload_comment_is_private_thread(asset_id='', comment_id='', is_private=Fals
 #   data = {
 #     "comment": comment_id,
 #   }
-#   url = paths.get_api_url() + 'comments/delete/0/'
+#   url = paths.BLENDERKIT_API + '/comments/delete/0/'
 #   r = rerequests.post(url, data=data, verify=True, headers=headers)
 #   if len(r.text)<1000:
 #   # here it's important we read back, so likes are updated accordingly:
@@ -164,7 +164,7 @@ def get_comments(asset_id, api_key):
   '''
   headers = utils.get_headers(api_key)
 
-  url = paths.get_api_url() + 'comments/assets-uuidasset/' + asset_id + '/'
+  url = paths.BLENDERKIT_API + '/comments/assets-uuidasset/' + asset_id + '/'
   params = {}
   r = rerequests.get(url, params=params, verify=True, headers=headers)
   if r is None:
@@ -249,7 +249,7 @@ def get_notifications(api_key, all_count=1000):
 
   params = {}
 
-  url = paths.get_api_url() + 'notifications/all_count/'
+  url = paths.BLENDERKIT_API + '/notifications/all_count/'
   r = rerequests.get(url, params=params, verify=True, headers=headers)
   if r.status_code == 200:
     rj = r.json()
@@ -258,7 +258,7 @@ def get_notifications(api_key, all_count=1000):
       tasks_queue.add_task((store_notifications_count_local, ([rj['allCount']])))
 
       return
-  url = paths.get_api_url() + 'notifications/unread/'
+  url = paths.BLENDERKIT_API + '/notifications/unread/'
   r = rerequests.get(url, params=params, verify=True, headers=headers)
   if r is None:
     return
@@ -279,7 +279,7 @@ def mark_notification_read(api_key, notification_id):
   '''
   headers = utils.get_headers(api_key)
 
-  url = paths.get_api_url() + f'notifications/mark-as-read/{notification_id}/'
+  url = f'{paths.BLENDERKIT_API}/notifications/mark-as-read/{notification_id}/'
   params = {}
   r = rerequests.get(url, params=params, verify=True, headers=headers)
   if r is None:

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -74,7 +74,6 @@ async def index(request: web_request.Request):
 async def consumer_exchange(request: web_request.Request):
   auth_code = request.rel_url.query.get('code', None)
   redirect_url = f'{globals.SERVER}/oauth-landing/'
-
   if auth_code == None:
     return web.Response(text="Authorization Failed. Authorization code was not provided.")
 
@@ -115,6 +114,14 @@ async def kill_download(request: web_request.Request):
       del globals.tasks[i]
       break
 
+  return web.Response(text="ok")
+
+
+async def code_verifier(request: web_request.Request):
+  """Gets code_verifier for OAuth login."""
+  
+  data = await request.json()
+  globals.code_verifier = data['code_verifier']
   return web.Response(text="ok")
 
 
@@ -191,6 +198,7 @@ async def online_status_check(app: web.Application, server: str):
       resp.close()
 
     await asyncio.sleep(60)
+
 
 async def start_background_tasks(app: web.Application):
   app['life_check'] = asyncio.create_task(life_check(app))
@@ -287,6 +295,7 @@ if __name__ == '__main__':
     web.get('/consumer/exchange/', consumer_exchange),
     web.get('/refresh_token', refresh_token),
     web.get('/get_disclaimer', get_disclaimer),
+    web.post('/code_verifier', code_verifier),
   ])
 
   server.on_startup.append(start_background_tasks)

--- a/daemon/oauth.py
+++ b/daemon/oauth.py
@@ -1,7 +1,7 @@
 """OAuth for login."""
 
+import logging
 import typing
-import uuid
 
 import globals
 import tasks
@@ -11,8 +11,8 @@ from aiohttp import client_exceptions, web
 async def get_tokens(request: web.Request, auth_code=None, refresh_token=None, grant_type="authorization_code") -> typing.Tuple[dict, int, str]:
   data = {
     "grant_type": grant_type,
-    "state": "random_state_string",
     "client_id": globals.OAUTH_CLIENT_ID,
+    "code_verifier": globals.code_verifier,
     "scopes": "read write",
     "redirect_uri" : f"http://localhost:{globals.PORT}/consumer/exchange/",
   }
@@ -25,13 +25,13 @@ async def get_tokens(request: web.Request, auth_code=None, refresh_token=None, g
   session = request.app['SESSION_API_REQUESTS']
   try:
     async with session.post(f"{globals.SERVER}/o/token/", data = data) as response:
-      await response.text()
+      text = await response.text()
 
       if response.status != 200:
-        return [], response.status, response.text
+        return [], response.status, text
 
       response_json = await response.json()
-      print("Token retrieval OK.")
+      logging.info("Token retrieval OK.")
 
       return response_json, 200, ""
 

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -100,6 +100,13 @@ def get_disclaimer():
     return resp
 
 
+def send_code_verifier(code_verifier: str):
+  data = {'code_verifier': code_verifier}
+  with requests.Session() as session:
+    resp = session.post(f'{get_address()}/code_verifier', json=data)
+    return resp
+
+
 def refresh_token(refresh_token):
   """Refresh authentication token."""
   

--- a/download.py
+++ b/download.py
@@ -181,7 +181,7 @@ def report_usages():
     api_key = user_preferences.api_key
     sid = utils.get_scene_id()
     headers = utils.get_headers(api_key)
-    url = paths.get_api_url() + paths.BLENDERKIT_REPORT_URL
+    url = paths.BLENDERKIT_REPORT_URL
 
     assets = {}
     asset_obs = []

--- a/global_vars.py
+++ b/global_vars.py
@@ -11,7 +11,7 @@ DATA = {
 LOGGING_LEVEL_BLENDERKIT = logging.INFO
 LOGGING_LEVEL_IMPORTED = logging.WARN
 PREFS = {}
-SERVER = 'https://www.blenderkit.com'
+SERVER = 'https://devel.blenderkit.com'
 TIPS = [
   ('You can disable tips in the add-on preferences.', 'https://docs.blender.org/manual/en/3.1/addons/3d_view/blenderkit.html#preferences'),
   ('Ratings help us distribute funds to creators.', 'https://www.blenderkit.com/docs/rating/'),
@@ -34,4 +34,5 @@ TIPS = [
   ]
 VERSION = None #filled in register()
 
+code_verifier = None
 daemon_process = None

--- a/global_vars.py
+++ b/global_vars.py
@@ -11,7 +11,13 @@ DATA = {
 LOGGING_LEVEL_BLENDERKIT = logging.INFO
 LOGGING_LEVEL_IMPORTED = logging.WARN
 PREFS = {}
-SERVER = 'https://devel.blenderkit.com'
+
+BLENDERKIT_LOCAL = 'http://localhost:8001'
+BLENDERKIT_MAIN = 'https://www.blenderkit.com'
+BLENDERKIT_DEVEL = 'https://devel.blenderkit.com'
+BLENDERKIT_STAGING = 'https://staging.blenderkit.com'
+SERVER = BLENDERKIT_MAIN
+
 TIPS = [
   ('You can disable tips in the add-on preferences.', 'https://docs.blender.org/manual/en/3.1/addons/3d_view/blenderkit.html#preferences'),
   ('Ratings help us distribute funds to creators.', 'https://www.blenderkit.com/docs/rating/'),

--- a/paths.py
+++ b/paths.py
@@ -29,25 +29,22 @@ from . import colors, global_vars, reports, tasks_queue, utils
 
 bk_logger = logging.getLogger(__name__)
 
-_presets = os.path.join(bpy.utils.user_resource('SCRIPTS'), "presets")
-BLENDERKIT_LOCAL = "http://localhost:8001"
-BLENDERKIT_MAIN = "https://www.blenderkit.com"
-BLENDERKIT_DEVEL = "https://devel.blenderkit.com"
-BLENDERKIT_STAGING = "https://staging.blenderkit.com"
-BLENDERKIT_API = "/api/v1/"
-BLENDERKIT_REPORT_URL = "usage_report/"
-BLENDERKIT_USER_ASSETS = "/my-assets"
-BLENDERKIT_PLANS = "/plans/pricing/"
-BLENDERKIT_MANUAL = "https://youtu.be/pSay3yaBWV0"
-BLENDERKIT_MODEL_UPLOAD_INSTRUCTIONS_URL = "https://www.blenderkit.com/docs/upload/"
-BLENDERKIT_MATERIAL_UPLOAD_INSTRUCTIONS_URL = "https://www.blenderkit.com/docs/uploading-material/"
-BLENDERKIT_BRUSH_UPLOAD_INSTRUCTIONS_URL = "https://www.blenderkit.com/docs/uploading-brush/"
-BLENDERKIT_HDR_UPLOAD_INSTRUCTIONS_URL = "https://www.blenderkit.com/docs/uploading-hdr/"
-BLENDERKIT_SCENE_UPLOAD_INSTRUCTIONS_URL = "https://www.blenderkit.com/docs/uploading-scene/"
-BLENDERKIT_LOGIN_URL = "https://www.blenderkit.com/accounts/login"
-BLENDERKIT_OAUTH_LANDING_URL = "/oauth-landing/"
-BLENDERKIT_SIGNUP_URL = "https://www.blenderkit.com/accounts/register"
-BLENDERKIT_SETTINGS_FILENAME = os.path.join(_presets, "bkit.json")
+_presets = os.path.join(bpy.utils.user_resource('SCRIPTS'), 'presets')
+BLENDERKIT_API = f'{global_vars.SERVER}/api/v1'
+BLENDERKIT_OAUTH_LANDING_URL = f'{global_vars.SERVER}/oauth-landing'
+BLENDERKIT_PLANS_URL = f'{global_vars.SERVER}/plans/pricing'
+BLENDERKIT_REPORT_URL = f'{global_vars.SERVER}/usage_report'
+BLENDERKIT_USER_ASSETS_URL = f'{global_vars.SERVER}/my-assets'
+BLENDERKIT_MANUAL_URL = 'https://youtu.be/pSay3yaBWV0'
+BLENDERKIT_MODEL_UPLOAD_INSTRUCTIONS_URL = f'{global_vars.SERVER}/docs/upload/'
+BLENDERKIT_MATERIAL_UPLOAD_INSTRUCTIONS_URL = f'{global_vars.SERVER}/docs/uploading-material/'
+BLENDERKIT_BRUSH_UPLOAD_INSTRUCTIONS_URL = f'{global_vars.SERVER}/docs/uploading-brush/'
+BLENDERKIT_HDR_UPLOAD_INSTRUCTIONS_URL = f'{global_vars.SERVER}/docs/uploading-hdr/'
+BLENDERKIT_SCENE_UPLOAD_INSTRUCTIONS_URL = f'{global_vars.SERVER}/docs/uploading-scene/'
+BLENDERKIT_LOGIN_URL = f'{global_vars.SERVER}/accounts/login'
+BLENDERKIT_SIGNUP_URL = f'{global_vars.SERVER}/accounts/register'
+
+BLENDERKIT_SETTINGS_FILENAME = os.path.join(_presets, 'bkit.json')
 
 
 def cleanup_old_folders():
@@ -60,21 +57,6 @@ def cleanup_old_folders():
             bk_logger.error(f'could not delete old temp directory: {e}')
 
 
-def get_bkit_url():
-    # bpy.app.debug_value = 2
-    d = bpy.app.debug_value
-    # d = 2
-    if d == 1:
-        url = BLENDERKIT_LOCAL
-    elif d == 2:
-        url = BLENDERKIT_DEVEL
-    elif d == 3:
-        url = BLENDERKIT_STAGING
-    else:
-        url = BLENDERKIT_MAIN
-    return url
-
-
 def find_in_local(text=''):
     fs = []
     for p, d, f in os.walk('.'):
@@ -84,20 +66,12 @@ def find_in_local(text=''):
     return fs
 
 
-def get_api_url():
-    return get_bkit_url() + BLENDERKIT_API
-
-
-def get_oauth_landing_url():
-    return get_bkit_url() + BLENDERKIT_OAUTH_LANDING_URL
-
-
 def get_author_gallery_url(author_id):
-    return f'{get_bkit_url()}/asset-gallery?query=author_id:{author_id}'
+    return f'{global_vars.SERVER}/asset-gallery?query=author_id:{author_id}'
 
 
 def get_asset_gallery_url(asset_id):
-    return f'{get_bkit_url()}/asset-gallery-detail/{asset_id}/'
+    return f'{global_vars.SERVER}/asset-gallery-detail/{asset_id}/'
 
 
 def default_global_dict():

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -96,9 +96,8 @@ def get_rating(asset_id, headers):
     -------
     ratings - dict of type:value ratings
     '''
-    import time
-    t = time.time()
-    url = paths.get_api_url() + 'assets/' + asset_id + '/rating/'
+
+    url = f'{paths.BLENDERKIT_API}/assets/{asset_id}/rating/'
     params = {}
     r = rerequests.get(url, params=params, verify=True, headers=headers)
     if r is None:
@@ -152,7 +151,7 @@ def update_ratings_quality(self, context):
         asset_id = self.asset_id
 
     if bkit_ratings.rating_quality > 0.1:
-        url = paths.get_api_url() + f'assets/{asset_id}/rating/'
+        url = f'{paths.BLENDERKIT_API}/assets/{asset_id}/rating/'
 
         store_rating_local(asset_id, type='quality', value=bkit_ratings.rating_quality)
 
@@ -175,7 +174,7 @@ def update_ratings_work_hours(self, context):
         asset_id = self.asset_id
 
     if bkit_ratings.rating_work_hours > 0.45:
-        url = paths.get_api_url() + f'assets/{asset_id}/rating/'
+        url = f'{paths.BLENDERKIT_API}/assets/{asset_id}/rating/'
 
         store_rating_local(asset_id, type='working_hours', value=bkit_ratings.rating_work_hours)
 

--- a/resolutions.py
+++ b/resolutions.py
@@ -242,7 +242,7 @@ def patch_asset_empty(asset_id, api_key):
     '''
     upload_data = {
     }
-    url = paths.get_api_url() + 'assets/' + str(asset_id) + '/'
+    url = f'{paths.BLENDERKIT_API}/assets/{asset_id}/'
     headers = utils.get_headers(api_key)
     try:
         r = rerequests.patch(url, json=upload_data, headers=headers, verify=True)  # files = files,
@@ -487,11 +487,9 @@ def assets_db_path():
 
 
 def get_assets_search():
-    # bpy.app.debug_value = 2
-
     results = []
     preferences = bpy.context.preferences.addons['blenderkit'].preferences
-    url = paths.get_api_url() + 'search/all'
+    url = f'{paths.BLENDERKIT_API}/search/all'
     i = 0
     while url is not None:
         headers = utils.get_headers(preferences.api_key)
@@ -703,7 +701,7 @@ def send_to_bg(asset_data, fpath, command='generate_resolutions', wait=True):
 
 def write_data_back(asset_data):
     '''ensures that the data in the resolution file is the same as in the database.'''
-    pass;
+    pass
 
 
 def run_bg(datafile):

--- a/search.py
+++ b/search.py
@@ -629,9 +629,9 @@ def fetch_gravatar(adata=None):
     avatar_path = paths.get_temp_dir(subdir='bkit_g/') + adata['id'] + '.jpg'
     if os.path.exists(avatar_path):
       tasks_queue.add_task((write_gravatar, (adata['id'], avatar_path)))
-      return;
+      return
 
-    url = paths.get_bkit_url() + adata['avatar128']
+    url = global_vars.SERVER + adata['avatar128']
     r = rerequests.get(url, stream=False)
     # print(r.body)
     if r.status_code == 200:
@@ -713,7 +713,7 @@ def write_profile(adata):
 
 
 def request_profile(api_key):
-  a_url = paths.get_api_url() + 'me/'
+  a_url = f'{paths.BLENDERKIT_API}/me/'
   headers = utils.get_headers(api_key)
   r = rerequests.get(a_url, headers=headers)
   adata = r.json()
@@ -745,7 +745,7 @@ def get_profile():
 
 def query_to_url(query={}, params={}):
   # build a new request
-  url = paths.get_api_url() + 'search/'
+  url = f'{paths.BLENDERKIT_API}/search/'
 
   # build request manually
   # TODO use real queries
@@ -1015,7 +1015,7 @@ def get_search_simple(parameters, filepath=None, page_size=100, max_results=1000
 
   '''
   headers = utils.get_headers(api_key)
-  url = paths.get_api_url() + 'search/'
+  url = f'{paths.BLENDERKIT_API}/search/'
   requeststring = url + '?query='
   for p in parameters.keys():
     requeststring += f'+{p}:{parameters[p]}'

--- a/ui.py
+++ b/ui.py
@@ -880,7 +880,7 @@ class AssetDragOperator(bpy.types.Operator):
             if not self.asset_data.get('canDownload'):
                 message = "Let's support asset creators and Open source."
                 link_text = 'Unlock the asset.'
-                url = paths.get_bkit_url() + '/get-blenderkit/' + self.asset_data['id'] + '/?from_addon=True'
+                url = f'{global_vars.SERVER}/get-blenderkit/{self.asset_data["id"]}/?from_addon=True'
                 bpy.ops.wm.blenderkit_url_dialog('INVOKE_REGION_WIN', url=url, message=message,
                                                  link_text=link_text)
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -325,7 +325,7 @@ def draw_panel_model_search(self, context):
         icon = 'ERROR'
     utils.label_multiline(layout, text=props.report, icon=icon)
     if props.report == 'You need Full plan to get this item.':
-        layout.operator("wm.url_open", text="Get Full plan", icon='URL').url = paths.BLENDERKIT_PLANS
+        layout.operator("wm.url_open", text="Get Full plan", icon='URL').url = paths.BLENDERKIT_PLANS_URL
 
     # layout.prop(props, "search_style")
     # layout.prop(props, "own_only")
@@ -549,8 +549,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
                     row.label(text='My plan:')
                     row.label(text='%s plan' % pn, icon_value=my_icon.icon_id)
                     if pn == 'Free':
-                        layout.operator("wm.url_open", text="Change plan",
-                                        icon='URL').url = paths.get_bkit_url() + paths.BLENDERKIT_PLANS
+                        layout.operator("wm.url_open", text="Change plan", icon='URL').url = paths.BLENDERKIT_PLANS_URL
 
                 # storage statistics
                 # if me.get('sumAssetFilesSize') is not None:  # TODO remove this when production server has these too.
@@ -560,8 +559,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
                 if me.get('remainingPrivateQuota') is not None:
                     layout.label(text='My free storage: %i MiB' % (me['remainingPrivateQuota']))
 
-            layout.operator("wm.url_open", text="See my uploads",
-                            icon='URL').url = paths.get_bkit_url() + paths.BLENDERKIT_USER_ASSETS
+            layout.operator("wm.url_open", text="See my uploads", icon='URL').url = paths.BLENDERKIT_USER_ASSETS_URL
         addon_updater_ops.update_notice_box_ui(self,context)
 
 class MarkNotificationRead(bpy.types.Operator):
@@ -832,7 +830,7 @@ def draw_notification(self, notification, width=600):
 
         op = row.operator('wm.blenderkit_open_notification_target', text='Open page', icon='HIDE_OFF')
         op.tooltip = 'Open the browser on the asset page to comment'
-        op.url = paths.get_bkit_url() + notification['target']['url']
+        op.url = global_vars.SERVER + notification['target']['url']
         op.notification_id = notification['id']
         # split =
         op = row.operator("wm.blenderkit_mark_notification_read", text="", icon='CANCEL')
@@ -1475,7 +1473,7 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
 
             # utils.label_multiline(layout, text="\n Let's start by searching for some cool materials?", width=300)
             op = layout.operator("wm.url_open", text='Watch Video Tutorial', icon='QUESTION')
-            op.url = paths.BLENDERKIT_MANUAL
+            op.url = paths.BLENDERKIT_MANUAL_URL
 
         else:
             message = "Operator Tutorial called with invalid step"
@@ -1568,7 +1566,7 @@ def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
 
     op = layout.operator('wm.url_open', text="See online", icon = 'URL')
     if utils.user_is_owner(asset_data) and asset_data["verificationStatus"] != "validated":
-        op.url = paths.get_bkit_url() + paths.BLENDERKIT_USER_ASSETS + f"/{asset_data['assetBaseId']}/?preview#"
+        op.url =  f'{paths.BLENDERKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?preview#'
     else:
         op.url = paths.get_asset_gallery_url(asset_data['id'])
         #TODO this is where validator should be able to go and see non-validated the assets in gallery,
@@ -1681,7 +1679,7 @@ def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
             if author_id == str(profile['user']['id']):
                 row.operator_context = 'EXEC_DEFAULT'
                 op = layout.operator('wm.blenderkit_url', text='Edit Metadata (browser)', icon='GREASEPENCIL')
-                op.url = paths.get_bkit_url() + paths.BLENDERKIT_USER_ASSETS + f"/{asset_data['assetBaseId']}/?edit#"
+                op.url = f'{paths.BLENDERKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?edit#'
 
             row.operator_context = 'INVOKE_DEFAULT'
 
@@ -1930,7 +1928,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         self.draw_property(box,
                            'License', t,
                            # icon_value=icon.icon_id,
-                           url="https://www.blenderkit.com/docs/licenses/",
+                           url=f'{global_vars.SERVER}/docs/licenses/',
                            tooltip='All BlenderKit assets are available for commercial use. \n' \
                                    'Click to read more about BlenderKit licenses on the website'
                            )
@@ -1962,7 +1960,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                                'Verification',
                                self.asset_data['verificationStatus'],
                                icon_value=icon.icon_id,
-                               url="https://www.blenderkit.com/docs/validation-status/",
+                               url=f'{global_vars.SERVER}/docs/validation-status/',
                                tooltip=verification_status_tooltips[self.asset_data['verificationStatus']]
 
                                )
@@ -2055,7 +2053,6 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                         '  *  Free plan - more than 50% of all assets\n' \
                         '  *  Full plan - unlimited access to everything\n' \
                         'Click to go to subscriptions page'
-        plans_link = 'https://www.blenderkit.com/plans/pricing/'
         if self.asset_data['isPrivate']:
             t = 'Private'
             self.draw_property(box, 'Access', t, icon='LOCKED')
@@ -2065,14 +2062,14 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             self.draw_property(box, 'Access', t,
                                icon_value=icon.icon_id,
                                tooltip=plans_tooltip,
-                               url=plans_link)
+                               url=paths.BLENDERKIT_PLANS_URL)
         else:
             t = 'Full plan'
             icon = pcoll['full']
             self.draw_property(box, 'Access', t,
                                icon_value=icon.icon_id,
                                tooltip=plans_tooltip,
-                               url=plans_link)
+                               url=paths.BLENDERKIT_PLANS_URL)
         if utils.profile_is_validator():
             date = self.asset_data['created'][:10]
             date = f"{date[8:10]}. {date[5:7]}. {date[:4]}"
@@ -2134,7 +2131,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                 row.label(text='Please introduce yourself to the community!')
 
                 op = col.operator('wm.blenderkit_url', text='Edit your profile')
-                op.url = 'https://www.blenderkit.com/profile'
+                op.url = f'{global_vars.SERVER}/profile'
                 op.tooltip = 'Edit your profile on BlenderKit webpage'
 
             button_row = author_box.row()
@@ -2229,7 +2226,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             row.prop(ui_props, 'drag_init_button', icon='MOUSE_LMB_DRAG', text='Click / Drag from here', emboss=True)
         else:
             op = layout.operator('wm.blenderkit_url', text='Unlock this asset', icon='UNLOCKED')
-            op.url = paths.get_bkit_url() + '/get-blenderkit/' + self.asset_data['id'] + '/?from_addon=True'
+            op.url = f'{global_vars.SERVER}/get-blenderkit/{self.asset_data["id"]}/?from_addon=True'
 
     def draw_menu_desc_author(self, context, layout, width=330):
         box = layout.column()
@@ -2407,10 +2404,10 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             split = split.split()
             row.alert = False
             op = row.operator("wm.url_open", text="", icon="GREASEPENCIL")
-            op.url = f"https://www.blenderkit.com/bksecretadmin/django_comments_xtd/xtdcomment/{comment['id']}/change/"
+            op.url = f'{global_vars.SERVER}/bksecretadmin/django_comments_xtd/xtdcomment/{comment["id"]}/change/'
             # row.alert = True
             # op = row.operator("wm.url_open", text="", icon='CANCEL')
-            # op.url = f"https://www.blenderkit.com/bksecretadmin/django_comments_xtd/xtdcomment/{comment['id']}/delete/"
+            # op.url = f'{global_vars.SERVER}/bksecretadmin/django_comments_xtd/xtdcomment/{comment["id"]}/delete/'
           
         if utils.user_logged_in():
             # row = rows[-1]

--- a/upload.py
+++ b/upload.py
@@ -546,7 +546,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
 
 def patch_individual_metadata(asset_id, metadata_dict, api_key):
     upload_data = metadata_dict
-    url = paths.get_api_url() + 'assets/' + str(asset_id) + '/'
+    url = f'{paths.BLENDERKIT_API}/assets/{asset_id}/'
     headers = utils.get_headers(api_key)
     try:
         r = rerequests.patch(url, json=upload_data, headers=headers, verify=True)  # files = files,
@@ -785,7 +785,7 @@ def verification_status_change_thread(asset_id, state, api_key):
     upload_data = {
         "verificationStatus": state
     }
-    url = paths.get_api_url() + 'assets/' + str(asset_id) + '/'
+    url = paths.BLENDERKIT_API + '/assets/' + str(asset_id) + '/'
     headers = utils.get_headers(api_key)
     try:
         r = rerequests.patch(url, json=upload_data, headers=headers, verify=True)  # files = files,
@@ -904,7 +904,7 @@ class Uploader(threading.Thread):
         script_path = os.path.dirname(os.path.realpath(__file__))
 
         # first upload metadata to server, so it can be saved inside the current file
-        url = paths.get_api_url() + 'assets/'
+        url = paths.BLENDERKIT_API + '/assets/'
 
         headers = utils.get_headers(self.upload_data['token'])
 
@@ -1042,7 +1042,7 @@ class Uploader(threading.Thread):
                         "verificationStatus": "uploaded"
                     }
 
-                    url = paths.get_api_url() + 'assets/'
+                    url = paths.BLENDERKIT_API + '/assets/'
 
                     headers = utils.get_headers(self.upload_data['token'])
 

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -84,7 +84,7 @@ def upload_file(upload_data, f):
         'fileIndex': f['index'],
         'originalFilename': os.path.basename(f['file_path'])
     }
-    upload_create_url = paths.get_api_url() + 'uploads/'
+    upload_create_url = f'{paths.BLENDERKIT_API}/uploads/'
     upload = rerequests.post(upload_create_url, json=upload_info, headers=headers, verify=True)
     upload = upload.json()
     #
@@ -112,7 +112,7 @@ def upload_file(upload_data, f):
 
                 if 250 > upload_response.status_code > 199:
                     uploaded = True
-                    upload_done_url = paths.get_api_url() + 'uploads_s3/' + upload['id'] + '/upload-file/'
+                    upload_done_url = f'{paths.BLENDERKIT_API}/uploads_s3/{upload["id"]}/upload-file/'
                     upload_response = rerequests.post(upload_done_url, headers=headers, verify=True)
                     # print(upload_response)
                     # print(upload_response.text)


### PR DESCRIPTION
fixes #301

- enables PKCE in the add-on
- moves and unifies switching between local/devel/stagging/production into global_vars.SERVER instead of using debug value

**How to test:**
- run, try login and search
- set `global_vars.DEBUG=BLENDERKIT_DEVEL` and try to login and search

**Testing of older add-ons on devel:**
- BlenderKit 2.93.0 on Blender 2.93.10 on devel - login, search and download is OK
- BlenderKit 3.0.4 on Blender 3.0.0 on devel - login, search and download is OK
- BlenderKit 3.1.0 on Blender 3.0.0 on devel - login, search and download is OK
- BlenderKit 3.1.5 on Blender 3.0.0 on devel - login, search and download is OK
- BlenderKit 3.2.0.220920 on Blender 3.0.0 on devel - login, search and download is OK 
(one must set debug_value and also set globals.SERVER to devel, no action should be needed for production server)