### PR TITLE
#556 Improve feedback on deps installation failure

### DIFF
--- a/append_link.py
+++ b/append_link.py
@@ -57,13 +57,13 @@ def append_material(file_name, matname=None, link=False, fake_user=True):
                     data_to.materials = [m]
                     matname = m
                     found = True
-                    break;
+                    break
 
             #not found yet? probably some name inconsistency then.
             if not found and len(data_from.materials)>0:
                 data_to.materials = [data_from.materials[0]]
                 matname = data_from.materials[0]
-                bk_logger.warn(f"the material wasn't found under the exact name, appended another one: {matname}")
+                bk_logger.warning(f"the material wasn't found under the exact name, appended another one: {matname}")
 
     except Exception as e:
         bk_logger.error(f'{e} - failed to open the asset file')

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -159,7 +159,7 @@ def modal_inside(self, context, event):
                     bpy.context.window_manager['appendable'] = False
         return {"PASS_THROUGH"}
     except Exception as e:
-        bk_logger.warn(f'{e}')
+        bk_logger.warning(f'{e}')
         self.finish()
         return {'FINISHED'}
 
@@ -206,7 +206,7 @@ def mouse_down_right(self, x, y):
         try:
             self.mouse_down_right_func(self)
         except Exception as e:
-            bk_logger.warn(f'{e}')
+            bk_logger.warning(f'{e}')
 
         return True
 

--- a/categories.py
+++ b/categories.py
@@ -134,7 +134,7 @@ def handle_categories_task(task: tasks.Task):
     try:
       shutil.copy(source_path, categories_filepath)
     except Exception as e:
-      bk_logger.warn(f'Could not copy categories file: {e}')
+      bk_logger.warning(f'Could not copy categories file: {e}')
       return
 
   try:

--- a/dependencies.py
+++ b/dependencies.py
@@ -80,22 +80,22 @@ def ensure_deps():
     try:
       import aiohttp
     except Exception as e:
-      error = e
-      bk_logger.warn(f"Failed to import aiohttp: {e}")
+      exception = e
+      bk_logger.warning(f"Failed to import aiohttp: {e}")
       install_dependencies()
       continue
     try:
       import certifi
     except Exception as e:
       exception = e
-      bk_logger.warn(f"Failed to import certifi: {e}")
+      bk_logger.warning(f"Failed to import certifi: {e}")
       install_dependencies()
       continue
     try:
       from aiohttp import web, web_request
     except Exception as e:
       exception = e
-      bk_logger.warn(f"Failed to import aiohttp.web and aiohttp.web_request: {e}")
+      bk_logger.warning(f"Failed to import aiohttp.web and aiohttp.web_request: {e}")
       install_dependencies()
       continue
     return bk_logger.info("Dependencies are available")
@@ -112,20 +112,20 @@ def install_dependencies():
 
   command = [sys.executable, '-m', 'ensurepip', '--user']
   result = subprocess.run(command, env=env, capture_output=True, text=True)
-  bk_logger.warn(f"PIP INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
+  bk_logger.warning(f"PIP INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
 
   requirements = path.join(path.dirname(__file__), 'requirements.txt')
   command = [sys.executable, '-m', 'pip', 'install', '--upgrade', '-t', get_installed_deps_path(), '-r', requirements]
   result = subprocess.run(command, env=env, capture_output=True, text=True)
-  bk_logger.warn(f"AIOHTTP INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
+  bk_logger.warning(f"AIOHTTP INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
   if result.returncode == 0:
     bk_logger.info(f"Install succesfully finished in {time.time()-started}")
     return
 
-  bk_logger.warn("Install from requirements.txt failed, trying with unconstrained versions...")
+  bk_logger.warning("Install from requirements.txt failed, trying with unconstrained versions...")
   command = [sys.executable, '-m', 'pip', 'install', '--upgrade', '-t', get_installed_deps_path(), 'aiohttp', 'certifi']
   result = subprocess.run(command, env=env, capture_output=True, text=True)
-  bk_logger.warn(f"UNCONSTRAINED INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
+  bk_logger.warning(f"UNCONSTRAINED INSTALLATION:\ncommand {command} exited: {result.returncode},\nstdout: {result.stdout},\nstderr: {result.stderr}")
   if result.returncode == 0:
     bk_logger.info(f"Install succesfully finished in {time.time()-started}")
     return

--- a/paths.py
+++ b/paths.py
@@ -122,7 +122,7 @@ def get_temp_dir(subdir=None):
         cleanup_old_folders()
     except Exception as e:
         reports.add_report('Cache directory not found. Resetting Cache folder path.')
-        bk_logger.warn(f'due to exception: {e}')
+        bk_logger.warning(f'due to exception: {e}')
 
         p = default_global_dict()
         if p == user_preferences.global_dir:


### PR DESCRIPTION
fixes #556 

This is mostly cosmetic change which will however improve the way user is informed about dependencies import failure. For now it was mostly silent, so giving it some visibility should help the users to know that something is wrong and that they should seek for help.

- #93 installation can fail due to missing libcrypt.so.1, this should be shown to GUI
- other dependency imports should be also shown to GUI
- check and report imports for aiohttp and certifi separately