### PR TITLE
Support dependencies for different versions of Python

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy, A. Gajdosik",
-    "version": (3, 4, 0, 230122), #X.Y.Z.yymmdd
+    "version": (3, 5, 0, 230130), #X.Y.Z.yymmdd
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",

--- a/__init__.py
+++ b/__init__.py
@@ -1950,8 +1950,8 @@ def register():
 
     addon_updater_ops.register(bl_info)
     dependencies.ensure_preinstalled_deps_copied()
-    dependencies.add_installed_deps()
-    dependencies.add_preinstalled_deps()
+    dependencies.add_installed_deps_path()
+    dependencies.add_preinstalled_deps_path()
     dependencies.ensure_deps()
 
     for cls in classes:

--- a/dependencies.py
+++ b/dependencies.py
@@ -15,7 +15,14 @@ bk_logger = logging.getLogger(__name__)
 
 
 def ensure_preinstalled_deps_copied():
-  """Copy dependencies for current platform into global_dir/dependencies-3.x.y/installed"""
+  """Copy dependencies for current platform and python version if aplicable.
+  Bundled dependencies might be already copied.
+  Or their python version might be different from python in currently running Blender.
+  """
+  if not bundled_version_is_correct():
+    bundled = global_vars.BUNDLED_FOR_PYTHON
+    bk_logger.info(f'Skipping dependencies copy: bundled for python {bundled}, running on python {sys.version}')
+    return
 
   deps_path = path.join(path.dirname(__file__), f"dependencies/{platform.system()}")
   deps_path = path.abspath(deps_path)
@@ -25,46 +32,46 @@ def ensure_preinstalled_deps_copied():
     bk_logger.info(f'Copying dependencies from {deps_path} into {install_into}')
     shutil.copytree(deps_path, install_into)
 
+def bundled_version_is_correct() -> tuple[bool, str, str]:
+    """Check if bundled dependencies are for the python version of currently running Blender."""
+    bundled = global_vars.BUNDLED_FOR_PYTHON
+    current = f'{sys.version_info.major}.{sys.version_info.minor}'
+    return bundled == current
 
 def get_deps_directory_path() -> str:
   """Get path where dependencies (preinstalled and installed) should/are installed for this version of addon."""
-
   daemon_directory = get_daemon_directory_path()
-  version = f'{global_vars.VERSION[0]}-{global_vars.VERSION[1]}-{global_vars.VERSION[2]}'
-  install_path = path.join(daemon_directory, 'dependencies', version)
+  addon_version = f'{global_vars.VERSION[0]}-{global_vars.VERSION[1]}-{global_vars.VERSION[2]}'
+  blender_python_version = f'{sys.version_info.major}-{sys.version_info.minor}'
+  install_path = path.join(daemon_directory, 'dependencies', addon_version, blender_python_version)
   return path.abspath(install_path)
 
 
 def get_installed_deps_path() -> str:
   """Get path to installed dependencies directory. Here addon will install external modules if needed."""
-
   installed_path = path.join(get_deps_directory_path(), 'installed')
   return path.abspath(installed_path)
 
 
 def get_preinstalled_deps_path() -> str:
   """Get path to preinstalled modules for current platform."""
-
   preinstalled_path = path.join(get_deps_directory_path(), 'preinstalled')
   return path.abspath(preinstalled_path)
 
 
-def add_installed_deps():
-  """Add installed dependencies directory into PATH."""
-
+def add_installed_deps_path():
+  """Add installed dependencies directory path into PATH."""
   installed_path = get_installed_deps_path()
   makedirs(installed_path, exist_ok=True)
   sys.path.insert(0, installed_path)
 
-def add_preinstalled_deps():
-  """Add preinstalled dependencies directory into PATH."""
-
+def add_preinstalled_deps_path():
+  """Add preinstalled dependencies directory path into PATH."""
   sys.path.insert(0, get_preinstalled_deps_path())
 
 
 def ensure_deps():
   """Make sure that dependencies which need installation are available. Install dependencies if needed."""
-
   tried = 0
   while tried < 2:
     tried = tried + 1
@@ -78,9 +85,7 @@ def ensure_deps():
 
 def install_dependencies():
   """Install pip and install dependencies."""
-
   started = time.time()
-
   env  = environ.copy()
   if platform.system() == "Windows":
     env['PATH'] = env['PATH'] + pathsep + path.abspath(path.dirname(sys.executable) + "/../../../blender.crt")
@@ -97,7 +102,7 @@ def install_dependencies():
     bk_logger.info(f"Install succesfully finished in {time.time()-started}")
     return
 
-  bk_logger.warn(f"Install from requirements.txt failed, trying with unconstrained versions...")
+  bk_logger.warn("Install from requirements.txt failed, trying with unconstrained versions...")
   command = [sys.executable, '-m', 'pip', 'install', '--upgrade', '-t', get_installed_deps_path(), 'aiohttp', 'certifi']
   result = subprocess.run(command, env=env, capture_output=True, text=True)
   bk_logger.info(f"UNCONSTRAINED INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
@@ -105,4 +110,4 @@ def install_dependencies():
     bk_logger.info(f"Install succesfully finished in {time.time()-started}")
     return
   
-  bk_logger.critical(f"Installation failed")
+  bk_logger.critical("Installation failed")

--- a/dev.py
+++ b/dev.py
@@ -4,8 +4,9 @@ import shutil
 import subprocess
 import sys
 
+import global_vars
 
-PYTHON_VERSION = "3.10"
+
 PACKAGES = [
   "multidict==6.0.4",
   "yarl==1.8.2",
@@ -21,10 +22,10 @@ PACKAGES = [
 
 
 def do_build(install_at=None, include_tests=False):
-  """Build addon by copying relevant addon directories and files to ./out/blenderkit directory. Create zip in ./out/blenderkit.zip."""
-
+  """Build addon by copying relevant addon directories and files to ./out/blenderkit directory.
+  Create zip in ./out/blenderkit.zip.
+  """
   shutil.rmtree('out', True)
-
   target_dir = "out/blenderkit"
   ignore_files = [
     '.gitignore',
@@ -46,16 +47,16 @@ def do_build(install_at=None, include_tests=False):
       continue # we copied directories above
     if item in ignore_files:
       continue
-    if include_tests == False and item == "test.py":
+    if include_tests is False and item == "test.py":
       continue
-    if include_tests == False and item.startswith('test_'):
+    if include_tests is False and item.startswith('test_'):
       continue # we do not include test files
     shutil.copy(item, f'{target_dir}/{item}')
 
   #CREATE ZIP
   shutil.make_archive('out/blenderkit', 'zip', 'out', 'blenderkit')
 
-  if install_at != None:
+  if install_at is not None:
     shutil.rmtree(f'{install_at}/blenderkit', ignore_errors=True)
     shutil.copytree('out/blenderkit', f'{install_at}/blenderkit')
 
@@ -78,7 +79,6 @@ def run_tests():
 
 def bundle_dependencies():
   """Bundle dependencies specified in PACKAGES variable into ./dependencies directory."""
-
   MACOS = {
     'name': 'Darwin',
     'platforms': {
@@ -113,7 +113,7 @@ def bundle_dependencies():
           'install',
           '--only-binary=:all:',
           f'--platform={platform}',
-          f'--python-version={PYTHON_VERSION}',
+          f'--python-version={global_vars.BUNDLED_FOR_PYTHON}',
           f'--target=dependencies/{OS["name"]}',
           '--no-deps',
           module,

--- a/global_vars.py
+++ b/global_vars.py
@@ -45,5 +45,6 @@ TIPS = [
   ('Get latest experimental versions of add-on by enabling prerelases in preferences.', ''),
 ]
 VERSION = None  # filled in register()
+BUNDLED_FOR_PYTHON = "3.10"
 
 daemon_process = None


### PR DESCRIPTION
fixes #187 

premise: We do not want to bundle for more than one version of Python, right? Once Blender with python 3.11 is released we gonna bundle 3.11 dependencies and if somebody is using older Blenders with python 3.10, the installation will fallback to pip install from requirements.txt file, is this thinking correct? Do we agree, @vilemduha?

Bundling for more than one version would increas the size of the add-on, which I believe is not great.

How this PR works:
1. add-on checks if dependencies are bundled for the same python version as Blender is running on - if so, the addon will copy them into `daemon/dependencies/3.5.0/3.10/preinstalled`, if they are not the same, no copying is performed
2. as before the add-on adds preinstalled and installed dirs into PATH
3. tries to import aiohttp, if that fails, add-on runs pip install into daemon/dependencies/3.5.0/3.10/installed`

If user uses more Blenders, then:
- when using Blender 3.4.1 with python 3.10 and add-on 3.5.0 with bundling for python 3.10 -> deps are copied
- when using Blender 3.9.9 with python 3.11 and add-on 3.5.0 with bundling for python 3.10 -> deps are not copied and add-on will install deps using pip for python, be it 3.11, 3.12 or 3.8....

In future, when user uses old add-on:
- when using Blender 3.9.9 with python 3.11 and add-on 3.5.0 with bundling for python 3.10 -> deps will be not copied, add-on will install deps into `daemon/dependencies/3.5.0/3.10/installed`
- once user updates to newer add-on with bundling for 3.11, it will copy preinstalled into `daemon/dependencies/3.77.0/3.11/preinstalled`

This way the installed modules should not clash with different add-on versions and different Blender versions.