### PR TITLE
Fix failing appends after download

### DIFF
--- a/daemon/tasks.py
+++ b/daemon/tasks.py
@@ -17,7 +17,7 @@ class Task():
     self.message = message
     self.progress = progress
     self.status = status # created / finished / error
-    self.result = result
+    self.result = result.copy()
 
     self.async_task: asyncio.Task | None = None
 


### PR DESCRIPTION
So this was reaaaaaly hard to debug - the results in daemon could get overwritten (file paths before all), because the task object had a dict for the results that wasn't copied on init, so it was shared between task objects.