### PR TITLE
Asset bar performance

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -802,6 +802,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
         self.draw_tooltip = False
         # let's take saved scroll offset and use it to keep scroll between operator runs
+
+        self.last_scroll_offset = -10 #set to -10 so it updates on first run
         self.scroll_offset = ui_props.scroll_offset
 
         self.text_color = (0.9, 0.9, 0.9, 1.0)
@@ -890,6 +892,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.panel.set_location(self.bar_x,
                                 self.bar_y)
         # to hide arrows accordingly
+
         self.scroll_update(always = True)
 
         self.window = context.window
@@ -1187,8 +1190,11 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.scroll_offset = min(self.scroll_offset, len(sr) - (self.wcount * self.hcount))
         self.scroll_offset = max(self.scroll_offset, 0)
         #only update if scroll offset actually changed, otherwise this is unnecessary
-        # this was pretty stupid, since offset changes BEFORE entering the function.
-        # if always  or orig_offset != self.scroll_offset:
+
+        if self.last_scroll_offset == self.scroll_offset:
+            return
+        self.last_scroll_offset = self.scroll_offset
+
         self.update_buttons()
 
         if sro['count'] > len(sr) and len(sr) - self.scroll_offset < (self.wcount * self.hcount) + 15:

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -787,8 +787,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
         self.button_scroll_down.height = self.bar_height
         self.button_scroll_down.set_image_position((0, int((self.bar_height - self.button_size) / 2)))
-        self.button_scroll_down.height = self.bar_height
-        self.button_scroll_down.set_image_position((0, int((self.bar_height - self.button_size) / 2)))
+        self.button_scroll_up.height = self.bar_height
+        self.button_scroll_up.set_image_position((0, int((self.bar_height - self.button_size) / 2)))
 
     def __init__(self):
         super().__init__()
@@ -1209,6 +1209,13 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             self.button_scroll_up.visible = False
         else:
             self.button_scroll_up.visible = True
+
+        # here we save some time by only updating the images if the scroll offset actually changed
+        if self.last_scroll_offset == self.scroll_offset:
+            return
+        self.last_scroll_offset = self.scroll_offset
+
+        self.update_images()
 
     def search_by_author(self, asset_index):
         sr = global_vars.DATA['search results']

--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -98,7 +98,7 @@ class BL_UI_Button(BL_UI_Widget):
             if self.__image and len(self.__image.pixels) == 0:
                 self.__image.reload()
                 self.__image.gl_load()
-            
+            bpy.context.region.tag_redraw()
         except Exception as e:
             print(e)
             self.__image = None

--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -31,6 +31,8 @@ class BL_UI_Button(BL_UI_Widget):
 
     @text_color.setter
     def text_color(self, value):
+        if value != self._text_color:
+            bpy.context.region.tag_redraw()
         self._text_color = value
 
     @property
@@ -39,6 +41,8 @@ class BL_UI_Button(BL_UI_Widget):
 
     @text.setter
     def text(self, value):
+        if value != self._text:
+            bpy.context.region.tag_redraw()
         self._text = value
 
     @property
@@ -47,6 +51,8 @@ class BL_UI_Button(BL_UI_Widget):
 
     @text_size.setter
     def text_size(self, value):
+        if value != self._text_size:
+            bpy.context.region.tag_redraw()
         self._text_size = value
 
     @property
@@ -55,6 +61,8 @@ class BL_UI_Button(BL_UI_Widget):
 
     @hover_bg_color.setter
     def hover_bg_color(self, value):
+        if value != self._hover_bg_color:
+            bpy.context.region.tag_redraw()
         self._hover_bg_color = value
 
     @property
@@ -63,6 +71,8 @@ class BL_UI_Button(BL_UI_Widget):
 
     @select_bg_color.setter
     def select_bg_color(self, value):
+        if value != self._select_bg_color:
+            bpy.context.region.tag_redraw()
         self._select_bg_color = value
 
     def set_image_size(self, imgage_size):
@@ -98,7 +108,6 @@ class BL_UI_Button(BL_UI_Widget):
             if self.__image and len(self.__image.pixels) == 0:
                 self.__image.reload()
                 self.__image.gl_load()
-            bpy.context.region.tag_redraw()
         except Exception as e:
             print(e)
             self.__image = None

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -35,10 +35,12 @@ class BL_UI_OT_draw_operator(Operator):
 
         context.window_manager.modal_handler_add(self)
 
-        #first set pointers to keep track if the area is still available
+        # first set pointers to keep track if the area is still available
         self.active_window_pointer = context.window.as_pointer()
         self.active_area_pointer = context.area.as_pointer()
         self.active_region_pointer = context.region.as_pointer()
+
+        context.region.tag_redraw()
         return {"RUNNING_MODAL"}
 
     def register_handlers(self, args, context):
@@ -69,7 +71,7 @@ class BL_UI_OT_draw_operator(Operator):
             return {'FINISHED'}
 
         if context.area:
-            context.area.tag_redraw()
+            context.region.tag_redraw()
 
         if self.handle_widget_events(event):
             return {'RUNNING_MODAL'}
@@ -81,6 +83,7 @@ class BL_UI_OT_draw_operator(Operator):
 
     def finish(self):
         self.unregister_handlers(bpy.context)
+        bpy.context.region.tag_redraw()
         self.on_finish(bpy.context)
 
 	# Draw handler to paint onto the screen

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -83,7 +83,9 @@ class BL_UI_OT_draw_operator(Operator):
 
     def finish(self):
         self.unregister_handlers(bpy.context)
-        bpy.context.region.tag_redraw()
+        # it is possible that the area has been closed, so we check if it is still available
+        if bpy.context.region is not None:
+            bpy.context.region.tag_redraw()
         self.on_finish(bpy.context)
 
 	# Draw handler to paint onto the screen

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -94,6 +94,9 @@ class BL_UI_OT_draw_operator(Operator):
 def draw_callback_px_separated(self, op, context):
     #separated only for puprpose of profiling
     try:
+        # hide during animation playback, to improve performance
+        if context.screen.is_animation_playing:
+            return
         if context.area.as_pointer() == self.active_area_pointer:
             for widget in self.widgets:
                 widget.draw()

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -49,7 +49,7 @@ class BL_UI_Image(BL_UI_Widget):
             if self.__image and len(self.__image.pixels) == 0:
                 self.__image.reload()
                 self.__image.gl_load()
-
+            bpy.context.region.tag_redraw()
         except Exception as e:
             print(e)
             self.__image = None

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -49,7 +49,6 @@ class BL_UI_Image(BL_UI_Widget):
             if self.__image and len(self.__image.pixels) == 0:
                 self.__image.reload()
                 self.__image.gl_load()
-            bpy.context.region.tag_redraw()
         except Exception as e:
             print(e)
             self.__image = None

--- a/bl_ui_widgets/bl_ui_label.py
+++ b/bl_ui_widgets/bl_ui_label.py
@@ -1,4 +1,5 @@
 import blf
+import bpy
 
 from .bl_ui_widget import *
 
@@ -20,6 +21,8 @@ class BL_UI_Label(BL_UI_Widget):
 
     @text_color.setter
     def text_color(self, value):
+        if value != self._text_color:
+            bpy.context.region.tag_redraw()
         self._text_color = value
 
     @property
@@ -28,6 +31,8 @@ class BL_UI_Label(BL_UI_Widget):
 
     @text.setter
     def text(self, value):
+        if value != self._text:
+            bpy.context.region.tag_redraw()
         self._text = value
 
     @property
@@ -36,6 +41,8 @@ class BL_UI_Label(BL_UI_Widget):
 
     @text_size.setter
     def text_size(self, value):
+        if value != self._text_size:
+            bpy.context.region.tag_redraw()
         self._text_size = value
 
     def is_in_rect(self, x, y):

--- a/bl_ui_widgets/bl_ui_widget.py
+++ b/bl_ui_widgets/bl_ui_widget.py
@@ -21,12 +21,14 @@ class BL_UI_Widget:
         self._is_active = True #if the widget needs to be disabled
 
     def set_location(self, x, y):
+        # if self.x != x or self.y != y or self.x_screen != x or self.y_screen != y:
+        #     bpy.context.region.tag_redraw()
         self.x = x
         self.y = y
         self.x_screen = x
         self.y_screen = y
         self.update(x,y)
-        bpy.context.region.tag_redraw()
+
 
     @property
     def bg_color(self):
@@ -34,8 +36,9 @@ class BL_UI_Widget:
 
     @bg_color.setter
     def bg_color(self, value):
+        if value != self._bg_color:
+            bpy.context.region.tag_redraw()
         self._bg_color = value
-        bpy.context.region.tag_redraw()
 
     @property
     def visible(self):
@@ -43,8 +46,9 @@ class BL_UI_Widget:
 
     @visible.setter
     def visible(self, value):
+        if value != self._is_visible:
+            bpy.context.region.tag_redraw()
         self._is_visible = value
-        bpy.context.region.tag_redraw()
 
     @property
     def active(self):
@@ -52,8 +56,9 @@ class BL_UI_Widget:
 
     @visible.setter
     def active(self, value):
+        if value != self._is_active:
+            bpy.context.region.tag_redraw()
         self._is_active = value
-        bpy.context.region.tag_redraw()
 
     @property
     def tag(self):

--- a/bl_ui_widgets/bl_ui_widget.py
+++ b/bl_ui_widgets/bl_ui_widget.py
@@ -1,6 +1,7 @@
+import bpy
 import gpu
 from gpu_extras.batch import batch_for_shader
-import bpy
+
 
 class BL_UI_Widget:
 

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -131,8 +131,9 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
     if self._finished:
       return {'FINISHED'}
 
-    if context.area:
-      context.area.tag_redraw()
+    if not context.area:
+      #end if area disappears
+      self.finish()
 
     if self.handle_widget_events(event):
       self.start_time = time.time()
@@ -155,6 +156,7 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
       widget.hover_bg_color = self.hover_bg_color
       if hasattr(widget, 'text_color'):
         widget.text_color = self.text_color
+
 
   def fadeout(self):
     """ Fade out widget after some time"""

--- a/download.py
+++ b/download.py
@@ -1292,7 +1292,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
             return wm.invoke_props_dialog(self)
         # if self.close_window:
         #     time.sleep(0.1)
-        #     context.area.tag_redraw()
+        #     context.region.tag_redraw()
         #     time.sleep(0.1)
         #
         #     context.window.cursor_warp(event.mouse_x, event.mouse_y);

--- a/search.py
+++ b/search.py
@@ -1182,14 +1182,6 @@ class SearchOperator(Operator):
 
     return {'FINISHED'}
 
-  # def invoke(self, context, event):
-  #     if self.close_window:
-  #         context.window.cursor_warp(event.mouse_x, event.mouse_y - 100);
-  #         context.area.tag_redraw()
-  #
-  #         context.window.cursor_warp(event.mouse_x, event.mouse_y);
-  #     return self. execute(context)
-
 
 class UrlOperator(Operator):
   """"""


### PR DESCRIPTION
Reduce asset bar draw calls.

Until now, the library bl_ui_widgets did draw every modal event(!)
Now only when something real happens should redraw.
This is done directly in the widgets library, so operators don't have to care when to call tag_redraw:
- all relevant setter functions for properties have a check for change and tag redraw
- several other substantial functions that update the look of the assetbar call tag redraw (mouse in/out, position update)
During animation, asset bar also gets hidden.
All this causes huge CPU savings on my macbook air