### PR TITLE
fix the 'missing operator' messages.

### DIFF
--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -88,10 +88,6 @@ class BL_UI_OT_draw_operator(Operator):
 
 def draw_callback_px_separated(self, op, context):
     #separated only for puprpose of profiling
-    if context.area.as_pointer() == self.active_area_pointer:
-        for widget in self.widgets:
-            widget.draw()
-    return
     try:
         if context.area.as_pointer() == self.active_area_pointer:
             for widget in self.widgets:


### PR DESCRIPTION
This is actually putting back a fix that was already there, for some testing it was tweaked and accidentaly commited such