### PR TITLE
Define timeout in requests from add-on into daemon

### DIFF
--- a/.github/make-tests-matrix.py
+++ b/.github/make-tests-matrix.py
@@ -3,6 +3,7 @@ from urllib import request
 
 
 jobs = [
+  {'version': '3.3.1-LTS', 'version_x_y': '3.3', 'download_url': 'https://download.blender.org/release/Blender3.3/blender-3.3.1-linux-x64.tar.xz'},
   {'version': '3.0.0', 'version_x_y': '3.0', 'download_url': 'https://download.blender.org/release/Blender3.0/blender-3.0.0-linux-x64.tar.xz'},
   {'version': '3.0.1', 'version_x_y': '3.0', 'download_url': 'https://download.blender.org/release/Blender3.0/blender-3.0.1-linux-x64.tar.xz'},
   {'version': '3.1.0', 'version_x_y': '3.1', 'download_url': 'https://download.blender.org/release/Blender3.1/blender-3.1.0-linux-x64.tar.xz'},
@@ -10,7 +11,8 @@ jobs = [
   {'version': '3.2.0', 'version_x_y': '3.2', 'download_url': 'https://download.blender.org/release/Blender3.2/blender-3.2.0-linux-x64.tar.xz'},
   {'version': '3.2.2', 'version_x_y': '3.2', 'download_url': 'https://download.blender.org/release/Blender3.2/blender-3.2.2-linux-x64.tar.xz'},
   {'version': '3.3.0', 'version_x_y': '3.3', 'download_url': 'https://download.blender.org/release/Blender3.3/blender-3.3.0-linux-x64.tar.xz'},
-  {'version': '3.3.1-LTS', 'version_x_y': '3.3', 'download_url': 'https://download.blender.org/release/Blender3.3/blender-3.3.1-linux-x64.tar.xz'},
+  {'version': '3.3.2', 'version_x_y': '3.3', 'download_url': 'https://download.blender.org/release/Blender3.3/blender-3.3.2-linux-x64.tar.xz'},
+  {'version': '3.4.0', 'version_x_y': '3.4', 'download_url': 'https://download.blender.org/release/Blender3.4/blender-3.4.0-linux-x64.tar.xz'},
   #{'version': '', 'version_x_y': '', 'download_url': ''},
 ]
 

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -13,7 +13,7 @@ from . import dependencies, global_vars, reports
 
 
 bk_logger = logging.getLogger(__name__)
-
+TIMEOUT = (0.1, 0.5) 
 
 def get_address() -> str:
   """Get address of the daemon."""
@@ -41,14 +41,13 @@ def get_daemon_directory_path() -> str:
 
 def get_reports(app_id: str):
   """Get reports for all tasks of app_id Blender instance at once."""
-
   bk_logger.debug('Getting reports')
   address = get_address()
   with requests.Session() as session:
     url = address + "/report"
     data = {'app_id': app_id}
     try:
-      resp = session.get(url, json=data)
+      resp = session.get(url, json=data, timeout=TIMEOUT, proxies={})
       bk_logger.debug('Got reports')
       return resp.json()
     except Exception as e:
@@ -63,7 +62,7 @@ def search_asset(data):
   data['app_id'] = os.getpid()
   with requests.Session() as session:
     url = address + "/search_asset"
-    resp = session.post(url, json=data)
+    resp = session.post(url, json=data, timeout=TIMEOUT, proxies={})
     bk_logger.debug('Got search response')
     return resp.json()
 
@@ -75,7 +74,7 @@ def download_asset(data):
   data['app_id'] = os.getpid()
   with requests.Session() as session:
     url = address + "/download_asset"
-    resp = session.post(url, json=data)
+    resp = session.post(url, json=data, timeout=TIMEOUT, proxies={})
     return resp.json()
 
 
@@ -91,7 +90,7 @@ def upload_asset(upload_data, export_data, upload_set):
   with requests.Session() as session:
     url = get_address() + "/upload_asset"
     bk_logger.info(f"making a request to: {url}")
-    resp = session.post(url, json=data)
+    resp = session.post(url, json=data, timeout=TIMEOUT, proxies={})
     return resp.json()
 
 
@@ -100,7 +99,7 @@ def kill_download(task_id):
   address = get_address()
   with requests.Session() as session:
     url = address + "/kill_download"
-    resp = session.get(url, json={'task_id':task_id})
+    resp = session.get(url, json={'task_id': task_id}, timeout=TIMEOUT, proxies={})
     return resp
 
 
@@ -111,14 +110,14 @@ def get_disclaimer():
   with requests.Session() as session:
     url = address + "/get_disclaimer"
     data = {'app_id': os.getpid()}
-    resp = session.get(url, json=data)
+    resp = session.get(url, json=data, timeout=TIMEOUT, proxies={})
     return resp
 
 
 def send_code_verifier(code_verifier: str):
   data = {'code_verifier': code_verifier}
   with requests.Session() as session:
-    resp = session.post(f'{get_address()}/code_verifier', json=data)
+    resp = session.post(f'{get_address()}/code_verifier', json=data, timeout=TIMEOUT, proxies={})
     return resp
 
 
@@ -127,7 +126,7 @@ def refresh_token(refresh_token):
   
   with requests.Session() as session:
     url = get_address() + "/refresh_token"
-    resp = session.get(url, json={'refresh_token': refresh_token})
+    resp = session.get(url, json={'refresh_token': refresh_token}, timeout=TIMEOUT, proxies={})
     return resp
 
 
@@ -136,7 +135,7 @@ def daemon_is_alive(session: requests.Session) -> tuple[bool, str]:
 
   address = get_address()
   try:
-    with session.get(address) as resp:
+    with session.get(address, timeout=TIMEOUT, proxies={}) as resp:
       if resp.status_code != 200:
         return False, f'Server response not 200: {resp.status_code}'
       return True, f'Server alive, PID: {resp.text}'
@@ -149,7 +148,7 @@ def report_blender_quit():
   address = get_address()
   with requests.Session() as session:
     url = address + "/report_blender_quit"
-    resp = session.get(url, json={'app_id':os.getpid()})
+    resp = session.get(url, json={'app_id':os.getpid()}, timeout=TIMEOUT, proxies={})
     return resp
 
 
@@ -158,7 +157,7 @@ def kill_daemon_server():
   address = get_address()
   with requests.Session() as session:
     url = address + "/shutdown"
-    resp = session.get(url)
+    resp = session.get(url, timeout=TIMEOUT, proxies={})
     return resp
 
 


### PR DESCRIPTION
Fixes #414 

This fixes a strange error: for some reason on my Windows machine the requests for daemon report stopped to fail when daemon is not running. Instead of error and trying later, the request.get gets stuck for ever, which means the daemon is never started and Blender is completely frozen, waiting for the request for ever ever ever...

This did not happen on the Windows before, must be some update or something which causes the Windows OS instead of replying "port closed" to not reply at all... This patch fixes all the requests to daemon to have a timeout, after which they fail.
