### PR TITLE
Fix assetbar redraw

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1936,8 +1936,7 @@ If you use HTTPS proxy, set in format https://ip:port, or https://username:passw
         layout.prop(self, "search_in_header")
         layout.prop(self, "thumbnail_use_gpu")
 
-        if bpy.context.preferences.view.show_developer_ui:
-            layout.prop(self, "experimental_features")
+        layout.prop(self, "experimental_features")
         if utils.profile_is_validator():
             layout.prop(self, "categories_fix")
 

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -145,7 +145,7 @@ def modal_inside(self, context, event):
         if self.check_ui_resized(context) or self.check_new_search_results(context):
             self.update_ui_size(context)
             self.update_layout(context, event)
-            self.scroll_update() # one extra update for scroll for correct redraw, can test if still necessary
+            self.scroll_update(always=True) # one extra update for scroll for correct redraw, updates all buttons
 
 
         # this was here to check if sculpt stroke is running, but obviously that didn't help,

--- a/upload.py
+++ b/upload.py
@@ -930,7 +930,7 @@ class UploadOperator(Operator):
             layout.prop(self, 'thumbnail')
 
         if props.asset_base_id != '' and not self.reupload:
-            utils.label_multiline(layout, text="Really upload as new?"
+            utils.label_multiline(layout, text="Really upload as new?\n\n"
                                                "Do this only when you create a new asset from an old one.\n"
                                                "For updates of thumbnail or model use reupload.\n",
                                   width=400, icon='ERROR')


### PR DESCRIPTION
This was the case where assetbar wasn't updated correctly and did show wrong icons (both locks and bookmark icons) also don't hide experimental switch behind developer extras, that was too much fix some typos