### PR TITLE
#502 Require saved project for download in local dir mode

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -890,6 +890,14 @@ class AssetDragOperator(bpy.types.Operator):
             bpy.ops.wm.blenderkit_url_dialog('INVOKE_REGION_WIN', url=url, message=message, link_text=link_text)
             return {'CANCELLED'}
 
+        dir_behaviour = bpy.context.preferences.addons['blenderkit'].preferences.directory_behaviour
+        if dir_behaviour == 'LOCAL' and bpy.data.filepath == '':
+            message = "Save the project to download in local directory mode."
+            link_text = 'See documentation'
+            url = 'https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#use-directories'
+            bpy.ops.wm.blenderkit_url_dialog('INVOKE_REGION_WIN', url=url, message=message, link_text=link_text)
+            return {'CANCELLED'}
+
         if self.asset_data.get('assetType') == 'brush':
           if not (context.sculpt_object or context.image_paint_object):
             message = "Please switch to sculpt or image paint modes."


### PR DESCRIPTION
fixes #502 

When preferences.directory_behaviour is set to LOCAL user truly wants her assets in the project. To do that add-on needs defined path - and for that project must be saved. This commit blocks download without saved project in local mode.