### PR TITLE
Exodus of network requests from add-on into daemon

### DIFF
--- a/asset_pack_bg.py
+++ b/asset_pack_bg.py
@@ -1,9 +1,0 @@
-import sys
-
-from blenderkit import resolutions
-
-
-BLENDERKIT_EXPORT_DATA = sys.argv[-1]
-
-if __name__ == "__main__":
-    resolutions.run_bg(sys.argv[-1])

--- a/autothumb_material_bg.py
+++ b/autothumb_material_bg.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import bpy
 
-from blenderkit import append_link, bg_blender, download, upload, utils
+from blenderkit import append_link, bg_blender, daemon_lib, download, upload, utils
 
 
 BLENDERKIT_EXPORT_DATA = sys.argv[-1]
@@ -63,14 +63,13 @@ if __name__ == "__main__":
             bpy.ops.wm.save_as_mainfile(filepath=temp_blend_path)
 
             asset_data = data['asset_data']
-            has_url = download.get_download_url(asset_data, utils.get_scene_id(), user_preferences.api_key, tcom=None,
-                                                resolution='blend')
+            has_url, asset_data = daemon_lib.get_download_url(asset_data, utils.get_scene_id(), user_preferences.api_key)
             if not has_url:
                 bg_blender.progress("couldn't download asset for thumnbail re-rendering")
                 exit()
             # download first, or rather make sure if it's already downloaded
             bg_blender.progress('downloading asset')
-            fpath = download.download_asset_file(asset_data)
+            fpath = download.download_asset_file(asset_data) #TODO: this got lost
             data['filepath'] = fpath
 
         mat = append_link.append_material(file_name=data['filepath'], matname=data["asset_name"], link=True,

--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -25,7 +25,7 @@ import sys
 
 import bpy
 
-from blenderkit import append_link, bg_blender, download, upload, upload_bg, utils
+from blenderkit import append_link, bg_blender, daemon_lib, download, upload, utils
 
 
 BLENDERKIT_EXPORT_DATA = sys.argv[-1]
@@ -101,13 +101,12 @@ if __name__ == "__main__":
 
             bg_blender.progress('Downloading asset')
             asset_data = data['asset_data']
-            has_url = download.get_download_url(asset_data, utils.get_scene_id(), user_preferences.api_key, tcom=None,
-                                                resolution='blend')
+            has_url, asset_data = daemon_lib.get_download_url(asset_data, utils.get_scene_id(), user_preferences.api_key)
             if not has_url == True:
                 bg_blender.progress("couldn't download asset for thumnbail re-rendering")
             # download first, or rather make sure if it's already downloaded
             bg_blender.progress('downloading asset')
-            fpath = download.download_asset_file(asset_data)
+            fpath = download.download_asset_file(asset_data) #TODO: this got lost
             data['filepath'] = fpath
             main_object, allobs = append_link.link_collection(fpath,
                                                           location=(0,0,0),

--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -106,12 +106,12 @@ def write_tokens(auth_token, refresh_token, oauth_response):
     props = utils.get_search_props()
     if props is not None:
         props.report = ''
-    search.get_profile()
+    daemon_lib.get_user_profile(preferences.api_key)
     # ui_props = bpy.context.window_manager.blenderkitUI
     # if ui_props.assetbar_on:
     #     ui_props.turn_off = True
     #     ui_props.assetbar_on = False
-    search.cleanup_search_results()
+    search.cleanup_search_results() #TODO: is it possible to start this from daemon automatically? probably YEA
     history = global_vars.DATA['search history']
     if len(history)>0:
         search.search(query = history[-1])

--- a/comments_utils.py
+++ b/comments_utils.py
@@ -19,9 +19,9 @@
 import logging
 import threading
 
-
-from . import global_vars, paths, rerequests, utils, ratings_utils
+from . import global_vars, paths, ratings_utils, rerequests, utils
 from .daemon import tasks
+
 
 bk_logger = logging.getLogger(__name__)
 

--- a/daemon/comments.py
+++ b/daemon/comments.py
@@ -1,0 +1,108 @@
+import logging
+
+from aiohttp import web
+
+import utils, globals, tasks
+
+
+async def get_comments(request: web.Request, task: tasks.Task):
+  """Retrieve comments from server."""
+  asset_id = task.data['asset_id']
+  headers = utils.get_headers(task.data.get('api_key',''))
+  session = request.app['SESSION_API_REQUESTS']
+  url = f'{globals.SERVER}/api/v1/comments/assets-uuidasset/{asset_id}/'
+  try:
+    async with session.get(url, headers=headers) as resp:
+      task.result = await resp.json()
+      task.finished('comments downloaded')
+  except Exception as e:
+    logging.warning(str(e))
+    task.error(f'{e}')
+
+
+async def create_comment(request: web.Request, task: tasks.Task):
+  """Create and upload the comment online."""
+  comment = task.data['comment_text']
+  asset_id = task.data['asset_id']
+  reply_to_id = task.data['reply_to_id']
+  headers = utils.get_headers(task.data['api_key'])
+  session = request.app['SESSION_API_REQUESTS']
+  url = f'{globals.SERVER}/api/v1/comments/asset-comment/{asset_id}/'
+  try:
+    async with session.get(url, headers=headers) as resp:
+      comment_data = await resp.json()
+      data = {
+        'name': '',
+        'email': '',
+        'url': '',
+        'followup': reply_to_id > 0,
+        'reply_to': reply_to_id,
+        'honeypot': '',
+        'content_type': 'assets.uuidasset',
+        'object_pk': asset_id,
+        'timestamp': comment_data['form']['timestamp'],
+        'security_hash': comment_data['form']['securityHash'],
+        'comment': comment,
+      }
+  except Exception as e:
+    logging.error(str(e))
+
+  try:
+    url = f'{globals.SERVER}/api/v1/comments/comment/'
+    async with session.post(url, headers=headers, data=data) as resp:
+      task.result = await resp.json()
+      if resp.status != 201:
+        return task.error(f'request status code: {resp.status}')
+
+      task.finished('comment created')
+      ###TODO: create a new task here - update the comments
+      ###or can we just update the comments with the new comment?
+      #get_comments(request) 
+  except Exception as e:
+    logging.error(str(e))
+    task.error(f'{e}')
+
+
+async def feedback_comment(request: web.Request, task: tasks.Task):
+  """Upload feeback on the comment to the server. Like/dislike but can be also a different flag."""
+  headers = utils.get_headers(task.data['api_key'])
+  session = request.app['SESSION_API_REQUESTS']
+  data = {
+    'comment': task.data['comment_id'],
+    'flag': task.data['flag'],
+  }
+  url = f'{globals.SERVER}/api/v1/comments/feedback/'
+  try:
+    async with session.post(url, data=data, headers=headers) as resp:
+      task.result = await resp.json()
+      if resp.status != 201:
+        return task.error(f'request status code: {resp.status}')
+  except Exception as e:
+    logging.warning(str(e))
+    task.error(f'{e}')
+
+  # here it's important we read back, so likes are updated accordingly:
+  #TODO: create a new task here which gets comments for fresh data
+  print(task.result)
+  return task.finished('flag uploaded')
+
+
+
+async def mark_comment_private(request: web.Request, task: tasks.Task):
+  """Update visibility of the comment."""
+  headers = utils.get_headers(task.data['api_key'])
+  session = request.app['SESSION_API_REQUESTS']
+  data = {'is_private': task.data['is_private']}
+  url = f'{globals.SERVER}/api/v1/comments/is_private/{task.data["comment_id"]}/'
+  try:
+    async with session.post(url, data=data, headers=headers) as resp:
+      task.result = await resp.json()
+      task.finished('comment visibility updated')
+      # here it's important we read back, so likes are updated accordingly:
+      #TODO: create a new task here which gets comments for fresh data
+  except Exception as e:
+    logging.error(f'{e}')
+    task.error(f'{e}')
+
+
+

--- a/daemon/comments.py
+++ b/daemon/comments.py
@@ -1,8 +1,10 @@
 import logging
 
+import globals
+import tasks
 from aiohttp import web
 
-import utils, globals, tasks
+import utils
 
 
 async def get_comments(request: web.Request, task: tasks.Task):

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -150,7 +150,7 @@ async def subscribe_new_addon(request: web.Request, data: dict):
 
   categories_task = asyncio.ensure_future(search.fetch_categories(request))
   categories_task.add_done_callback(tasks.handle_async_errors)
-  if data['app_id'] == '':
+  if data['api_key'] == '':
     return #everything done, if not logged in
 
   notifications_task = asyncio.ensure_future(disclaimer.get_notifications(request))

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -35,6 +35,7 @@ import comments
 import disclaimer
 import globals
 import oauth
+import profiles
 import tasks
 import uploads
 
@@ -339,11 +340,13 @@ if __name__ == '__main__':
     web.post('/comments/{func}', comments.comments_handler),
     web.post('/notifications/mark_notification_read', comments.mark_notification_read_handler),
     web.get('/wrappers/get_download_url', assets.get_download_url_wrapper),
+    web.get('/profiles/fetch_gravatar_image', profiles.fetch_gravatar_image_handler),
+    web.get('/profiles/get_user_profile', profiles.get_user_profile_handler),
   ])
 
   server.on_startup.append(start_background_tasks)
   server.on_cleanup.append(cleanup_background_tasks)
-  
+
   try:
     logging.info(f'Starting with {args}')
     web.run_app(server, host='127.0.0.1', port=args.port)

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -353,7 +353,7 @@ if __name__ == '__main__':
     web.get('/consumer/exchange/', consumer_exchange),
     web.get('/refresh_token', refresh_token),
     web.post('/code_verifier', code_verifier),
-
+    web.post('/report_usages', assets.report_usages_handler),
     web.post('/comments/{func}', comments_handler),
   ])
 

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -135,7 +135,7 @@ async def consumer_exchange(request: web.Request):
 
 
 async def refresh_token(request: web.Request):
-  atask = asyncio.ensure_future(oauth.refresh_tokens(request)) #TODO: Await errors here
+  atask = asyncio.ensure_future(oauth.refresh_tokens(request))
   atask.add_done_callback(tasks.handle_async_errors)
   return web.Response(text="ok")
 

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -88,24 +88,6 @@ async def upload_asset(request: web.Request):
   return web.json_response({'task_id': task_id})
 
 
-async def comments_handler(request: web.Request):
-  data = await request.json()
-  func  = request.match_info['func']
-  task = tasks.Task(data, data['app_id'], f'comments/{func}')
-  globals.tasks.append(task)
-  if func == 'get_comments':
-    task.async_task = asyncio.ensure_future(comments.get_comments(request, task))
-  elif func == 'create_comment':
-    task.async_task = asyncio.ensure_future(comments.create_comment(request, task))  
-  elif func == 'feedback_comment':
-    task.async_task = asyncio.ensure_future(comments.feedback_comment(request, task))
-  elif func == 'mark_comment_private':
-    task.async_task = asyncio.ensure_future(comments.mark_comment_private(request, task))
-
-  task.async_task.add_done_callback(tasks.handle_async_errors)
-  return web.json_response({'task_id': task.task_id})
-
-
 async def index(request: web.Request):
   """Report PID of server as Index page, can be used as is-alive endpoint."""
   pid = str(os.getpid())
@@ -354,7 +336,8 @@ if __name__ == '__main__':
     web.get('/refresh_token', refresh_token),
     web.post('/code_verifier', code_verifier),
     web.post('/report_usages', assets.report_usages_handler),
-    web.post('/comments/{func}', comments_handler),
+    web.post('/comments/{func}', comments.comments_handler),
+    web.post('/notifications/mark_notification_read', comments.mark_notification_read_handler),
   ])
 
   server.on_startup.append(start_background_tasks)

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -74,7 +74,7 @@ async def search_assets(request: web.Request):
 
 
 async def upload_asset(request: web.Request):
-  """WORK IN PROGRESS: Handle request for download of asset."""
+  """Handle request for upload of asset."""
   data = await request.json()  
   task_id = str(uuid.uuid4())
   app_id = data.pop('app_id')
@@ -123,7 +123,7 @@ async def refresh_token(request: web.Request):
 
 async def subscribe_new_addon(request: web.Request, data: dict):
   """Subscribe new add-on into list of active applications.
-  Also run all tasks which are needed on add-on startup - will be reported once finished.
+  Also run all tasks which are needed on add-on startup - will be reported back to add-on once finished.
   """
   globals.active_apps.append(data['app_id'])
   disclaimer_task = asyncio.ensure_future(disclaimer.get_disclaimer(request))
@@ -131,6 +131,11 @@ async def subscribe_new_addon(request: web.Request, data: dict):
 
   categories_task = asyncio.ensure_future(search.fetch_categories(request))
   categories_task.add_done_callback(tasks.handle_async_errors)
+  if data['app_id'] == '':
+    return #everything done, if not logged in
+
+  notifications_task = asyncio.ensure_future(disclaimer.get_notifications(request))
+  notifications_task.add_done_callback(tasks.handle_async_errors)
 
 
 async def kill_download(request: web.Request):

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -338,6 +338,7 @@ if __name__ == '__main__':
     web.post('/report_usages', assets.report_usages_handler),
     web.post('/comments/{func}', comments.comments_handler),
     web.post('/notifications/mark_notification_read', comments.mark_notification_read_handler),
+    web.get('/wrappers/get_download_url', assets.get_download_url_wrapper),
   ])
 
   server.on_startup.append(start_background_tasks)

--- a/daemon/profiles.py
+++ b/daemon/profiles.py
@@ -1,0 +1,107 @@
+"""Contains functions for work with profiles - profile of current user and also profiles of authors.
+TODO: We should find a better vocabulary for this.
+"""
+
+import asyncio
+import os
+import tempfile
+from urllib.parse import urljoin
+
+import globals
+import tasks
+from aiohttp import web
+
+import utils
+
+
+async def fetch_gravatar_image_handler(request: web.Request):
+  data = await request.json()
+  task = tasks.Task(data, data['app_id'], 'profiles/fetch_gravatar_image', message='Fetching gravatar image')
+  globals.tasks.append(task)
+  task.async_task = asyncio.ensure_future(fetch_gravatar_image(task, request))
+  task.async_task.add_done_callback(tasks.handle_async_errors)
+  return web.Response(text='ok')
+
+async def get_user_profile_handler(request: web.Request):
+  data = await request.json()
+  task = tasks.Task(data, data['app_id'], 'profiles/get_user_profile', message='Getting user profile')
+  globals.tasks.append(task)
+  task.async_task = asyncio.ensure_future(get_user_profile(task, request))
+  task.async_task.add_done_callback(tasks.handle_async_errors)
+  return web.Response(text='ok')
+
+
+async def fetch_gravatar_image(task: tasks.Task, request: web.Request):
+  """Get gravatar image from blenderkit server.
+  - task.data - author data from elastic search result + task.data['app_id']
+  """
+  if 'avatar128' not in task.data:
+    return fetch_gravatar_image_old(task, request)
+  
+  gravatar_path = os.path.join(tempfile.gettempdir(), 'bkit_temp', 'bkit_g', f'{task.data["id"]}.jpg')
+  if os.path.exists(gravatar_path):
+    task.result = {'gravatar_path': gravatar_path}
+    return task.finished('Found on disk')
+
+  url = urljoin(globals.SERVER, task.data["avatar128"])
+  session = request.app['SESSION_SMALL_THUMBS']
+  try:
+    await utils.download_file(url, gravatar_path, session)
+  except Exception as e:
+    return task.error(f'Download error: {e}')
+
+  task.result = {'gravatar_path': gravatar_path}
+  return task.finished('Downloaded')
+
+
+async def fetch_gravatar_image_old(task: tasks.Task, request: web.Request):
+  """Older way of getting gravatar image. May be needed for some users with old gravatars.""" #TODO: is this still in use?
+  if task.data.get('gravatarHash') is None:
+    return
+  gravatar_path = os.path.join(tempfile.gettempdir(), 'bkit_temp', 'bkit_g', f'{task.data["gravatarHash"]}.jpg')
+  if os.path.exists(gravatar_path):
+    task.result = {'gravatar_path': gravatar_path}
+    return task.finished('Found on disk')
+
+  url = urljoin('https://www.gravatar.com/avatar', f'{task.data["gravatarHash"]}?d=404')
+  session = request.app['SESSION_SMALL_THUMBS']
+  try:
+    await utils.download_file(url, gravatar_path, session)
+  except Exception as e:
+    return task.error(f'Download error: {e}')
+
+  task.result = {'gravatar_path': gravatar_path}
+  return task.finished('Downloaded')
+
+
+async def get_user_profile(task: tasks.Task, request: web.Request):
+  """Get profile data for currently logged-in user. Data are cleaned a little bit and then reported to the add-on."""
+  api_key = task.data['api_key']
+  headers = utils.get_headers(api_key)
+  url = f'{globals.SERVER}/api/v1/me/'
+  session = request.app['SESSION_API_REQUESTS']
+  try:
+    async with session.get(url, headers=headers) as resp:
+      data = await resp.json()
+  except Exception as e:
+    return task.error(f'request failed {e}')
+  if resp.status != 200:
+    return task.error(f'request returned code ({resp.status})')  
+  if data.get('user') is None:
+    return task.error('profile is None')
+
+  task.result = convert_user_data(data)
+  return task.finished('data suceessfully fetched')
+
+
+def convert_user_data(data: dict):
+  """Convert user data quotas to MiB, otherwise numbers would be too big for Python int type"""
+  user = data['user']
+  if user.get('sumAssetFilesSize') is not None:
+    user['sumAssetFilesSize'] /= (1024 * 1024)
+  if user.get('sumPrivateAssetFilesSize') is not None:
+    user['sumPrivateAssetFilesSize'] /= (1024 * 1024)
+  if user.get('remainingPrivateQuota') is not None:
+    user['remainingPrivateQuota'] /= (1024 * 1024)
+  data['user'] = user
+  return data

--- a/daemon/search.py
+++ b/daemon/search.py
@@ -26,7 +26,6 @@ def report_image_finished(data, filepath, done=True):
 
 async def download_image(session: aiohttp.ClientSession, task: tasks.Task):
   """Download a single image and report to addon."""
-
   image_url = task.data["image_url"]
   image_path = task.data["image_path"]
   try:
@@ -43,7 +42,6 @@ async def download_image(session: aiohttp.ClientSession, task: tasks.Task):
 
 async def download_image_batch(session: aiohttp.ClientSession, tsks: list[tasks.Task], block: bool = False):
   """Download batch of images. images are tuples of file path and url."""
-  
   coroutines = []
   for task in tsks:
     coroutine = asyncio.ensure_future(download_image(session, task))
@@ -153,21 +151,18 @@ async def do_search(request: web.Request, task: tasks.Task):
 
 async def fetch_categories(request: web.Request):
   data = await request.json()
-  app_id = data['app_id']
-  prefs = data.get('PREFS', {})
-  api_key = prefs.get('api_key', '')
-  task = tasks.Task(data, app_id, 'categories_update', str(uuid.uuid4()), message='Getting updated categories')
+  task = tasks.Task(data, data['app_id'], 'categories_update', str(uuid.uuid4()), message='Getting updated categories')
   globals.tasks.append(task)
 
-  url = f'{globals.SERVER}/api/v1/categories/'
-  headers = utils.get_headers(api_key)
+  headers = utils.get_headers(data['api_key'])
   session = request.app['SESSION_API_REQUESTS']
   try:
-    async with session.get(url, headers=headers) as resp:
+    async with session.get(f'{globals.SERVER}/api/v1/categories/', headers=headers) as resp:
       data = await resp.json()
       categories = data['results']
       fix_category_counts(categories)           # filter_categories(categories) #TODO this should filter categories for search, but not for upload. by now off.
       task.result = categories
+      print(f'categories fetched {categories}')
       task.finished('Categories fetched')
 
   except Exception as e:

--- a/daemon/search.py
+++ b/daemon/search.py
@@ -162,7 +162,6 @@ async def fetch_categories(request: web.Request):
       categories = data['results']
       fix_category_counts(categories)           # filter_categories(categories) #TODO this should filter categories for search, but not for upload. by now off.
       task.result = categories
-      print(f'categories fetched {categories}')
       task.finished('Categories fetched')
 
   except Exception as e:

--- a/daemon/tasks.py
+++ b/daemon/tasks.py
@@ -12,7 +12,7 @@ class Task():
     
     self.data = data
     self.task_id = task_id
-    self.app_id = app_id
+    self.app_id = app_id #TODO: implement solution for report to "all" Blenders
     self.task_type = task_type
     
     self.message = message

--- a/daemon/utils.py
+++ b/daemon/utils.py
@@ -4,11 +4,12 @@ import platform
 import re
 import sys
 
+import aiohttp
 import globals
 
 
 def get_headers(api_key: str = '') -> dict[str, str]:
-  """Get headers with authorization."""
+  """Get headers with or without authorization."""
   headers = {
     'accept': 'application/json',
     'Platform-Version': platform.platform(),
@@ -50,14 +51,10 @@ def dict_to_params(inputs, parameters=None):
 
 def slugify(slug: str) -> str:
   """Normalizes string, converts to lowercase, removes non-alpha characters, and converts spaces to hyphens."""
-
   slug = slug.lower()
   characters = '<>:"/\\|?\*., ()#'
   for ch in characters:
     slug = slug.replace(ch, '_')
-  # import re
-  # slug = unicodedata.normalize('NFKD', slug)
-  # slug = slug.encode('ascii', 'ignore').lower()
   slug = re.sub(r'[^a-z0-9]+.- ', '-', slug).strip('-')
   slug = re.sub(r'[-]+', '-', slug)
   slug = re.sub(r'/', '_', slug)
@@ -70,16 +67,24 @@ def slugify(slug: str) -> str:
 
 def get_process_flags():
   """Get proper priority flags so background processess can run with lower priority."""
-
   ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000
   BELOW_NORMAL_PRIORITY_CLASS = 0x00004000
   HIGH_PRIORITY_CLASS = 0x00000080
   IDLE_PRIORITY_CLASS = 0x00000040
   NORMAL_PRIORITY_CLASS = 0x00000020
   REALTIME_PRIORITY_CLASS = 0x00000100
-
   flags = BELOW_NORMAL_PRIORITY_CLASS
   if sys.platform != 'win32':  # TODO test this on windows
     flags = 0
-
   return flags
+
+
+async def download_file(url: str, destination: str, session: aiohttp.ClientSession, api_key: str=''):
+  """Download a file from url into destination on the disk. With api_key the request will be authorized for BlenderKit server."""
+  headers = get_headers(api_key)
+  async with session.get(url, headers=headers) as resp:
+    if resp.status != 200:
+      raise Exception(f"File download error: {resp.status}")
+    with open(destination, 'wb') as file:
+      async for chunk in resp.content.iter_chunked(4096 * 32):
+        file.write(chunk)

--- a/daemon/utils.py
+++ b/daemon/utils.py
@@ -3,6 +3,7 @@
 import platform
 import re
 import sys
+from pathlib import Path
 
 import aiohttp
 import globals
@@ -80,7 +81,10 @@ def get_process_flags():
 
 
 async def download_file(url: str, destination: str, session: aiohttp.ClientSession, api_key: str=''):
-  """Download a file from url into destination on the disk. With api_key the request will be authorized for BlenderKit server."""
+  """Download a file from url into destination on the disk, creates directory structure if needed.
+  With api_key the request will be authorized for BlenderKit server.
+  """
+  parent_dir = Path(destination).parent.mkdir(parents=True, exist_ok=True)
   headers = get_headers(api_key)
   async with session.get(url, headers=headers) as resp:
     if resp.status != 200:

--- a/daemon/utils.py
+++ b/daemon/utils.py
@@ -1,6 +1,5 @@
 """Contains utility functions for daemon server. Mix of everything."""
 
-import os
 import platform
 import re
 import sys
@@ -10,16 +9,18 @@ import globals
 
 def get_headers(api_key: str = '') -> dict[str, str]:
   """Get headers with authorization."""
-
   headers = {
     'accept': 'application/json',
     'Platform-Version': platform.platform(),
     'system-id': globals.SYSTEM_ID,
     'addon-version': globals.VERSION,
   }
-  if api_key != '':
-    headers['Authorization'] = f'Bearer {api_key}'
+  if api_key == '':
+    return headers
+  if api_key == None:
+    return headers
 
+  headers['Authorization'] = f'Bearer {api_key}'
   return headers
 
 

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -145,6 +145,16 @@ def mark_comment_private(asset_id, comment_id, api_key, is_private=False):
     return session.post(f'{get_address()}/comments/mark_comment_private', json=data)
 
 
+### REPORTS
+def report_usages(report: dict):
+  """Report usages of assets in current scene via daemon to the server."""
+  report['api_key'] = bpy.context.preferences.addons['blenderkit'].preferences.api_key
+  report['app_id'] = os.getpid()
+  with requests.Session() as session:
+    resp = session.post(f'{get_address()}/report_usages', json=report)
+    return resp
+
+
 ### AUTHORIZATION
 def send_code_verifier(code_verifier: str):
   data = {'code_verifier': code_verifier}

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -173,6 +173,24 @@ def send_code_verifier(code_verifier: str):
     return resp
 
 
+### WRAPPERS
+def get_download_url(asset_data, scene_id, api_key):
+  data = {
+    'app_id': os.getpid(),
+    'resolution': 'blend',
+    'asset_data': asset_data,
+    'PREFS': {
+      'api_key': api_key,
+      'scene_id': scene_id,
+    },
+  }
+  with requests.Session() as session:
+    url = get_address() + "/wrappers/get_download_url"
+    resp = session.get(url, json=data)
+    resp = resp.json()
+    return (resp['has_url'], resp['asset_data'])
+
+
 def refresh_token(refresh_token):
   """Refresh authentication token."""
   with requests.Session() as session:

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -97,6 +97,20 @@ def kill_download(task_id):
     return resp
 
 
+### PROFILES
+def fetch_gravatar_image(author_data):
+  """Fetch gravatar image for specified user. Find it on disk or download it from server."""
+  author_data['app_id'] = os.getpid()
+  with requests.Session() as session:
+    return session.get(f'{get_address()}/profiles/fetch_gravatar_image', json=author_data)
+
+def get_user_profile(api_key):
+  """Get profile of currently logged-in user. This creates task to daemon to fetch data which are later handled once available."""
+  data = {'api_key': api_key, 'app_id': os.getpid()}
+  with requests.Session() as session:
+    return session.get(f'{get_address()}/profiles/get_user_profile', json=data)
+
+
 ### COMMENTS
 def get_comments(asset_id, api_key=''):
   """Get all comments on the asset."""

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -144,6 +144,16 @@ def mark_comment_private(asset_id, comment_id, api_key, is_private=False):
   with requests.Session() as session:
     return session.post(f'{get_address()}/comments/mark_comment_private', json=data)
 
+### NOTIFICATIONS
+def mark_notification_read(notification_id):
+  """Mark the notification as read on the server."""
+  data = {
+    'notification_id': notification_id,
+    'api_key': bpy.context.preferences.addons['blenderkit'].preferences.api_key,
+    'app_id': os.getpid(),
+    }
+  with requests.Session() as session:
+    return session.post(f'{get_address()}/notifications/mark_notification_read', json=data)
 
 ### REPORTS
 def report_usages(report: dict):

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -17,18 +17,12 @@ TIMEOUT = (0.1, 0.5)
 
 def get_address() -> str:
   """Get address of the daemon."""
-
   return 'http://127.0.0.1:' + get_port()
 
 
 def get_port() -> str:
   """Get port of the daemon."""
-  
-  if __name__ == "__main__":
-    port = 10753
-  else:
-    port = bpy.context.preferences.addons['blenderkit'].preferences.daemon_port
-
+  port = bpy.context.preferences.addons['blenderkit'].preferences.daemon_port
   return str(port)
 
 
@@ -39,13 +33,16 @@ def get_daemon_directory_path() -> str:
   return path.abspath(directory)
 
 
-def get_reports(app_id: str):
+def get_reports(app_id: str, api_key=''):
   """Get reports for all tasks of app_id Blender instance at once."""
   bk_logger.debug('Getting reports')
   address = get_address()
   with requests.Session() as session:
     url = address + "/report"
-    data = {'app_id': app_id}
+    data = {
+      'app_id': app_id,
+      'api_key': api_key,
+      }
     try:
       resp = session.get(url, json=data, timeout=TIMEOUT, proxies={})
       bk_logger.debug('Got reports')
@@ -56,7 +53,6 @@ def get_reports(app_id: str):
 
 def search_asset(data):
   """Search for specified asset."""
-
   bk_logger.debug('Starting search request')
   address = get_address()
   data['app_id'] = os.getpid()
@@ -69,7 +65,6 @@ def search_asset(data):
 
 def download_asset(data):
   """Download specified asset."""
-
   address = get_address()
   data['app_id'] = os.getpid()
   with requests.Session() as session:
@@ -79,8 +74,7 @@ def download_asset(data):
 
 
 def upload_asset(upload_data, export_data, upload_set):
-  """Upload specified asset.
-  WIP: Only a sketch, needs to be further implemented."""
+  """Upload specified asset."""
   data = {
     'app_id': os.getpid(),
     'upload_data': upload_data,
@@ -89,7 +83,7 @@ def upload_asset(upload_data, export_data, upload_set):
   }
   with requests.Session() as session:
     url = get_address() + "/upload_asset"
-    bk_logger.info(f"making a request to: {url}")
+    bk_logger.debug(f"making a request to: {url}")
     resp = session.post(url, json=data, timeout=TIMEOUT, proxies={})
     return resp.json()
 
@@ -112,7 +106,6 @@ def send_code_verifier(code_verifier: str):
 
 def refresh_token(refresh_token):
   """Refresh authentication token."""
-  
   with requests.Session() as session:
     url = get_address() + "/refresh_token"
     resp = session.get(url, json={'refresh_token': refresh_token}, timeout=TIMEOUT, proxies={})
@@ -121,7 +114,6 @@ def refresh_token(refresh_token):
 
 def daemon_is_alive(session: requests.Session) -> tuple[bool, str]:
   """Check whether daemon is responding."""
-
   address = get_address()
   try:
     with session.get(address, timeout=TIMEOUT, proxies={}) as resp:
@@ -142,7 +134,7 @@ def report_blender_quit():
 
 
 def kill_daemon_server():
-  '''Request to restart the daemon server.'''
+  """Request to restart the daemon server."""
   address = get_address()
   with requests.Session() as session:
     url = address + "/shutdown"
@@ -204,7 +196,6 @@ def check_daemon_exit_code() -> tuple[int, str]:
 
 def start_daemon_server():
   """Start daemon server in separate process."""
-
   daemon_dir = get_daemon_directory_path()
   log_path = f'{daemon_dir}/daemon-{get_port()}.log'
   blenderkit_path = path.dirname(__file__)

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -103,17 +103,6 @@ def kill_download(task_id):
     return resp
 
 
-def get_disclaimer():
-  """Get disclaimer from server."""
-
-  address = get_address()
-  with requests.Session() as session:
-    url = address + "/get_disclaimer"
-    data = {'app_id': os.getpid()}
-    resp = session.get(url, json=data, timeout=TIMEOUT, proxies={})
-    return resp
-
-
 def send_code_verifier(code_verifier: str):
   data = {'code_verifier': code_verifier}
   with requests.Session() as session:

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -97,6 +97,55 @@ def kill_download(task_id):
     return resp
 
 
+### COMMENTS
+def get_comments(asset_id, api_key=''):
+  """Get all comments on the asset."""
+  data = {
+    'asset_id': asset_id,
+    'api_key': api_key,
+    'app_id': os.getpid(),
+    }
+  with requests.Session() as session:
+    return session.post(f'{get_address()}/comments/get_comments', json=data)
+
+def create_comment(asset_id, comment_text, api_key, reply_to_id=0):
+  """Create a new comment."""
+  data = {
+    'asset_id': asset_id,
+    'comment_text': comment_text,
+    'api_key': api_key,
+    'reply_to_id': reply_to_id,
+    'app_id': os.getpid(),
+    }
+  with requests.Session() as session:
+    return session.post(f'{get_address()}/comments/create_comment', json=data)
+
+def feedback_comment(asset_id, comment_id, api_key, flag='like'):
+  """Feedback the comment - by default with like. Other flags can be used also."""
+  data = {
+    'asset_id': asset_id,
+    'comment_id': comment_id,
+    'api_key': api_key,
+    'flag': flag,
+    'app_id': os.getpid(),
+    }
+  with requests.Session() as session:
+    return session.post(f'{get_address()}/comments/feedback_comment', json=data)
+
+def mark_comment_private(asset_id, comment_id, api_key, is_private=False):
+  """Mark the comment as private or public."""
+  data = {
+    'asset_id': asset_id,
+    'comment_id': comment_id,
+    'api_key': api_key,
+    'is_private': is_private,
+    'app_id': os.getpid(),
+    }
+  with requests.Session() as session:
+    return session.post(f'{get_address()}/comments/mark_comment_private', json=data)
+
+
+### AUTHORIZATION
 def send_code_verifier(code_verifier: str):
   data = {'code_verifier': code_verifier}
   with requests.Session() as session:

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -95,8 +95,6 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
     self.button_close.set_mouse_down(self.cancel_press)
 
   def on_invoke(self, context, event):
-
-
     # Add new widgets here (TODO: perhaps a better, more automated solution?)
     widgets_panel = [self.label, self.button_close, self.logo]
     widgets = [self.panel]
@@ -118,11 +116,8 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
     self.logo.set_image_position((img_pos, img_pos))
 
     # self.logo.set_image_position(0,0)
-
     self.init_widgets(context, widgets)
-
     self.panel.add_widgets(widgets_panel)
-
     self.start_time = time.time()
 
   def modal(self, context, event):

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -190,7 +190,8 @@ def handle_disclaimer_task(task: tasks.Task):
   """Handles incoming disclaimer task. If there are any results, it shows them in disclaimer popup.
   If the results are empty, it shows random tip in the disclaimer popup.
   """
-
+  global disclaimer_counter
+  disclaimer_counter = -1
   if task.status == 'finished':
     if task.result == None:
       show_random_tip()
@@ -230,11 +231,10 @@ def show_disclaimer_timer():
   if preferences.tips_on_start == False:
     return
 
-  if global_vars.DAEMON_ONLINE == True:
-    daemon_lib.get_disclaimer()
+  if disclaimer_counter == -1:
     return
 
-  elif disclaimer_counter > 2:
+  if disclaimer_counter > 2:
     show_random_tip()
     return
 

--- a/download.py
+++ b/download.py
@@ -28,7 +28,6 @@ import requests
 
 from . import (
     append_link,
-    colors,
     daemon_lib,
     global_vars,
     paths,

--- a/download.py
+++ b/download.py
@@ -62,8 +62,7 @@ download_tasks = {}
 
 
 def check_missing():
-    '''checks for missing files, and possibly starts re-download of these into the scene'''
-    s = bpy.context.scene
+    """Checks for missing files, and possibly starts re-download of these into the scene"""
     # missing libs:
     # TODO: put these into a panel and let the user decide if these should be downloaded.
     missing = []
@@ -88,13 +87,13 @@ def check_missing():
 
 
 def check_unused():
-    '''find assets that have been deleted from scene but their library is still present.'''
+    """Find assets that have been deleted from scene but their library is still present."""
     # this is obviously broken. Blender should take care of the extra data automaticlaly
     # first clean up collections
     for c in bpy.data.collections:
         if len(c.all_objects) == 0 and c.get('is_blenderkit_asset'):
             bpy.data.collections.remove(c)
-    return;
+    return
     used_libs = []
     for ob in bpy.data.objects:
         if ob.instance_collection is not None and ob.instance_collection.library is not None:
@@ -121,7 +120,7 @@ def check_unused():
 
 @persistent
 def scene_save(context):
-    ''' does cleanup of blenderkit props and sends a message to the server about assets used.'''
+    """Do cleanup of blenderkit props and send a message to the server about assets used."""
     # TODO this can be optimized by merging these 2 functions, since both iterate over all objects.
     if not bpy.app.background:
         check_unused()

--- a/download.py
+++ b/download.py
@@ -1214,36 +1214,26 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
         return properties.tooltip
 
     def get_asset_data(self, context):
-        # get asset data - it can come from scene, or from search results.
-        s = bpy.context.scene
-
-        if self.asset_index > -1:
-            # either get the data from search results
+        """Get asset data - it can come from scene, or from search results."""
+        scene = bpy.context.scene
+        if self.asset_index > -1: # Getting the data from search results
             sr = global_vars.DATA['search results']
-            asset_data = sr[
-                self.asset_index]  # TODO CHECK ALL OCCURRENCES OF PASSING BLENDER ID PROPS TO THREADS!
+            asset_data = sr[self.asset_index]  # TODO CHECK ALL OCCURRENCES OF PASSING BLENDER ID PROPS TO THREADS!
             asset_base_id = asset_data['assetBaseId']
-        else:
-            # or from the scene.
-            asset_base_id = self.asset_base_id
+            return asset_data
 
-            au = s.get('assets used')
-            if au == None:
-                s['assets used'] = {}
-            if asset_base_id in s.get('assets used'):
-                # already used assets have already download link and especially file link.
-                asset_data = s['assets used'][asset_base_id].to_dict()
-            else:
-                # when not in scene nor in search results, we need to get it from the server
-                params = {
-                    'asset_base_id': self.asset_base_id
-                }
-                preferences = bpy.context.preferences.addons['blenderkit'].preferences
+        # Getting the data from scene
+        asset_base_id = self.asset_base_id
+        assets_used = scene.get('assets used', {})
+        if asset_base_id in assets_used: # already used assets have already download link and especially file link.
+            asset_data = scene['assets used'][asset_base_id].to_dict()
+            return asset_data
 
-                results = search.get_search_simple(params, page_size=1, max_results=1,
-                                                   api_key=preferences.api_key)
-                asset_data = search.parse_result(results[0])
-
+        # when not in scene nor in search results, we need to get it from the server
+        params = {'asset_base_id': self.asset_base_id}
+        preferences = bpy.context.preferences.addons['blenderkit'].preferences
+        results = search.get_search_simple(params, page_size=1, max_results=1, api_key=preferences.api_key)
+        asset_data = search.parse_result(results[0])
         return asset_data
 
     def execute(self, context):

--- a/global_vars.py
+++ b/global_vars.py
@@ -9,6 +9,7 @@ DATA = {
   'images available': {},
   'search history': collections.deque(maxlen=20),
   'bkit notifications': None,
+  'bkit authors': {},
   'asset comments': {},
 }
 LOGGING_LEVEL_BLENDERKIT = logging.INFO

--- a/global_vars.py
+++ b/global_vars.py
@@ -8,6 +8,7 @@ DAEMON_ONLINE = False
 DATA = {
   'images available': {},
   'search history': collections.deque(maxlen=20),
+  'bkit notifications': None,
 }
 LOGGING_LEVEL_BLENDERKIT = logging.INFO
 LOGGING_LEVEL_IMPORTED = logging.WARN

--- a/global_vars.py
+++ b/global_vars.py
@@ -9,6 +9,7 @@ DATA = {
   'images available': {},
   'search history': collections.deque(maxlen=20),
   'bkit notifications': None,
+  'asset comments': {},
 }
 LOGGING_LEVEL_BLENDERKIT = logging.INFO
 LOGGING_LEVEL_IMPORTED = logging.WARN

--- a/paths.py
+++ b/paths.py
@@ -24,7 +24,7 @@ import tempfile
 
 import bpy
 
-from . import global_vars, reports, tasks_queue, utils
+from . import daemon_lib, global_vars, reports, tasks_queue, utils
 
 
 bk_logger = logging.getLogger(__name__)
@@ -345,11 +345,10 @@ def get_download_filepaths(asset_data, resolution='blend', can_return_others=Fal
 
 def delete_asset_debug(asset_data):
     '''TODO fix this for resolutions - should get ALL files from ALL resolutions.'''
-    from . import download
     user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
     api_key = user_preferences.api_key
 
-    download.get_download_url(asset_data, utils.get_scene_id(), api_key)
+    _, asset_data = daemon_lib.get_download_url(asset_data, utils.get_scene_id(), api_key)
 
     file_names = get_download_filepaths(asset_data)
     for f in file_names:

--- a/paths.py
+++ b/paths.py
@@ -24,7 +24,7 @@ import tempfile
 
 import bpy
 
-from . import colors, global_vars, reports, tasks_queue, utils
+from . import global_vars, reports, tasks_queue, utils
 
 
 bk_logger = logging.getLogger(__name__)
@@ -175,7 +175,6 @@ def slugify(slug):
     and converts spaces to hyphens.
     """
     import re
-    import unicodedata
     slug = slug.lower()
 
     characters = '<>:"/\\|?\*., ()#'

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -22,12 +22,7 @@ import threading
 # mainly update functions and callbacks for ratings properties, here to avoid circular imports.
 import bpy
 import requests
-from bpy.props import (
-    EnumProperty,
-    FloatProperty,
-    IntProperty,
-    StringProperty,
-)
+from bpy.props import EnumProperty, FloatProperty, IntProperty, StringProperty
 from bpy.types import PropertyGroup
 
 from . import global_vars, paths, rerequests, tasks_queue, utils

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -23,7 +23,6 @@ import threading
 import bpy
 import requests
 from bpy.props import (
-    CollectionProperty,
     EnumProperty,
     FloatProperty,
     IntProperty,

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -69,13 +69,11 @@ def send_rating_to_thread_work_hours(url, ratings, headers):
 
 
 def store_rating_local_empty(asset_id):
-    context = bpy.context
     ar = global_vars.DATA['asset ratings']
     ar[asset_id] = ar.get(asset_id, {})
 
 
 def store_rating_local(asset_id, type='quality', value=0):
-    context = bpy.context
     ar   = global_vars.DATA['asset ratings']
     ar[asset_id] = ar.get(asset_id, {})
     ar[asset_id][type] = value

--- a/rerequests.py
+++ b/rerequests.py
@@ -19,10 +19,9 @@
 
 import logging
 
-import bpy
 import requests
 
-from . import global_vars, reports, tasks_queue, utils
+from . import global_vars, reports, tasks_queue
 
 
 bk_logger = logging.getLogger(__name__)

--- a/resolutions.py
+++ b/resolutions.py
@@ -23,7 +23,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import threading
 import time
 
 import bpy

--- a/resolutions.py
+++ b/resolutions.py
@@ -26,15 +26,7 @@ import time
 import bpy
 import requests
 
-from . import (
-    bg_blender,
-    image_utils,
-    paths,
-    rerequests,
-    search,
-    upload,
-    utils,
-)
+from . import bg_blender, image_utils, paths, rerequests, search, upload, utils
 
 
 bk_logger = logging.getLogger(__name__)

--- a/resolutions.py
+++ b/resolutions.py
@@ -379,20 +379,6 @@ def regenerate_thumbnail_material(data):
     return
 
 
-def get_materials_for_validation(page_size=100, max_results=100000000):
-    preferences = bpy.context.preferences.addons['blenderkit'].preferences
-    dpath = os.path.dirname(bpy.data.filepath)
-    filepath = os.path.join(dpath, 'materials_for_validation.json')
-    params = {
-        'order': '-created',
-        'asset_type': 'material',
-        'verification_status': 'uploaded'
-    }
-    search.get_search_simple(params, filepath=filepath, page_size=page_size, max_results=max_results,
-                             api_key=preferences.api_key)
-    return filepath
-
-
 def run_bg(datafile):
     print('background file operation')
     with open(datafile, 'r',encoding='utf-8') as f:

--- a/search.py
+++ b/search.py
@@ -144,38 +144,16 @@ def scene_load(context):
   if not bpy.app.timers.is_registered(bkit_oauth.refresh_token_timer) and not bpy.app.background:
     bpy.app.timers.register(bkit_oauth.refresh_token_timer, persistent=True, first_interval=5)
     #bpy.app.timers.register(bkit_oauth.refresh_token_timer, persistent=True, first_interval=36000)
-  # if utils.experimental_enabled() and not bpy.app.timers.is_registered(
-  #         refresh_notifications_timer) and not bpy.app.background:
-  #     bpy.app.timers.register(refresh_notifications_timer, persistent=True, first_interval=5)
 
   update_assets_data()
 
 
-def fetch_server_data():
-  '''Download profile, and refresh token if needed.'''
-  if bpy.app.background:
-    return
-  user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
-  api_key = user_preferences.api_key
-  # Only refresh new type of tokens(by length), and only one hour before the token timeouts.
-  if api_key != '' and global_vars.DATA.get('bkit profile') == None:
-    get_profile()
-  # all_notifications_count = comments_utils.count_all_notifications()
-  # comments_utils.get_notifications_thread(api_key, all_count = all_notifications_count)
-
-
-first_time = True
-first_search_parsing = True
 last_clipboard = ''
-
-
 def check_clipboard():
-  '''
-  Checks clipboard for an exact string containing asset ID.
+  """Check clipboard for an exact string containing asset ID.
   The string is generated on www.blenderkit.com as for example here:
   https://www.blenderkit.com/get-blenderkit/54ff5c85-2c73-49e9-ba80-aec18616a408/
-  '''
-
+  """
   # clipboard monitoring to search assets from web
   if platform.system() != 'Linux':
     global last_clipboard
@@ -336,10 +314,8 @@ def cleanup_search_results():
     global_vars.DATA.pop(f'{sr} orig', None)
 
 def handle_search_task(task: tasks.Task) -> bool:
-  '''parse search results, try to load all available previews.'''
-  ##############original
-
-  global search_tasks, first_search_parsing
+  """Parse search results, try to load all available previews."""
+  global search_tasks
   if len(search_tasks) == 0:
     # utils.p('end search timer')
     props = utils.get_search_props()
@@ -364,11 +340,6 @@ def handle_search_task(task: tasks.Task) -> bool:
   if bpy.app.version < (3, 3, 0):
     sys_prefs = bpy.context.preferences.system
     sys_prefs.gl_texture_limit = 'CLAMP_OFF'
-
-  global first_search_parsing
-  if first_search_parsing:
-    comments_utils.check_notifications()
-    first_search_parsing = False
 
   ###################
 
@@ -607,10 +578,9 @@ def generate_author_textblock(adata):
 
 
 def write_gravatar(a_id, gravatar_path):
-  '''
-  Write down gravatar path, as a result of thread-based gravatar image download.
+  """Write down gravatar path, as a result of thread-based gravatar image download.
   This should happen on timer in queue.
-  '''
+  """
   # print('write author', a_id, type(a_id))
   authors = global_vars.DATA['bkit authors']
   if authors.get(a_id) is not None:
@@ -619,13 +589,11 @@ def write_gravatar(a_id, gravatar_path):
 
 
 def fetch_gravatar(adata=None):
-  '''
-  Gets avatars from blenderkit server
+  """Get avatars from blenderkit server
   Parameters
   ----------
   adata - author data from elastic search result
-
-  '''
+  """
 
   # fetch new avatars if available already
   if adata.get('avatar128') is not None:
@@ -671,13 +639,12 @@ fetching_gravatars = {}
 
 
 def get_author(r):
-  ''' Writes author info (now from search results) and fetches gravatar if needed.
+  """Write author info (now from search results) and fetches gravatar if needed.
   this is now tweaked to be able to get authors from
-  '''
+  """
   global fetching_gravatars
 
   a_id = str(r['author']['id'])
-  preferences = bpy.context.preferences.addons['blenderkit'].preferences
   authors = global_vars.DATA.get('bkit authors', {})
   if authors == {}:
     global_vars.DATA['bkit authors'] = authors
@@ -735,6 +702,7 @@ def fetch_profile(api_key):
     bk_logger.error(e)
 
 
+#TODO: migrate -> daemon new addon subscribed
 def get_profile():
   preferences = bpy.context.preferences.addons['blenderkit'].preferences
   profile = global_vars.DATA.get('bkit profile')
@@ -795,14 +763,8 @@ def query_to_url(query={}, params={}):
   return urlquery
 
 
-def parse_html_formated_error(text):
-  report = text[text.find('<title>') + 7: text.find('</title>')]
-
-  return report
-
-
 def build_query_common(query, props):
-  '''add shared parameters to query'''
+  """Add shared parameters to query."""
   query_common = {}
   if props.search_keywords != '':
     # keywords = urllib.parse.urlencode(props.search_keywords)
@@ -826,8 +788,7 @@ def build_query_common(query, props):
 
 
 def build_query_model():
-  '''use all search input to request results from server'''
-
+  """Use all search input to request results from server."""
   props = bpy.context.window_manager.blenderkit_models
   query = {
     "asset_type": 'model',
@@ -864,8 +825,7 @@ def build_query_model():
 
 
 def build_query_scene():
-  '''use all search input to request results from server'''
-
+  """Use all search input to request results from server."""
   props = bpy.context.window_manager.blenderkit_scene
   query = {
     "asset_type": 'scene',
@@ -877,12 +837,10 @@ def build_query_scene():
 
 
 def build_query_HDR():
-  '''use all search input to request results from server'''
-
+  """Use all search input to request results from server."""
   props = bpy.context.window_manager.blenderkit_HDR
   query = {
     "asset_type": 'hdr',
-
     # "engine": props.search_engine,
     # "adult": props.search_adult,
   }
@@ -894,10 +852,7 @@ def build_query_HDR():
 
 def build_query_material():
   props = bpy.context.window_manager.blenderkit_mat
-  query = {
-    "asset_type": 'material',
-
-  }
+  query = {"asset_type": 'material'}
   # if props.search_engine == 'NONE':
   #     query["engine"] = ''
   # if props.search_engine != 'OTHER':
@@ -916,25 +871,18 @@ def build_query_material():
     if props.search_texture_resolution:
       query["textureResolutionMax_gte"] = props.search_texture_resolution_min
       query["textureResolutionMax_lte"] = props.search_texture_resolution_max
-
-
-
   elif props.search_procedural == "PROCEDURAL":
     # todo this procedural hack should be replaced with the parameter
     query["files_size_lte"] = 1024 * 1024
     # query["procedural"] = True
 
   build_query_common(query, props)
-
   return query
 
 
 def build_query_texture():
   props = bpy.context.scene.blenderkit_tex
-  query = {
-    "asset_type": 'texture',
-
-  }
+  query = {"asset_type": 'texture'}
 
   if props.search_style != 'ANY':
     if props.search_style != 'OTHER':
@@ -943,13 +891,11 @@ def build_query_texture():
       query["search_style"] = props.search_style_other
 
   build_query_common(query, props)
-
   return query
 
 
 def build_query_brush():
   props = bpy.context.window_manager.blenderkit_brush
-
   brush_type = ''
   if bpy.context.sculpt_object is not None:
     brush_type = 'sculpt'
@@ -959,18 +905,15 @@ def build_query_brush():
 
   query = {
     "asset_type": 'brush',
-
     "mode": brush_type
   }
 
   build_query_common(query, props)
-
   return query
 
 
 def add_search_process(query, params):
   global search_tasks
-
   if len(search_tasks) > 0:
     # just remove all running search tasks.
     # we can also kill them in daemon, but not so urgent now
@@ -979,8 +922,6 @@ def add_search_process(query, params):
     search_tasks = dict()
 
   tempdir = paths.get_temp_dir('%s_search' % query['asset_type'])
-  headers = utils.get_headers(params['api_key'])
-
   if params.get('get_next'):
     urlquery = params['next']
   else:
@@ -998,9 +939,7 @@ def add_search_process(query, params):
 
 
 def get_search_simple(parameters, filepath=None, page_size=100, max_results=100000000, api_key=''):
-  '''
-  Searches and returns the
-
+  """Searches and returns the search results.
 
   Parameters
   ----------
@@ -1013,8 +952,7 @@ def get_search_simple(parameters, filepath=None, page_size=100, max_results=1000
   Returns
   -------
   Returns search results as a list, and optionally saves to filepath
-
-  '''
+  """
   headers = utils.get_headers(api_key)
   url = f'{paths.BLENDERKIT_API}/search/'
   requeststring = url + '?query='
@@ -1062,10 +1000,9 @@ def get_single_asset(asset_base_id):
 
 
 def search(category='', get_next=False, query = None, author_id=''):
-  ''' initialize searching
+  """Initialize searching
   query : submit an already built query from search history
-  '''
-
+  """
   if global_vars.DAEMON_ACCESSIBLE != True:
     reports.add_report('Cannot search, daemon is not accessible.', timeout = 2, type='ERROR')
     return
@@ -1073,7 +1010,6 @@ def search(category='', get_next=False, query = None, author_id=''):
   # print(category,get_next,author_id)
   user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
 
-  scene = bpy.context.scene
   wm = bpy.context.window_manager
   ui_props = bpy.context.window_manager.blenderkitUI
 
@@ -1081,39 +1017,38 @@ def search(category='', get_next=False, query = None, author_id=''):
   # it's possible get_next was requested more than once.
   if props.is_searching and get_next == True:
     # print('return because of get next and searching is happening')
-    return;
+    return
 
   if not query:
     if ui_props.asset_type == 'MODEL':
       if not hasattr(wm, 'blenderkit_models'):
-        return;
+        return
       query = build_query_model()
 
     if ui_props.asset_type == 'SCENE':
       if not hasattr(wm, 'blenderkit_scene'):
-        return;
+        return
       query = build_query_scene()
 
     if ui_props.asset_type == 'HDR':
       if not hasattr(wm, 'blenderkit_HDR'):
-        return;
+        return
       query = build_query_HDR()
 
     if ui_props.asset_type == 'MATERIAL':
       if not hasattr(wm, 'blenderkit_mat'):
-        return;
-
+        return
       query = build_query_material()
 
     if ui_props.asset_type == 'TEXTURE':
       if not hasattr(wm, 'blenderkit_tex'):
-        return;
+        return
       # props = scene.blenderkit_tex
       # query = build_query_texture()
 
     if ui_props.asset_type == 'BRUSH':
       if not hasattr(wm, 'blenderkit_brush'):
-        return;
+        return
       query = build_query_brush()
 
     # crop long searches
@@ -1165,11 +1100,10 @@ def search(category='', get_next=False, query = None, author_id=''):
   if orig_results is not None and get_next:
     params['next'] = orig_results['next']
   add_search_process(query, params)
-
   props.report = 'BlenderKit searching....'
 
 def clean_filters():
-  '''cleanup filters in case search needs to be reset, typicaly when asset id is copy pasted'''
+  """Cleanup filters in case search needs to be reset, typicaly when asset id is copy pasted."""
   sprops = utils.get_search_props()
   ui_props = bpy.context.window_manager.blenderkitUI
   sprops.property_unset('own_only')
@@ -1274,7 +1208,7 @@ def strip_accents(s):
   return ''.join(c for c in unicodedata.normalize('NFD', s)
                  if unicodedata.category(c) != 'Mn')
 
-
+#TODO: fix the tooltip?
 class SearchOperator(Operator):
   """Tooltip"""
   bl_idname = "view3d.blenderkit_search"

--- a/search.py
+++ b/search.py
@@ -21,9 +21,7 @@ import logging
 import math
 import os
 import platform
-import random
 import threading
-import time
 import unicodedata
 
 import bpy
@@ -35,12 +33,8 @@ from bpy.props import (  # TODO only keep the ones actually used when cleaning
 from bpy.types import Operator
 
 from . import (
-    addon_updater_ops,
     asset_bar_op,
     bkit_oauth,
-    categories,
-    colors,
-    comments_utils,
     daemon_lib,
     global_vars,
     image_utils,
@@ -50,7 +44,6 @@ from . import (
     rerequests,
     resolutions,
     tasks_queue,
-    ui,
     utils,
     version_checker,
 )
@@ -74,7 +67,6 @@ def check_errors(rdata):
 
 
 search_tasks = {}
-
 
 
 def update_ad(ad):

--- a/search.py
+++ b/search.py
@@ -872,17 +872,6 @@ def get_search_simple(parameters, filepath=None, page_size=100, max_results=1000
   return results
 
 
-def get_single_asset(asset_base_id):
-  preferences = bpy.context.preferences.addons['blenderkit'].preferences
-  params = {
-    'asset_base_id': asset_base_id
-  }
-  results = get_search_simple(params, api_key=preferences.api_key)
-  if len(results) > 0:
-    return results[0]
-  return None
-
-
 def search(category='', get_next=False, query = None, author_id=''):
   """Initialize searching
   query : submit an already built query from search history

--- a/test_daemon_lib.py
+++ b/test_daemon_lib.py
@@ -51,7 +51,7 @@ class Test02DaemonRunning(unittest.TestCase):
 
 class Test03DaemonUtilFunctions(unittest.TestCase):
   def test_get_port(self):
-    ports = ["62485","65425", "55428", "49452", "35452","25152","5152", "1234"]
+    ports = ["62485","65425","55428","49452","35452","25152","5152","1234"]
     self.assertIn(daemon_lib.get_port(), ports)
 
   def test_get_address(self):

--- a/timer.py
+++ b/timer.py
@@ -238,14 +238,14 @@ def on_startup_timer():
 
 def on_startup_daemon_online_timer():
   """Run once when daemon is online after startup."""
+  if not global_vars.DAEMON_ONLINE:
+    return 1
 
-  if global_vars.DAEMON_ONLINE:
-    preferences = bpy.context.preferences.addons['blenderkit'].preferences
-    if preferences.show_on_start:
-      search.search()
-    return
+  preferences = bpy.context.preferences.addons['blenderkit'].preferences
+  if preferences.show_on_start:
+    search.search()
+  return
 
-  return 1
 
 def register_timers():
   """Registers all timers. 

--- a/timer.py
+++ b/timer.py
@@ -178,6 +178,10 @@ def handle_task(task: tasks.Task):
     return disclaimer_op.handle_disclaimer_task(task)
 
 
+  #HANDLE CATEGORIES FETCH
+  if task.task_type == "categories_update":
+    categories.handle_categories_task(task)
+
 def setup_asyncio_executor():
   """Set up AsyncIO to run properly on each platform."""
 
@@ -231,7 +235,6 @@ def on_startup_timer():
   utils.ensure_system_ID()
 
   api_key = bpy.context.preferences.addons['blenderkit'].preferences.api_key
-  categories.fetch_categories_thread(api_key)
   if api_key != '':
     search.get_profile()
 

--- a/timer.py
+++ b/timer.py
@@ -172,6 +172,17 @@ def handle_task(task: tasks.Task):
   if task.task_type == "notifications":
     return comments_utils.handle_notifications_task(task)
 
+  #HANDLE VARIOUS COMMENTS TASKS
+  if task.task_type == "comments/get_comments":
+    return comments_utils.handle_get_comments_task(task)
+  if task.task_type == "comments/create_comment":
+    return comments_utils.handle_create_comment_task(task)
+  if task.task_type == "comments/feedback_comment":
+    return comments_utils.handle_feedback_comment_task(task)
+  if task.task_type == "comments/mark_comment_private":
+    return comments_utils.handle_mark_comment_private_task(task)
+
+
 def setup_asyncio_executor():
   """Set up AsyncIO to run properly on each platform."""
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2781,10 +2781,9 @@ class VIEW3D_PT_blenderkit_downloads(Panel):
 
 
 def header_search_draw(self, context):
-    '''Top bar menu in 3D view'''
-
+    """Top bar menu in 3D view"""
     if not utils.guard_from_crash():
-        return;
+        return
 
     preferences = bpy.context.preferences.addons['blenderkit'].preferences
     if not preferences.search_in_header:
@@ -2793,7 +2792,6 @@ def header_search_draw(self, context):
         return
 
     layout = self.layout
-    s = bpy.context.scene
     wm = bpy.context.window_manager
     ui_props = bpy.context.window_manager.blenderkitUI
     if ui_props.asset_type == 'MODEL':
@@ -2851,7 +2849,7 @@ def header_search_draw(self, context):
         row.label(text='', icon_value=icon_id)
 
     notifications = global_vars.DATA.get('bkit notifications')
-    if notifications is not None and notifications['count'] > 0:
+    if notifications is not None and notifications.get('count', 0) > 0:
         layout.operator('wm.show_notifications', text="", icon_value=pcoll['bell'].icon_id)
         # layout.popover(panel="VIEW3D_PT_blenderkit_notifications", text="", icon_value=pcoll['bell'].icon_id)
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -589,6 +589,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
             layout.operator("wm.url_open", text="See my uploads", icon='URL').url = paths.BLENDERKIT_USER_ASSETS_URL
         addon_updater_ops.update_notice_box_ui(self,context)
 
+
 class MarkNotificationRead(bpy.types.Operator):
     """Mark notification as read here and also on BlenderKit server"""
     bl_idname = "wm.blenderkit_mark_notification_read"
@@ -610,37 +611,33 @@ class MarkNotificationRead(bpy.types.Operator):
             if n['id'] == self.notification_id:
                 n['unread'] = 0
         comments_utils.check_notifications_read()
-        user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
-        api_key = user_preferences.api_key
-        comments_utils.mark_notification_read_thread(api_key, self.notification_id)
-
+        daemon_lib.mark_notification_read(self.notification_id)
         return {'FINISHED'}
 
+
 class MarkAllNotificationsRead(bpy.types.Operator):
-    """Mark notification as read here and also on BlenderKit server"""
+    """Mark all notifications as read here and also on BlenderKit server"""
     bl_idname = "wm.blenderkit_mark_notifications_read_all"
     bl_label = "Mark all notifications as read"
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
-
 
     @classmethod
     def poll(cls, context):
         return True
 
     def execute(self, context):
-        user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
-        api_key = user_preferences.api_key
         notifications = global_vars.DATA['bkit notifications']
         for n in notifications.get('results'):
             if n['unread'] == 1:
                 n['unread'] = 0
-                comments_utils.mark_notification_read_thread(api_key, n['id'])
+                daemon_lib.mark_notification_read(n['id'])
 
         comments_utils.check_notifications_read()
         return {'FINISHED'}
 
+
 class NotificationOpenTarget(bpy.types.Operator):
-    """"""
+    """Open notification target and mark notification as read"""
     bl_idname = "wm.blenderkit_open_notification_target"
     bl_label = ""
     bl_description = "Open notification target and mark notification as read"

--- a/upload.py
+++ b/upload.py
@@ -804,14 +804,14 @@ def get_upload_location(props):
     return None
 
 
-def check_storage_quota(props):
+def check_storage_quota(props): #TODO: fix this function
     if props.is_private == 'PUBLIC':
         return True
 
     profile = bpy.context.window_manager.get('bkit profile')
     if profile is None or profile.get('remainingPrivateQuota') is None:
         preferences = bpy.context.preferences.addons['blenderkit'].preferences
-        adata = search.request_profile(preferences.api_key)
+        adata = daemon_lib.get_user_profile(preferences.api_key) #TODO: here it needs a fix
         if adata is None:
             props.report = 'Please log-in first.'
             return False
@@ -906,7 +906,6 @@ def upload_files(upload_data, files):
 
 def prepare_asset_data(self, context, asset_type, reupload, upload_set):
     """Process asset and its data for upload."""
-
     # fix the name first
     props = utils.get_upload_props()
     utils.name_update(props)

--- a/upload.py
+++ b/upload.py
@@ -864,7 +864,8 @@ def upload_file(upload_data, f):
             else:
                 session.trust_env = True
             upload_response = session.put(upload['s3UploadUrl'],
-                                            data=upload_in_chunks(f['file_path'], chunk_size, f['type']),
+                                            data=upload_in_chunks(f['file_path'], #BUG: upload_in_chunks is not defined
+                                            chunk_size, f['type']), #TODO: is this needed with new resolutions generation?
                                             stream=True, verify=True)
 
             if 250 > upload_response.status_code > 199:

--- a/upload.py
+++ b/upload.py
@@ -805,6 +805,11 @@ def get_upload_location(props):
 
 
 def check_storage_quota(props): #TODO: fix this function
+    #TODO: do we really need to fetch the data?
+    # we have a user profile data loaded when user logged-in (and on start?) ((If not, we should fetch fresh data on start))
+    # is to soooo needed to fetch here? can't we just check available quotas and start upload?
+    # if rare edge case happened and quota got full between last check and update
+    # we can handle the error.
     if props.is_private == 'PUBLIC':
         return True
 
@@ -815,7 +820,6 @@ def check_storage_quota(props): #TODO: fix this function
         if adata is None:
             props.report = 'Please log-in first.'
             return False
-        search.write_profile(adata)
         profile = adata
     quota = profile['user'].get('remainingPrivateQuota')
     if quota is None or quota > 0:

--- a/utils.py
+++ b/utils.py
@@ -925,10 +925,11 @@ def user_logged_in():
 
 
 def profile_is_validator():
-    a = global_vars.DATA.get('bkit profile')
-    if a is not None and a['user'].get('exmenu'):
-        return True
-    return False
+    profile = global_vars.DATA.get('bkit profile')
+    if profile is None:
+      return False
+    result = profile.get('canEditAllAssets', False)
+    return result
 
 
 def user_is_owner(asset_data=None):

--- a/utils.py
+++ b/utils.py
@@ -25,13 +25,12 @@ import platform
 import re
 import shutil
 import sys
-import traceback
 import uuid
 
 import bpy
 from mathutils import Vector
 
-from . import global_vars, image_utils, paths, rerequests
+from . import global_vars, image_utils, paths
 
 
 bk_logger = logging.getLogger(__name__)
@@ -722,10 +721,6 @@ def get_dimensions(obs):
     return dim, bbmin, bbmax
 
 
-def requests_post_thread(url, json, headers):
-    r = rerequests.post(url, json=json, verify=True, headers=headers)
-
-
 def get_headers(api_key: str = '') -> dict[str, str]:
     headers = {
         'accept': 'application/json',
@@ -1139,7 +1134,3 @@ def is_upload_old(asset_data):
     if age > old:
         return (age.days - old.days)
     return 0
-
-def trace():
-    traceback.print_stack()
-

--- a/version_checker.py
+++ b/version_checker.py
@@ -18,12 +18,10 @@
 
 import json
 import os
-import threading
 
 import bpy
-import requests
 
-from . import global_vars, paths, utils
+from . import paths
 
 
 def get_blender_version():
@@ -31,43 +29,15 @@ def get_blender_version():
     ver = bpy.app.version
     return '%i.%i.%i' % (ver[0], ver[1], ver[2])
 
+
 def get_addon_version():
     # should return addon version, but since Blender 3.0 this is synced with Blender version
     # ver = bpy.app.version
     # return '%i.%i.%i' % (ver[0], ver[1], ver[2])
 
-
     import blenderkit
     ver = blenderkit.bl_info['version']
     return '%i.%i.%i' % (ver[0], ver[1], ver[2])
-
-
-def check_version(url, api_key, module):
-    headers = utils.get_headers(api_key=api_key)
-    print('checking online version of module %s' % str(module.bl_info['name']))
-    try:
-        session = requests.Session()
-        proxy_which = global_vars.PREFS.get('proxy_which')
-        proxy_address = global_vars.PREFS.get('proxy_address')
-        if proxy_which == 'NONE':
-            session.trust_env = False
-        elif proxy_which == 'CUSTOM':
-            session.trust_env = False
-            session.proxies = {'https': proxy_address}
-        else:
-            session.trust_env = True
-        r = session.get(url, headers=headers)
-        data = r.json()
-        ver_online = {
-            'addonVersion2.8': data['addonVersion']
-        }
-        tempdir = paths.get_temp_dir()
-
-        ver_filepath = os.path.join(tempdir, 'addon_version.json')
-        with open(ver_filepath, 'w', encoding = 'utf-8') as s:
-            json.dump(ver_online, s,  ensure_ascii=False, indent=4)
-    except:
-        print("couldn't check online for version updates")
 
 
 def compare_versions(module):
@@ -90,7 +60,3 @@ def compare_versions(module):
         print("couldn't compare addon versions")
     return False
 
-
-def check_version_thread(url, API_key, module):
-    thread = threading.Thread(target=check_version, args=([url, API_key, module]), daemon=True)
-    thread.start()


### PR DESCRIPTION
Delayed into 3.5.0. Merge after 3.4.0 is release.

fixes #357 

Fixes:
- adds subscribe_new_addon func into daemon - this func runs when new addon appears and creates all the internet tasks needed after the startup like: fetch disclaimer, fetch categories etc. 
- improves fetch disclaimer - now is initiated from daemon
- fetches categories from daemon
- daemon fetches notifications when new Blender instance appears (and user is logged in)
- fetches comments - create, rate, mark as private, get
- removes unused file asset_pack_bg.py
- removes unsused functions from resolutions.py
- moves notifications requests into daemon
- update comments after comment creation/like/public
- moved get_download_url into daemon
- moved gravatar fetch into daemon
- moved fetching data about logged-in user into daemon
- fix check_storage_quota() needs to be fixed
- clean upload.py

TODO in next PR:
- clean ratings_utils.py
- clean ratings.py
- clean search.py
