### PR TITLE
Handle daemon startup errors correctly

### DIFF
--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -6,6 +6,8 @@ import argparse
 import asyncio
 import logging
 import os
+import platform
+import signal
 import socket
 import ssl
 import time
@@ -173,7 +175,7 @@ async def report(request: web_request.Request):
 async def shutdown(request: web_request.Request):
   """Shedules shutdown of the server."""
   logging.warning('Shutdown requested, exiting Daemon')
-  asyncio.ensure_future(shutdown_daemon(request.app))
+  signal.raise_signal(signal.SIGINT)
   return web.Response(text='Going to shutdown.')
 
 
@@ -184,7 +186,7 @@ async def report_blender_quit(request: web_request.Request):
     globals.active_apps.remove(data['app_id'])
   if len(globals.active_apps)==0:
     logging.warning('No more apps to serve, exiting Daemon')
-    asyncio.ensure_future(shutdown_daemon(request.app))
+    signal.raise_signal(signal.SIGINT)
 
   return web.Response(text="ok") 
 
@@ -195,7 +197,7 @@ async def life_check(app: web.Application):
   while True:
     since_report = time.time() - globals.last_report_time
     if since_report > globals.TIMEOUT:
-      asyncio.ensure_future(shutdown_daemon(app))
+      signal.raise_signal(signal.SIGINT)
     await asyncio.sleep(10)
 
 
@@ -203,15 +205,13 @@ async def online_status_check(app: web.Application):
   while True:
     try:
       url = f'{globals.SERVER}/-/alive/'
-      resp = await app['SESSION_API_REQUESTS'].head(url, timeout=3)
-      globals.online_status = resp.status
-      if resp.status != 200:
-        logging.warning(f'{url}: status code {resp.status}')
+      async with app['SESSION_API_REQUESTS'].head(url, timeout=3) as resp:
+        globals.online_status = resp.status
+        if resp.status != 200:
+          logging.warning(f'{url}: status code {resp.status}')
     except Exception as e:
       logging.warning(f'{url}: request failed')
       globals.online_status = f'{e}'
-    finally:
-      resp.close()
 
     if globals.online_status == 200:
       await asyncio.sleep(300)
@@ -221,21 +221,15 @@ async def online_status_check(app: web.Application):
 
 async def start_background_tasks(app: web.Application):
   app['life_check'] = asyncio.create_task(life_check(app))
-  app[f'online_status_check'] = asyncio.create_task(online_status_check(app))
+  app['online_status_check'] = asyncio.create_task(online_status_check(app))
 
 
 async def cleanup_background_tasks(app: web.Application):
   try:
     app['life_check'].cancel()
-    app[f'online_status_check'].cancel()
+    app['online_status_check'].cancel()
   except:
     logging.warning(f'BG tasks canceling failed: {e}')
-  exit(0)
-
-
-async def shutdown_daemon(app: web.Application):
-  await app.shutdown()
-  await app.cleanup()
 
 
 ## CONFIGURATION
@@ -292,7 +286,7 @@ async def persistent_sessions(app):
   )
 
 
-## MAIN 
+## MAIN
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()
@@ -336,16 +330,14 @@ if __name__ == '__main__':
   server.on_cleanup.append(cleanup_background_tasks)
   
   try:
-    print(f'Starting with {args}')
+    logging.info(f'Starting with {args}')
     web.run_app(server, host='127.0.0.1', port=args.port)
   except OSError as e:
-    # [Errno 10013] error while attempting to bind on address ('[host IP]', [port?]): An attempt was made to access a socket in a way forbidden by its access permissions
-    if e.errno == 10013:
-      logging.error(f'Antivirus blocked Daemon: {e}')
-      exit(113)
-    else:
-      logging.error(f'Daemon start blocked by error: {e}')
-      exit(100)
-  except Exception as e:
-    logging.error(f'Daemon start blocked by error: {e}')
-    exit(100)
+    if platform.system() == "Windows":
+      if e.winerror == 121: exit(121)
+    if e.errno == 10013: exit(113)
+    if e.errno == 10014: exit(114)
+    if e.errno == 48: exit(148)
+    if e.errno == 10048: exit(149)
+    exit(110)
+  except Exception as e: exit(100)

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -186,21 +186,30 @@ def check_daemon_exit_code() -> tuple[int, str]:
   """Checks the exit code of daemon process. Returns exit_code and its message.
   Function polls the process which should not block, but better run only when daemon misbehaves and is expected that it already exited.
   """
-
   exit_code = global_vars.daemon_process.poll()
   if exit_code == None:
     return exit_code, "Daemon process is running."
   
   #exit_code = global_vars.daemon_process.returncode
+  log_path = f'{get_daemon_directory_path()}/daemon-{get_port()}.log'
   if exit_code == 101:
-    message = f'Failed to import AIOHTTP. Try to delete {dependencies.get_dependencies_path()} and restart Blender.'
+    message = f'failed to import AIOHTTP. Try to delete {dependencies.get_dependencies_path()} and restart Blender.'
   elif exit_code == 102:
-    message = f'Failed to import CERTIFI. Try to delete {dependencies.get_dependencies_path()} and restart Blender.'
+    message = f'failed to import CERTIFI. Try to delete {dependencies.get_dependencies_path()} and restart Blender.'
+  elif exit_code == 100:
+    message = f'unexpected OSError. Please report a bug and paste content of log {log_path}'
   elif exit_code == 113:
-    message = 'OSError: [Errno 10013] - cannot open port. Please check your antivirus or firewall and unblock blenderkit and/or daemon.py script.'
+    message = 'cannot open port. Check your antivirus/firewall and unblock BlenderKit.'
+  elif exit_code == 114:
+    message = f'invalid pointer address. Please report a bug and paste content of log {log_path}'
+  elif exit_code == 121:
+    message = f'semaphore timeout exceeded. In preferences set IP version to "Use only IPv4".'
+  elif exit_code == 148:
+    message = 'address already in use. Select different daemon port in preferences.'
+  elif exit_code == 149:
+    message = 'address already in use. Select different daemon port in preferences.'
   else:
-    log_path = f'{get_daemon_directory_path()}/daemon-{get_port()}.log'
-    message = f'Unknown problem. Please report a bug and paste content of log {log_path}'
+    message = f'unexpected Exception. Please report a bug and paste content of log {log_path}'
 
   return exit_code, message
 


### PR DESCRIPTION
fixes #380 

So the daemon exited with return code 0 even when some error happened. This code makes the daemon to exit with correct return codes which are then handled by add-on which shows useful information how to fix the issue, or how to report it into bug tracker.

Also this PR adds some error codes which we got previously reported on the GitHub.