### PR TITLE
Webp thumbnails

### DIFF
--- a/daemon/search.py
+++ b/daemon/search.py
@@ -59,9 +59,13 @@ async def parse_thumbnails(task: tasks.Task):
   # get thumbnails that need downloading
 
   for i, search_result in enumerate(task.result.get('results', [])):
+    # Find out if the asset is older than 1 hour, so we can use .webp images
+    webp_ext = '.webp'
+
     # SMALL THUMBNAIL
-    imgname = assets.extract_filename_from_url(search_result['thumbnailSmallUrl'])
+    imgname = assets.extract_filename_from_url(search_result['thumbnailSmallUrl'])+webp_ext
     imgpath = os.path.join(task.data['tempdir'], imgname)
+
     data = {
       "image_path": imgpath,
       "image_url": search_result["thumbnailSmallUrl"],
@@ -84,11 +88,11 @@ async def parse_thumbnails(task: tasks.Task):
     else:
       large_thumb_url = search_result['thumbnailMiddleUrl']
 
-    imgname = assets.extract_filename_from_url(large_thumb_url)
+    imgname = assets.extract_filename_from_url(large_thumb_url)+webp_ext
     imgpath = os.path.join(task.data['tempdir'], imgname)
     data = {
       "image_path": imgpath,
-      "image_url": large_thumb_url,
+      "image_url": large_thumb_url+webp_ext,
       "assetBaseId": search_result['assetBaseId'],
       "thumbnail_type": "full",
       "index": i

--- a/search.py
+++ b/search.py
@@ -214,19 +214,16 @@ def parse_result(r):
     get_author(r)
 
     r['available_resolutions'] = []
-    allthumbs = []
     durl, tname, small_tname = '', '', ''
 
+    # Find out if the asset is older than 1 hour, so we can use .webp images
+    webp_ext = '.webp'
+
     if r['assetType'] == 'hdr':
-      tname = paths.extract_filename_from_url(r['thumbnailLargeUrlNonsquared'])
+      tname = paths.extract_filename_from_url(r['thumbnailLargeUrlNonsquared'])+webp_ext
     else:
-      tname = paths.extract_filename_from_url(r['thumbnailMiddleUrl'])
-    small_tname = paths.extract_filename_from_url(r['thumbnailSmallUrl'])
-    allthumbs.append(tname)  # TODO just first thumb is used now.
-    # if r['fileType'] == 'thumbnail':
-    #     tname = paths.extract_filename_from_url(f['fileThumbnailLarge'])
-    #     small_tname = paths.extract_filename_from_url(f['fileThumbnail'])
-    #     allthumbs.append(tname)  # TODO just first thumb is used now.
+      tname = paths.extract_filename_from_url(r['thumbnailMiddleUrl'])+webp_ext
+    small_tname = paths.extract_filename_from_url(r['thumbnailSmallUrl'])+webp_ext
 
     for f in r['files']:
       # if f['fileType'] == 'thumbnail':

--- a/test_daemon_lib.py
+++ b/test_daemon_lib.py
@@ -83,6 +83,7 @@ class Test04GetReportsDaemonRunning(unittest.TestCase):
     self.assertEqual(reports[0]['app_id'], app_id)
     self.assertEqual(reports[0]['task_type'], 'daemon_status')
 
+
 class Test05SearchAndDownloadAsset(unittest.TestCase):
   assets_to_download = []
   def _search_asset(self, search_word, asset_type):
@@ -95,6 +96,7 @@ class Test05SearchAndDownloadAsset(unittest.TestCase):
       'tempdir': tempdir,
       'urlquery': urlquery,
       'asset_type': asset_type,
+      'blender_version': f'{blender_version[0]}.{blender_version[1]}.{blender_version[2]}',
     }
     response = daemon_lib.search_asset(data)
     search_task_id = response['task_id']
@@ -105,6 +107,8 @@ class Test05SearchAndDownloadAsset(unittest.TestCase):
       for task in reports:
         if search_task_id != task['task_id']:
           continue
+        if task['status'] == 'error':
+          self.fail(f'Search task failed {task["message"]}')
         if task['status'] != 'finished':
           continue
         if task['result'] != {}:


### PR DESCRIPTION
fixes #369

- uses .webp thumbnails if Blender version >= 3.4.0
- uses .webp images if webpGeneratedTimestamp is not None (None means webp is not yet generated), in that case it fallbacks to use non-webp urls