### PR TITLE
#517 Fix decoding error when OS use gbk encoding

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,7 @@ from importlib import reload
 from os import path
 
 
+sys.stdout.reconfigure(encoding='utf-8')
 bk_logger = logging.getLogger(__name__)
 
 # lib = path.join(path.dirname(__file__), 'lib')

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -10,10 +10,12 @@ from platform import system
 from signal import SIGINT, raise_signal
 from socket import AF_INET, SO_REUSEADDR, SOL_SOCKET, socket
 from ssl import PROTOCOL_TLS_CLIENT, Purpose, SSLContext
+from sys import stdout
 from time import time
 from uuid import uuid4
 
 
+stdout.reconfigure(encoding='utf-8')
 logger = getLogger('bk_daemon')
 
 try:

--- a/daemon/utils.py
+++ b/daemon/utils.py
@@ -185,6 +185,7 @@ def configure_logger():
   logger.propagate = False
   logger.handlers = []
   handler = StreamHandler()
+  handler.stream = sys.stdout #517
   handler.setFormatter(get_formatter())
   logger.addHandler(handler)
 
@@ -196,6 +197,7 @@ def configure_imported_loggers():
   aiohttp_logger.propagate = False
   aiohttp_logger.handlers = []
   aiohttp_handler = StreamHandler()
+  aiohttp_handler.stream = sys.stdout #517
   aiohttp_handler.setLevel(globals.LOGGING_LEVEL_IMPORTED)
   aiohttp_handler.setFormatter(get_formatter())
   aiohttp_logger.addHandler(aiohttp_handler)

--- a/log.py
+++ b/log.py
@@ -24,6 +24,7 @@ def configure_bk_logger():
   bk_logger.handlers = []
 
   stream_handler = logging.StreamHandler()
+  stream_handler.stream = sys.stdout #517
   stream_handler.setFormatter(get_formatter())
   bk_logger.addHandler(stream_handler)
 
@@ -35,6 +36,7 @@ def configure_imported_loggers():
   urllib3_logger.handlers = []
 
   urllib3_handler = logging.StreamHandler()
+  urllib3_handler.stream = sys.stdout #517
   urllib3_handler.setLevel(global_vars.LOGGING_LEVEL_IMPORTED)
   urllib3_handler.setFormatter(get_formatter())
   urllib3_logger.addHandler(urllib3_handler)


### PR DESCRIPTION
fixes #517 #508 

reconfiguring sys.stdout to explicitly use utf-8 encoding, UTF-8 default encoding
set streamHandller.stream to stdout so special chars are printed fine