### PR TITLE
initial support for webp images

### DIFF
--- a/daemon/search.py
+++ b/daemon/search.py
@@ -59,9 +59,13 @@ async def parse_thumbnails(task: tasks.Task):
   # get thumbnails that need downloading
 
   for i, search_result in enumerate(task.result.get('results', [])):
+    # Find out if the asset is older than 1 hour, so we can use .webp images
+    webp_ext = '.webp'
+
     # SMALL THUMBNAIL
-    imgname = assets.extract_filename_from_url(search_result['thumbnailSmallUrl'])
+    imgname = assets.extract_filename_from_url(search_result['thumbnailSmallUrl'])+webp_ext
     imgpath = os.path.join(task.data['tempdir'], imgname)
+
     data = {
       "image_path": imgpath,
       "image_url": search_result["thumbnailSmallUrl"],
@@ -84,11 +88,11 @@ async def parse_thumbnails(task: tasks.Task):
     else:
       large_thumb_url = search_result['thumbnailMiddleUrl']
 
-    imgname = assets.extract_filename_from_url(large_thumb_url)
+    imgname = assets.extract_filename_from_url(large_thumb_url)+webp_ext
     imgpath = os.path.join(task.data['tempdir'], imgname)
     data = {
       "image_path": imgpath,
-      "image_url": large_thumb_url,
+      "image_url": large_thumb_url+webp_ext,
       "assetBaseId": search_result['assetBaseId'],
       "thumbnail_type": "full",
       "index": i

--- a/search.py
+++ b/search.py
@@ -214,19 +214,16 @@ def parse_result(r):
     get_author(r)
 
     r['available_resolutions'] = []
-    allthumbs = []
     durl, tname, small_tname = '', '', ''
 
+    # Find out if the asset is older than 1 hour, so we can use .webp images
+    webp_ext = '.webp'
+
     if r['assetType'] == 'hdr':
-      tname = paths.extract_filename_from_url(r['thumbnailLargeUrlNonsquared'])
+      tname = paths.extract_filename_from_url(r['thumbnailLargeUrlNonsquared'])+webp_ext
     else:
-      tname = paths.extract_filename_from_url(r['thumbnailMiddleUrl'])
-    small_tname = paths.extract_filename_from_url(r['thumbnailSmallUrl'])
-    allthumbs.append(tname)  # TODO just first thumb is used now.
-    # if r['fileType'] == 'thumbnail':
-    #     tname = paths.extract_filename_from_url(f['fileThumbnailLarge'])
-    #     small_tname = paths.extract_filename_from_url(f['fileThumbnail'])
-    #     allthumbs.append(tname)  # TODO just first thumb is used now.
+      tname = paths.extract_filename_from_url(r['thumbnailMiddleUrl'])+webp_ext
+    small_tname = paths.extract_filename_from_url(r['thumbnailSmallUrl'])+webp_ext
 
     for f in r['files']:
       # if f['fileType'] == 'thumbnail':


### PR DESCRIPTION
fixes #369 

this just shows all the places we need to address

TODO:
- add version check, seems loading webp is quite slow and was optimized in Blender 3.4, so really allow only since 3.4
- add check for if the .webp is actually there, has to be now done by trying to download .webp and then reverting, can also be limited by 'validated' status of the asset, since then it should there be 99.99% probably
- the checks for .webp could also happen on the server side, where it makes more sense - asked Petr about it, lets see