### PR TITLE
#494 Update description and tags on download from search result data

### DIFF
--- a/download.py
+++ b/download.py
@@ -470,14 +470,21 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
 
     asset_data['resolution'] = kwargs['resolution']
     udpate_asset_data_in_dicts(asset_data)
-
-    asset_main['asset_data'] = asset_data  # TODO remove this??? should write to blenderkit Props?
-    asset_main.blenderkit.asset_base_id = asset_data['assetBaseId']
-    asset_main.blenderkit.id = asset_data['id']
+    update_asset_metadata(asset_main, asset_data)
 
     bpy.ops.ed.undo_push('INVOKE_REGION_WIN', message='add %s to scene' % asset_data['name'])
     # moving reporting to on save.
     # report_use_success(asset_data['id'])
+
+
+def update_asset_metadata(asset_main, asset_data):
+    """Update downloaded asset_data on the asset_main placed in the scene."""
+    asset_main.blenderkit.asset_base_id = asset_data['assetBaseId']
+    asset_main.blenderkit.id = asset_data['id']
+    asset_main.blenderkit.description = asset_data['description']
+    asset_main.blenderkit.tags = utils.list2string(asset_data['tags'])
+    #BUG #554: categories needs update, but are not in asset_data
+    asset_main['asset_data'] = asset_data  # TODO remove this??? should write to blenderkit Props?
 
 
 def replace_resolution_linked(file_paths, asset_data):

--- a/upload.py
+++ b/upload.py
@@ -57,27 +57,10 @@ licenses = (
 )
 
 
-def comma2array(text):
-    commasep = text.split(',')
-    ar = []
-    for i, s in enumerate(commasep):
-        s = s.strip()
-        if s != '':
-            ar.append(s)
-    return ar
-
-
-def get_app_version():
-    ver = bpy.app.version
-    return '%i.%i.%i' % (ver[0], ver[1], ver[2])
-
-
 def add_version(data):
-    app_version = get_app_version()
-    addon_version = version_checker.get_addon_version()
     data["sourceAppName"] = "blender"
-    data["sourceAppVersion"] = app_version
-    data["addonVersion"] = addon_version
+    data["sourceAppVersion"] = version_checker.get_blender_version()
+    data["addonVersion"] = version_checker.get_addon_version()
 
 
 def write_to_report(props, text):
@@ -243,9 +226,9 @@ def get_upload_data(caller=None, context=None, asset_type=None):
             "productionLevel": props.production_level.lower(),
             "model_style": style,
             "engines": engines,
-            "modifiers": comma2array(props.modifiers),
-            "materials": comma2array(props.materials),
-            "shaders": comma2array(props.shaders),
+            "modifiers": utils.string2list(props.modifiers),
+            "materials": utils.string2list(props.materials),
+            "shaders": utils.string2list(props.shaders),
             "uv": props.uv,
             "dimensionX": round(props.dimensions[0], 4),
             "dimensionY": round(props.dimensions[1], 4),
@@ -331,9 +314,9 @@ def get_upload_data(caller=None, context=None, asset_type=None):
             "productionLevel": props.production_level.lower(),
             "model_style": style,
             "engines": engines,
-            "modifiers": comma2array(props.modifiers),
-            "materials": comma2array(props.materials),
-            "shaders": comma2array(props.shaders),
+            "modifiers": utils.string2list(props.modifiers),
+            "materials": utils.string2list(props.materials),
+            "shaders": utils.string2list(props.shaders),
             "uv": props.uv,
 
             "animated": props.animated,
@@ -391,7 +374,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
         upload_params = {
             "material_style": style,
             "engine": engine,
-            "shaders": comma2array(props.shaders),
+            "shaders": utils.string2list(props.shaders),
             "uv": props.uv,
             "animated": props.animated,
             "purePbr": props.pbr,
@@ -506,7 +489,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
         upload_data["displayName"] = props.name
 
     upload_data["description"] = props.description
-    upload_data["tags"] = comma2array(props.tags)
+    upload_data["tags"] = utils.string2list(props.tags)
     # category is always only one value by a slug, that's why we go down to the lowest level and overwrite.
     if props.category == '':
         upload_data["category"] = asset_type.lower()
@@ -678,7 +661,7 @@ class FastMetadata(bpy.types.Operator):
             'category': category,
             'displayName': self.name,
             'description': self.description,
-            'tags': comma2array(self.tags),
+            'tags': utils.string2list(self.tags),
             'isPrivate': self.is_private == 'PRIVATE',
             'isFree': self.free_full == 'FREE',
             'license': self.license,

--- a/utils.py
+++ b/utils.py
@@ -1147,3 +1147,23 @@ def handle_nonblocking_request_task(task: tasks.Task):
         reports.add_report(task.message)
     if task.status == 'error':
         reports.add_report(task.message, type='ERROR')
+
+
+def string2list(text: str) -> list:
+    """Convert a comma separated string to a list of strings."""
+    items = text.split(',')
+    lst = []
+    for item in items:
+        item = item.strip()
+        if item != '':
+            lst.append(item)
+    return lst
+
+
+def list2string(lst: list) -> str:
+    """Convert a list of strings to a comma separated string."""
+    text = ""
+    for item in lst:
+        text += item + ", "
+    return text[:-2]
+

--- a/version_checker.py
+++ b/version_checker.py
@@ -24,17 +24,14 @@ import bpy
 from . import paths
 
 
-def get_blender_version():
-    # should return addon version, but since Blender 3.0 this is synced with Blender version
+def get_blender_version() -> str:
+    """Get Blender version as string."""
     ver = bpy.app.version
     return '%i.%i.%i' % (ver[0], ver[1], ver[2])
 
 
-def get_addon_version():
-    # should return addon version, but since Blender 3.0 this is synced with Blender version
-    # ver = bpy.app.version
-    # return '%i.%i.%i' % (ver[0], ver[1], ver[2])
-
+def get_addon_version() -> str:
+    """Get BlenderKit addon version as string."""
     import blenderkit
     ver = blenderkit.bl_info['version']
     return '%i.%i.%i' % (ver[0], ver[1], ver[2])


### PR DESCRIPTION
fixes #494

And there is follow-up issue for all categories, which can have the same problem as description and tags had #554 - but hm, why it is correct in the fast metadata? 