### PR TITLE
UI tweaks

### DIFF
--- a/search.py
+++ b/search.py
@@ -585,6 +585,11 @@ def handle_get_user_profile(task: tasks.Task):
   if task.status == 'finished':
     user_data = task.result
     global_vars.DATA['bkit profile'] = user_data
+    global_vars.DATA['bkit authors'][str(user_data['user']['id'])] = user_data['user']
+
+    #after profile arrives, we can check for gravatar image
+    daemon_lib.fetch_gravatar_image(user_data['user'])
+
 
 
 def query_to_url(query={}, params={}):

--- a/search.py
+++ b/search.py
@@ -998,6 +998,7 @@ def update_filters():
   # update filters for 2 reasons
   # - first to show if filters are active
   # - second to show login popup if user needs to log in
+  # returns True if search should proceed, False to bounce search(like in the case of bookmarks)
 
   sprops = utils.get_search_props()
   ui_props = bpy.context.window_manager.blenderkitUI
@@ -1005,9 +1006,11 @@ def update_filters():
   if sprops.search_bookmarks and not utils.user_logged_in():
     sprops.search_bookmarks = False
     bpy.ops.wm.blenderkit_login_dialog("INVOKE_DEFAULT", message="Please login to use bookmarks.")
+    return False
   if sprops.own_only and not utils.user_logged_in():
     sprops.own_only = False
     bpy.ops.wm.blenderkit_login_dialog("INVOKE_DEFAULT", message="Please login to upload and filter your own assets.")
+    return False
 
   fcommon = sprops.own_only or \
             sprops.search_texture_resolution or \
@@ -1029,6 +1032,7 @@ def update_filters():
     sprops.use_filters = fcommon
   elif ui_props.asset_type == 'HDR':
     sprops.use_filters = sprops.true_hdr
+  return True
 
 def search_update_delayed(self,context):
   '''run search after user changes a search parameter,
@@ -1040,7 +1044,9 @@ def search_update_delayed(self,context):
 def search_update(self, context):
   '''run search after user changes a search parameter'''
   # if self.search_keywords != '':
-  update_filters()
+  go_on = update_filters()
+  if not go_on:
+    return;
   ui_props = bpy.context.window_manager.blenderkitUI
   if ui_props.down_up != 'SEARCH':
     ui_props.down_up = 'SEARCH'

--- a/utils.py
+++ b/utils.py
@@ -921,7 +921,9 @@ def user_logged_in():
     user_preferences = bpy.context.preferences.addons['blenderkit'].preferences
     a = global_vars.DATA.get('bkit profile')
     # Check both profile and token, profile sometimes isn't cleaned up after logout
-    if a is not None and user_preferences.api_key != '':
+    # vilem - removed (a is not None) - the profile isn't always ready on start of blender,
+    # it can take a while, and e.g. bookmark popup could be spawned.
+    if user_preferences.api_key != '':
         return True
     return False
 


### PR DESCRIPTION
Improve UI of profile panel
-remove/disable login panel
-remove 'login as someone else' button
-move login button to profile panel (and rename the panel if user is not logged in to 'blenderkit login')
Add profile picture -
-this is fetched same as authors gravatar, and also stored in the same way - this way it's compatible. It's a question if we should store blenderkit profile separately at all, but now I kept it.
-display of profile picture should be tested, if it works well.