### PR TITLE
fix #426 convert filesSize to kb

### DIFF
--- a/search.py
+++ b/search.py
@@ -173,10 +173,12 @@ def parse_result(r):
   scene = bpy.context.scene
   # TODO remove this fix when filesSize is fixed.
   # this is a temporary fix for too big numbers from the server.
-  # try:
-  #     r['filesSize'] = int(r['filesSize'] / 1024)
-  # except:
-  #     utils.p('asset with no files-size')
+  # can otherwise get the Python int too large to convert to C int
+  try:
+      r['filesSize'] = int(r['filesSize'] / 1024)
+  except:
+      utils.p('asset with no files-size')
+
   asset_type = r['assetType']
   #TODO: REVERSE THIS CONDITION AND RETURN
   if len(r['files']) > 0:  # TODO remove this condition so all assets are parsed.

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2003,7 +2003,8 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             t = utils.fmt_dimensions(mparams)
             self.draw_property(box, 'Size', t)
         if self.asset_data.get('filesSize'):
-            fs = self.asset_data['filesSize']
+            fs = self.asset_data['filesSize'] * 1024
+            #multiply because the number is reduced when search is done to avoind C intiger limit with large files
             fsmb = fs // (1024 * 1024)
             fskb = fs % 1024
             if fsmb == 0:


### PR DESCRIPTION
to avoid  "Python int too large to convert to C int" when writing asset data to scene used assets data.