### PR TITLE
webp - don't write error to .webp file

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -259,14 +259,23 @@ def get_tooltip_data(asset_data):
 
 
 def set_thumb_check(element, asset, thumb_type = 'thumbnail_small'):
-    '''sets image in case it is loaded in search'''
+    '''sets image in case it is loaded in search results
+     - if image doesn't exist, it will be set to 'thumbnail_notready.jpg'
+
+    '''
     directory = paths.get_temp_dir('%s_search' % asset['assetType'])
-    tpath = os.path.join(directory, asset[thumb_type])
+    if asset[thumb_type] == '': # for thumbnails not present at all
+        tpath = paths.get_addon_thumbnail_path('thumbnail_notready.jpg')
+    else:
+        tpath = os.path.join(directory, asset[thumb_type])
+
     if element.get_image_path() == tpath:
+        # no need to update
         return
-    img_name_datablock = f'.{asset["thumbnail_small"]}'
+    # img_name_datablock = f'.{asset["thumbnail_small"]}'
+
     # if not os.path.exists(tpath):
-    #     global_vars.DATA['images available'][tpath]=None
+    #     del global_vars.DATA['images available'][tpath]
 
     if not global_vars.DATA['images available'].get(tpath):
         tpath = paths.get_addon_thumbnail_path('thumbnail_notready.jpg')
@@ -1115,6 +1124,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 asset_button.validation_icon.visible = False
 
     def update_image(self, asset_id):
+        '''should be run after thumbs are retrieved so they can be updated '''
         sr = global_vars.DATA.get('search results')
         if not sr:
             return

--- a/daemon/search.py
+++ b/daemon/search.py
@@ -34,10 +34,11 @@ async def download_image(session: aiohttp.ClientSession, task: tasks.Task):
     async with session.get(image_url, headers=utils.get_headers()) as resp:
       if resp and resp.status != 200:
         task.error(f"thumbnail download error: {resp.status}")
-      with open(image_path, 'wb') as file:
-        async for chunk in resp.content.iter_chunked(4096 * 32):
-          file.write(chunk)
-      task.finished("thumbnail downloaded")
+      elif resp and resp.status == 200:
+        with open(image_path, 'wb') as file:
+          async for chunk in resp.content.iter_chunked(4096 * 32):
+            file.write(chunk)
+          task.finished("thumbnail downloaded")
   except Exception as e:
     task.error(f"thumbnail download error: {e}")
 


### PR DESCRIPTION

The main problem was if server returns another response than 200, the response content still got written into a file.

handle better check for existing files to avoid pink or empty thumbnails, and provide thumbnail_notready.jpg instead.
This still doesn't show fallback thumbnails if server returns bad webp. I concluded implementing the fallback is too complex for now considering that it actually fixes an error from our server.