### PR TITLE
Fix first search string

### DIFF
--- a/search.py
+++ b/search.py
@@ -413,7 +413,7 @@ def handle_search_task(task: tasks.Task) -> bool:
       tasks_queue.add_task((reports.add_report, (f"Found {global_vars.DATA['search results orig']['count']} results.",)))
     # show asset bar automatically, but only on first page - others are loaded also when asset bar is hidden.
     if not ui_props.assetbar_on and not task.data.get('get_next'):
-      bpy.ops.view3d.run_assetbar_fix_context()
+      bpy.ops.view3d.run_assetbar_fix_context(keep_running=True, do_search=False)
 
   else:
     props.report = error

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2799,7 +2799,11 @@ def header_search_draw(self, context):
     layout.label(text='',icon_value=pcoll[ui_props.logo_status].icon_id)
     # layout.separator()
     layout.prop(ui_props, "asset_type", expand=True, icon_only=True, text='', icon=asset_type_icon)
-    layout.prop(props, "search_keywords", text="", icon='VIEWZOOM')
+    row = layout.row()
+    if (context.region.width)>700:
+        row.ui_units_x = 5+int(context.region.width/200)
+    row.prop(props, "search_keywords", text="", icon='VIEWZOOM')
+
     draw_assetbar_show_hide(layout, props)
     layout.popover(panel="VIEW3D_PT_blenderkit_categories", text="", icon='OUTLINER')
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -38,6 +38,7 @@ from . import (
     paths,
     ratings,
     ratings_utils,
+    search,
     ui,
     upload,
     utils,
@@ -1478,38 +1479,11 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
 
     def execute(self, context):
         if self.step == 0:
-            # move mouse:
-            # bpy.context.window_manager.windows[0].cursor_warp(1000, 1000)
-            # show n-key sidebar (spaces[index] has to be found for view3d too:
-            # bpy.context.window_manager.windows[0].screen.areas[5].spaces[0].show_region_ui = False
             ui_props = bpy.context.window_manager.blenderkitUI
-            # random_searches = [
-            #     ('MATERIAL', 'ice'),
-            #     ('MODEL', 'car'),
-            #     ('MODEL', 'vase'),
-            #     ('MODEL', 'grass'),
-            #     ('MODEL', 'plant'),
-            #     ('MODEL', 'man'),
-            #     ('MATERIAL', 'metal'),
-            #     ('MATERIAL', 'wood'),
-            #     ('MATERIAL', 'floor'),
-            #     ('MATERIAL', 'bricks'),
-            # ]
-            # random_search = random.choice(random_searches)
-            # ui_props.asset_type = random_search[0]
+
             ui_props.asset_type = 'MODEL'
 
-            score_limit = 450
-            if ui_props.asset_type == 'MATERIAL':
-                props = bpy.context.window_manager.blenderkit_mat
-
-            elif ui_props.asset_type == 'MODEL':
-                props = bpy.context.window_manager.blenderkit_models
-                score_limit = 1000
-
-            props.search_keywords = ''  # random_search[1]
-            props.search_keywords += f'+is_free:true+score_gte:{score_limit}+order:-created'  # random_search[1]
-            # search.search()
+            search.search(query = {'asset_type': 'model', 'query': f'+is_free:true+score_gte:1000+order:-created'})
         return {'FINISHED'}
 
     def invoke(self, context, event):


### PR DESCRIPTION
Send first search after installation of addon directly to daemon instead of to UI keywords field, avoids occasional errors from people typing into that string.

also make search field slightly wider.
