### PR TITLE
fix #488 - remove bgl module

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -890,7 +890,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
             set_thumb_check(self.tooltip_image,asset_data,thumb_type='thumbnail')
             get_tooltip_data(asset_data)
-            an = asset_data['name']
+            an = asset_data['displayName']
             max_name_length = 30
             if len(an) > max_name_length + 3:
                 an = an[:30] + '...'

--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -121,13 +121,10 @@ class BL_UI_Button(BL_UI_Widget):
 
         self.set_colors()
 
-        bgl.glEnable(bgl.GL_BLEND)
 
         self.batch_panel.draw(self.shader)
 
         self.draw_image()
-
-        bgl.glDisable(bgl.GL_BLEND)
 
         # Draw text
         self.draw_text(area_height)
@@ -165,41 +162,7 @@ class BL_UI_Button(BL_UI_Widget):
             off_x, off_y = self.__image_position
             sx, sy = self.__image_size
             ui_bgl.draw_image(self.x_screen + off_x, y_screen_flip - off_y - sy, sx, sy, self.__image, 1.0, crop=(0, 0, 1, 1), batch=None)
-            return
-            try:
-
-                y_screen_flip = self.get_area_height() - self.y_screen
-
-                off_x, off_y =  self.__image_position
-                sx, sy = self.__image_size
-
-                # bottom left, top left, top right, bottom right
-                vertices = (
-                            (self.x_screen + off_x, y_screen_flip - off_y),
-                            (self.x_screen + off_x, y_screen_flip - sy - off_y),
-                            (self.x_screen + off_x + sx, y_screen_flip - sy - off_y),
-                            (self.x_screen + off_x + sx, y_screen_flip - off_y))
-
-                self.shader_img = gpu.shader.from_builtin('2D_IMAGE')
-                self.batch_img = batch_for_shader(self.shader_img, 'TRI_FAN',
-                { "pos" : vertices,
-                "texCoord": ((0, 1), (0, 0), (1, 0), (1, 1))
-                },)
-
-                # send image to gpu if it isn't there already
-                if self.__image.gl_load():
-                    raise Exception()
-
-                bgl.glActiveTexture(bgl.GL_TEXTURE0)
-                bgl.glBindTexture(bgl.GL_TEXTURE_2D, self.__image.bindcode)
-
-                self.shader_img.bind()
-                self.shader_img.uniform_int("image", 0)
-                self.batch_img.draw(self.shader_img)
-                return True
-            except:
-                pass
-
+            return True
         return False
 
     def set_mouse_down(self, mouse_down_func):

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -71,13 +71,9 @@ class BL_UI_Image(BL_UI_Widget):
 
         self.shader.bind()
 
-        bgl.glEnable(bgl.GL_BLEND)
-
         self.batch_panel.draw(self.shader)
 
         self.draw_image()
-
-        bgl.glDisable(bgl.GL_BLEND)
 
 
     def draw_image(self):
@@ -88,39 +84,6 @@ class BL_UI_Image(BL_UI_Widget):
             ui_bgl.draw_image(self.x_screen + off_x, y_screen_flip - off_y - sy, sx, sy, self.__image, 1.0,
                               crop=(0, 0, 1, 1), batch=None)
             return True
-            try:
-                y_screen_flip = self.get_area_height() - self.y_screen
-
-                off_x, off_y =  self.__image_position
-                sx, sy = self.__image_size
-
-                # bottom left, top left, top right, bottom right
-                vertices = (
-                            (self.x_screen + off_x, y_screen_flip - off_y),
-                            (self.x_screen + off_x, y_screen_flip - sy - off_y),
-                            (self.x_screen + off_x + sx, y_screen_flip - sy - off_y),
-                            (self.x_screen + off_x + sx, y_screen_flip - off_y))
-
-                self.shader_img = gpu.shader.from_builtin('2D_IMAGE')
-                self.batch_img = batch_for_shader(self.shader_img, 'TRI_FAN',
-                { "pos" : vertices,
-                "texCoord": ((0, 1), (0, 0), (1, 0), (1, 1))
-                },)
-
-                # send image to gpu if it isn't there already
-                if self.__image.gl_load():
-                    raise Exception()
-
-                bgl.glActiveTexture(bgl.GL_TEXTURE0)
-                bgl.glBindTexture(bgl.GL_TEXTURE_2D, self.__image.bindcode)
-
-                self.shader_img.bind()
-                self.shader_img.uniform_int("image", 0)
-                self.batch_img.draw(self.shader_img)
-                return True
-            except:
-                pass
-
         return False
 
     def set_mouse_down(self, mouse_down_func):

--- a/bl_ui_widgets/bl_ui_widget.py
+++ b/bl_ui_widgets/bl_ui_widget.py
@@ -1,4 +1,3 @@
-import bgl
 import gpu
 from gpu_extras.batch import batch_for_shader
 
@@ -58,9 +57,7 @@ class BL_UI_Widget:
         self.shader.bind()
         self.shader.uniform_float("color", self._bg_color)
 
-        bgl.glEnable(bgl.GL_BLEND)
         self.batch_panel.draw(self.shader)
-        bgl.glDisable(bgl.GL_BLEND)
 
     def init(self, context):
         self.context = context

--- a/ui_bgl.py
+++ b/ui_bgl.py
@@ -34,9 +34,9 @@ def draw_rect(x, y, width, height, color):
     shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
     batch = batch_for_shader(shader, 'TRIS', {"pos": points}, indices=indices)
 
+    gpu.state.blend_set('ALPHA')
     shader.bind()
     shader.uniform_float("color", color)
-    gpu.state.blend_set('ALPHA')
     batch.draw(shader)
 
 
@@ -49,6 +49,7 @@ def draw_line2d(x1, y1, x2, y2, width, color):
 
     shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
     batch = batch_for_shader(shader, 'LINES', {"pos": coords}, indices=indices)
+    gpu.state.blend_set('ALPHA')
     shader.bind()
     shader.uniform_float("color", color)
     batch.draw(shader)
@@ -58,6 +59,7 @@ def draw_lines(vertices, indices, color):
 
     shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
     batch = batch_for_shader(shader, 'LINES', {"pos": vertices}, indices=indices)
+    gpu.state.blend_set('ALPHA')
     shader.bind()
     shader.uniform_float("color", color)
     batch.draw(shader)
@@ -68,6 +70,7 @@ def draw_rect_3d(coords, color):
     shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
     batch = batch_for_shader(shader, 'TRIS', {"pos": coords}, indices=indices)
     shader.uniform_float("color", color)
+    gpu.state.blend_set('ALPHA')
     batch.draw(shader)
 
 cached_images = {}
@@ -113,7 +116,7 @@ def draw_image(x, y, width, height, image, transparency, crop=(0, 0, 1, 1), batc
     if image.gl_load():
         raise Exception()
 
-    texture = gpu.texture.from_image(image)
+    # texture = gpu.texture.from_image(image)
     gpu.state.blend_set('ALPHA')
     image_shader.bind()
     image_shader.uniform_sampler("image", texture)


### PR DESCRIPTION
fixes #488, #484

there was only needed to set correctly the alpha blend instead of glblend and fix image draw function

NEEDS a lot of testing, we might have to drop support for 2.93.
-images might unload from memory, or the whole thing might be much slower now, so we really need to test well, also performance before-after