### PR TITLE
#419 - Show info when global dir is not accessible

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1958,11 +1958,6 @@ def register():
     bpy.utils.register_class(BlenderKitAddonPreferences)
 
     addon_updater_ops.register(bl_info)
-    dependencies.ensure_preinstalled_deps_copied()
-    dependencies.add_installed_deps_path()
-    dependencies.add_preinstalled_deps_path()
-    dependencies.ensure_deps()
-
     for cls in classes:
         bpy.utils.register_class(cls)
 

--- a/dependencies.py
+++ b/dependencies.py
@@ -7,7 +7,7 @@ import sys
 import time
 from os import environ, makedirs, path, pathsep
 
-from . import global_vars
+from . import global_vars, reports
 from .daemon_lib import get_daemon_directory_path
 
 
@@ -30,7 +30,10 @@ def ensure_preinstalled_deps_copied():
   
   if not path.isdir(install_into):
     bk_logger.info(f'Copying dependencies from {deps_path} into {install_into}')
-    shutil.copytree(deps_path, install_into)
+    try:
+        shutil.copytree(deps_path, install_into)
+    except Exception as e:
+        reports.add_report(f'Dependencies install failed: {e}', 20, 'ERROR')
 
 def bundled_version_is_correct() -> tuple[bool, str, str]:
     """Check if bundled dependencies are for the python version of currently running Blender."""

--- a/timer.py
+++ b/timer.py
@@ -11,6 +11,7 @@ from . import (
     categories,
     comments_utils,
     daemon_lib,
+    dependencies,
     disclaimer_op,
     download,
     global_vars,
@@ -246,8 +247,14 @@ def check_timers_timer():
 def on_startup_timer():
   """Run once on the startup of add-on."""
   addon_updater_ops.check_for_update_background()
+  utils.check_globaldir_permissions()
   utils.ensure_system_ID()
 
+  dependencies.ensure_preinstalled_deps_copied()
+  dependencies.add_installed_deps_path()
+  dependencies.add_preinstalled_deps_path()
+  dependencies.ensure_deps()
+  return None
 
 def on_startup_daemon_online_timer():
   """Run once when daemon is online after startup."""
@@ -268,7 +275,6 @@ def register_timers():
   It registers check_timers_timer which registers all other periodic non-ending timers.
   And individually it register all timers which are expected to end.
   """
-
   if bpy.app.background:
     return
 

--- a/utils.py
+++ b/utils.py
@@ -1169,3 +1169,25 @@ def list2string(lst: list) -> str:
         text += item + ", "
     return text[:-2]
 
+
+def check_globaldir_permissions():
+    """Check if the user has the required permissions to upload assets."""
+    global_dir = bpy.context.preferences.addons['blenderkit'].preferences.global_dir
+    if os.path.isfile(global_dir):
+        reports.add_report('Global dir is a file. Please remove it or change global dir path in preferences.', 10, type='ERROR')
+        return False
+    if not os.path.isdir(global_dir):
+        bk_logger.info(f'Global dir does not exist. Creating it at {global_dir}')
+        try:
+            os.mkdir(global_dir)
+        except Exception as e:
+            reports.add_report(f'Cannot create Global dir. Check global dir path in preferences. {e}', 10, type='ERROR')
+            return False
+
+    exists = os.access(global_dir, os.F_OK)
+    can_write = os.access(global_dir, os.W_OK)
+    can_execute = os.access(global_dir, os.X_OK)
+    if exists and can_write and can_execute:
+        bk_logger.info('Global dir permissions are OK.')
+        return True
+    reports.add_report(f'Change path or give permissions to Global dir, wrong permissions now: exists={exists}, write={can_write}, execute={can_execute}.', 15, type='ERROR')


### PR DESCRIPTION
fixes #419 

- prevent registration from failing when global_dir is not accessible by moving dependencies install into timer.on_startup_timer()
- add check for global_dir permissions with informative message to users
- put dependencies install into TRY with informative report to GUI on failure