### PR TITLE
#399 check errors reported in JSON from server

### DIFF
--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -59,7 +59,7 @@ async def download_asset(request: web.Request):
     del data["app_id"]
 
     task = daemon_tasks.Task(
-        data, app_id, "asset_download", task_id, message="Looking for asset"
+        data, app_id, "asset_download", task_id=task_id, message="Looking for asset"
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(
@@ -79,7 +79,7 @@ async def search_assets(request: web.Request):
     del data["app_id"]
 
     task = daemon_tasks.Task(
-        data, app_id, "search", task_id, message="Searching assets"
+        data, app_id, "search", task_id=task_id, message="Searching assets"
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(daemon_search.do_search(request, task))
@@ -95,7 +95,11 @@ async def upload_asset(request: web.Request):
     app_id = data.pop("app_id")
 
     task = daemon_tasks.Task(
-        data, app_id, "asset_upload", task_id, message="Asset upload has started"
+        data,
+        app_id,
+        "asset_upload",
+        task_id=task_id,
+        message="Asset upload has started",
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(daemon_uploads.do_upload(request, task))

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -316,17 +316,17 @@ async def persistent_sessions(app):
 
     conn_api_requests = aiohttp.TCPConnector(ssl=sslcontext, limit=64, family=family)
     app["SESSION_API_REQUESTS"] = session_api_requests = aiohttp.ClientSession(
-        connector=conn_api_requests, trust_env=trust_env, raise_for_status=True
+        connector=conn_api_requests, trust_env=trust_env
     )
 
     conn_small_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=16, family=family)
     app["SESSION_SMALL_THUMBS"] = session_small_thumbs = aiohttp.ClientSession(
-        connector=conn_small_thumbs, trust_env=trust_env, raise_for_status=True
+        connector=conn_small_thumbs, trust_env=trust_env
     )
 
     conn_big_thumbs = aiohttp.TCPConnector(ssl=sslcontext, limit=8, family=family)
     app["SESSION_BIG_THUMBS"] = session_big_thumbs = aiohttp.ClientSession(
-        connector=conn_big_thumbs, trust_env=trust_env, raise_for_status=True
+        connector=conn_big_thumbs, trust_env=trust_env
     )
 
     timeout = aiohttp.ClientTimeout(total=24 * 60 * 60)  # 1 day
@@ -334,7 +334,6 @@ async def persistent_sessions(app):
     app["SESSION_ASSETS"] = session_assets = aiohttp.ClientSession(
         connector=conn_assets,
         trust_env=trust_env,
-        raise_for_status=True,
         timeout=timeout,
     )
 
@@ -342,7 +341,6 @@ async def persistent_sessions(app):
     app["SESSION_UPLOADS"] = session_uploads = aiohttp.ClientSession(
         connector=conn_uploads,
         trust_env=trust_env,
-        raise_for_status=True,
         timeout=timeout,
     )
 

--- a/daemon/daemon_assets.py
+++ b/daemon/daemon_assets.py
@@ -188,8 +188,8 @@ async def get_download_url(
         ) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get download URL"

--- a/daemon/daemon_comments.py
+++ b/daemon/daemon_comments.py
@@ -42,8 +42,8 @@ async def get_comments(request: web.Request, task: daemon_tasks.Task):
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
             return task.finished("comments downloaded")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
@@ -63,8 +63,8 @@ async def create_comment(request: web.Request, task: daemon_tasks.Task) -> bool:
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            comment_data = await resp.json()
             resp.raise_for_status()
+            comment_data = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "GET in create_comment"
@@ -91,8 +91,8 @@ async def create_comment(request: web.Request, task: daemon_tasks.Task) -> bool:
         async with session.post(url, headers=headers, data=post_data) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "POST in create_comment"
@@ -123,8 +123,8 @@ async def feedback_comment(request: web.Request, task: daemon_tasks.Task):
         async with session.post(url, data=data, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "POST comment feedback"
@@ -153,8 +153,8 @@ async def mark_comment_private(request: web.Request, task: daemon_tasks.Task) ->
         async with session.post(url, data=data, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Mark comment failed"
@@ -193,11 +193,11 @@ async def mark_notification_read(request: web.Request, task: daemon_tasks.Task) 
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
-            return task.finished("notification marked as read")
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Mark notification as read failed"
         )
         return task.error(msg, message_detailed=detail)
+    return task.finished("notification marked as read")

--- a/daemon/daemon_comments.py
+++ b/daemon/daemon_comments.py
@@ -3,7 +3,6 @@
 import asyncio
 from logging import getLogger
 
-import aiohttp
 import daemon_globals
 import daemon_tasks
 import daemon_utils
@@ -39,15 +38,16 @@ async def get_comments(request: web.Request, task: daemon_tasks.Task):
     session = request.app["SESSION_API_REQUESTS"]
     url = f"{daemon_globals.SERVER}/api/v1/comments/assets-uuidasset/{asset_id}/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_read
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("comments downloaded")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get comments failed"
+            e, resp_text, resp_status, "Get comments failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -59,14 +59,15 @@ async def create_comment(request: web.Request, task: daemon_tasks.Task) -> bool:
     session = request.app["SESSION_API_REQUESTS"]
     url = f"{daemon_globals.SERVER}/api/v1/comments/asset-comment/{asset_id}/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_get
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            comment_data = resp_json = await resp.json()
+            comment_data = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, comment_data, "GET in create_comment"
+            e, resp_text, resp_status, "GET in create_comment"
         )
         task.error(msg, message_detailed=detail)
         return False
@@ -86,14 +87,15 @@ async def create_comment(request: web.Request, task: daemon_tasks.Task) -> bool:
     }
     url = f"{daemon_globals.SERVER}/api/v1/comments/comment/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_comment_create
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.post(url, headers=headers, data=post_data) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "POST in create_comment"
+            e, resp_text, resp_status, "POST in create_comment"
         )
         task.error(msg, message_detailed=detail)
         return False
@@ -117,14 +119,15 @@ async def feedback_comment(request: web.Request, task: daemon_tasks.Task):
     }
     url = f"{daemon_globals.SERVER}/api/v1/comments/feedback/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_feedback_create
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.post(url, data=data, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "POST comment feedback"
+            e, resp_text, resp_status, "POST comment feedback"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -146,14 +149,15 @@ async def mark_comment_private(request: web.Request, task: daemon_tasks.Task) ->
         f'{daemon_globals.SERVER}/api/v1/comments/is_private/{task.data["comment_id"]}/'
     )
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_feedback_create
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.post(url, data=data, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Mark comment failed"
+            e, resp_text, resp_status, "Mark comment failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -185,14 +189,15 @@ async def mark_notification_read(request: web.Request, task: daemon_tasks.Task) 
     session = request.app["SESSION_API_REQUESTS"]
     url = f'{daemon_globals.SERVER}/api/v1/notifications/mark-as-read/{task.data["notification_id"]}/'
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/comments_feedback_create
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("notification marked as read")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Mark notification as read failed"
+            e, resp_text, resp_status, "Mark notification as read failed"
         )
         return task.error(msg, message_detailed=detail)

--- a/daemon/daemon_disclaimer.py
+++ b/daemon/daemon_disclaimer.py
@@ -65,11 +65,11 @@ async def get_notifications(request: web.Request):
             f"{daemon_globals.SERVER}/api/v1/notifications/unread/", headers=headers
         ) as resp:
             resp_text = await resp.text()
-            task.result = resp_json= await resp.json()
+            task.result = resp_json = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_json, "Get notifications failed"
         )
         return task.error(msg, message_detailed=detail)
-        
+
     return task.finished("Notifications retrieved")

--- a/daemon/daemon_disclaimer.py
+++ b/daemon/daemon_disclaimer.py
@@ -7,7 +7,7 @@ from logging import getLogger
 import daemon_globals
 import daemon_tasks
 import daemon_utils
-from aiohttp import ClientResponseError, web
+from aiohttp import web
 
 
 logger = getLogger(__name__)
@@ -27,13 +27,13 @@ async def get_disclaimer(request: web.Request) -> None:
     daemon_globals.tasks.append(task)
     headers = daemon_utils.get_headers(data["api_key"])
     session = request.app["SESSION_API_REQUESTS"]
-    try:
+    url = f"{daemon_globals.SERVER}/api/v1/disclaimer/active/"
+    try:  # https://www.blenderkit.com/api/v1/docs/#operation/disclaimer_active_list
         resp_text, resp_json = None, None
-        async with session.get(
-            f"{daemon_globals.SERVER}/api/v1/disclaimer/active/", headers=headers
-        ) as resp:
+        async with session.get(url, headers=headers) as resp:
             resp_text = await resp.text()
             resp_json = await resp.json()
+            resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_json, "Get disclaimer failed"
@@ -59,13 +59,13 @@ async def get_notifications(request: web.Request):
     daemon_globals.tasks.append(task)
     headers = daemon_utils.get_headers(data["api_key"])
     session = request.app["SESSION_API_REQUESTS"]
-    try:
+    url = f"{daemon_globals.SERVER}/api/v1/notifications/unread/"
+    try:  # https://www.blenderkit.com/api/v1/docs/#operation/notifications_unread_list
         resp_text, resp_json = None, None
-        async with session.get(
-            f"{daemon_globals.SERVER}/api/v1/notifications/unread/", headers=headers
-        ) as resp:
+        async with session.get(url, headers=headers) as resp:
             resp_text = await resp.text()
             task.result = resp_json = await resp.json()
+            resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_json, "Get notifications failed"

--- a/daemon/daemon_disclaimer.py
+++ b/daemon/daemon_disclaimer.py
@@ -33,8 +33,8 @@ async def get_disclaimer(request: web.Request) -> None:
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get disclaimer failed"
@@ -66,12 +66,11 @@ async def get_notifications(request: web.Request):
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get notifications failed"
         )
         return task.error(msg, message_detailed=detail)
-
     return task.finished("Notifications retrieved")

--- a/daemon/daemon_disclaimer.py
+++ b/daemon/daemon_disclaimer.py
@@ -29,14 +29,15 @@ async def get_disclaimer(request: web.Request) -> None:
     session = request.app["SESSION_API_REQUESTS"]
     url = f"{daemon_globals.SERVER}/api/v1/disclaimer/active/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/disclaimer_active_list
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
             resp_json = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get disclaimer failed"
+            e, resp_text, resp_status, "Get disclaimer failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -61,14 +62,15 @@ async def get_notifications(request: web.Request):
     session = request.app["SESSION_API_REQUESTS"]
     url = f"{daemon_globals.SERVER}/api/v1/notifications/unread/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/notifications_unread_list
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get notifications failed"
+            e, resp_text, resp_status, "Get notifications failed"
         )
         return task.error(msg, message_detailed=detail)
 

--- a/daemon/daemon_oauth.py
+++ b/daemon/daemon_oauth.py
@@ -36,7 +36,7 @@ async def get_tokens(
     headers = daemon_utils.get_headers()
     url = f"{daemon_globals.SERVER}/o/token/"
     try:
-        resp_text, resp_json, resp_status = None, None, -1
+        resp_text, resp_status = None, -1
         async with session.post(url, data=data, headers=headers) as response:
             resp_status = response.status
             resp_text = await response.text()
@@ -46,7 +46,7 @@ async def get_tokens(
             return resp_json, resp_status, ""
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get download URL"
+            e, resp_text, resp_status, "Get download URL"
         )
         logger.warning(detail)
         return resp_json, resp_status, msg

--- a/daemon/daemon_oauth.py
+++ b/daemon/daemon_oauth.py
@@ -37,11 +37,11 @@ async def get_tokens(
     url = f"{daemon_globals.SERVER}/o/token/"
     try:
         resp_text, resp_status = None, -1
-        async with session.post(url, data=data, headers=headers) as response:
-            resp_status = response.status
-            resp_text = await response.text()
-            resp_json = await response.json()
-            response.raise_for_status()
+        async with session.post(url, data=data, headers=headers) as resp:
+            resp_status = resp.status
+            resp_text = await resp.text()
+            resp.raise_for_status()
+            resp_json = await resp.json()
             logger.info("Token retrieval OK.")
             return resp_json, resp_status, ""
     except Exception as e:

--- a/daemon/daemon_profiles.py
+++ b/daemon/daemon_profiles.py
@@ -103,8 +103,8 @@ async def get_user_profile(task: daemon_tasks.Task, request: web.Request) -> Non
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get profile"

--- a/daemon/daemon_profiles.py
+++ b/daemon/daemon_profiles.py
@@ -99,14 +99,15 @@ async def get_user_profile(task: daemon_tasks.Task, request: web.Request) -> Non
     session = request.app["SESSION_API_REQUESTS"]
     url = f"{daemon_globals.SERVER}/api/v1/me/"
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/me_list
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
             resp_json = await resp.json()
             resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get profile"
+            e, resp_text, resp_status, "Get profile"
         )
         return task.error(msg, message_detailed=detail)
 

--- a/daemon/daemon_profiles.py
+++ b/daemon/daemon_profiles.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 import daemon_globals
 import daemon_tasks
 import daemon_utils
-from aiohttp import ClientResponseError, web
+from aiohttp import web
 
 
 logger = getLogger(__name__)
@@ -96,13 +96,14 @@ async def get_user_profile(task: daemon_tasks.Task, request: web.Request) -> Non
     """Get profile data for currently logged-in user. Data are cleaned a little bit and then reported to the add-on."""
     api_key = task.data["api_key"]
     headers = daemon_utils.get_headers(api_key)
-    url = f"{daemon_globals.SERVER}/api/v1/me/"
     session = request.app["SESSION_API_REQUESTS"]
-    try:
+    url = f"{daemon_globals.SERVER}/api/v1/me/"
+    try:  # https://www.blenderkit.com/api/v1/docs/#operation/me_list
         resp_text, resp_json = None, None
         async with session.get(url, headers=headers) as resp:
             resp_text = await resp.text()
             resp_json = await resp.json()
+            resp.raise_for_status()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_json, "Get profile"

--- a/daemon/daemon_ratings.py
+++ b/daemon/daemon_ratings.py
@@ -26,17 +26,16 @@ async def get_rating(task: daemon_tasks.Task, request: web.Request) -> None:
     headers = daemon_utils.get_headers(task.data.get("api_key", ""))
     url = f'{daemon_globals.SERVER}/api/v1/assets/{task.data["asset_id"]}/rating/'
     try:
+        resp_text, resp_json = None, None
         async with session.get(url, headers=headers) as resp:
-            task.result = await resp.json()
+            resp_text = await resp.text()
+            task.result = resp_json = await resp.json()
             return task.finished("Rating data obtained")
-    except ClientResponseError as e:
-        logger.warning(
-            f'ClientResponseError: {e.message} ({e.status}) on {e.request_info.method} to "{e.request_info.real_url}", headers:{e.headers}, history:{e.history}'
-        )
-        return task.error(f"Get rating failed: {e.message} ({e.status})")
     except Exception as e:
-        logger.warning(f"{type(e)}: {e}")
-        return task.error(f"Get rating {type(e)}: {e}")
+        msg, detail = daemon_utils.extract_error_message(
+            e, resp_text, resp_json, "Get rating failed"
+        )
+        return task.error(msg, message_detailed=detail)
 
 
 async def send_rating_handler(request: web.Request):
@@ -69,17 +68,16 @@ async def send_rating(task: daemon_tasks.Task, request: web.Request) -> None:
         f'Sending rating {task.data["rating_type"]}={task.data["rating_value"]} for asset {task.data["asset_id"]}'
     )
     try:
+        resp_text, resp_json = None, None
         async with session.put(url, headers=headers, json=data) as resp:
-            task.result = await resp.json()
+            resp_text = await resp.text()
+            task.result = resp_json = await resp.json()
             return task.finished("Rating uploaded")
-    except ClientResponseError as e:
-        logger.warning(
-            f'ClientResponseError: {e.message} ({e.status}) on {e.request_info.method} to "{e.request_info.real_url}", headers:{e.headers}, history:{e.history}'
-        )
-        return task.error(f"Send rating failed: {e.message} ({e.status})")
     except Exception as e:
-        logger.warning(f"{type(e)}: {e}")
-        return task.error(f"Send rating {type(e)}: {e}")
+        msg, detail = daemon_utils.extract_error_message(
+            e, resp_text, resp_json, "Send rating failed"
+        )
+        return task.error(msg, message_detailed=detail)
 
 
 async def delete_rating(task: daemon_tasks.Task, request: web.Request) -> None:
@@ -91,19 +89,18 @@ async def delete_rating(task: daemon_tasks.Task, request: web.Request) -> None:
         f'Deleting rating {task.data["rating_type"]}={task.data["rating_value"]} for asset {task.data["asset_id"]}'
     )
     try:
+        resp_text, resp_json = None, None
         async with session.delete(url, headers=headers) as resp:
-            task.result = await resp.json()
+            resp_text = await resp.text()
+            task.result = resp_json = await resp.json()
             return task.finished(
                 "Rating uploaded"
             )  # TODO can we rename to rating deleted?
-    except ClientResponseError as e:
-        logger.warning(
-            f'ClientResponseError: {e.message} ({e.status}) on {e.request_info.method} to "{e.request_info.real_url}", headers:{e.headers}, history:{e.history}'
-        )
-        return task.error(f"Delete rating failed: {e.message} ({e.status})")
     except Exception as e:
-        logger.warning(f"{type(e)}: {e}")
-        return task.error(f"Delete rating {type(e)}: {e}")
+        msg, detail = daemon_utils.extract_error_message(
+            e, resp_text, resp_json, "Delete rating failed"
+        )
+        return task.error(msg, message_detailed=detail)
 
 
 async def get_bookmarks_handler(request: web.Request):
@@ -122,14 +119,13 @@ async def get_bookmarks(task: daemon_tasks.Task, request: web.Request) -> None:
     headers = daemon_utils.get_headers(task.data.get("api_key", ""))
     url = f"{daemon_globals.SERVER}/api/v1/search/?query=bookmarks_rating:1"
     try:
+        resp_text, resp_json = None, None
         async with session.get(url, headers=headers) as resp:
-            task.result = await resp.json()
+            resp_text = await resp.text()
+            task.result = resp_json = await resp.json()
             return task.finished("Bookmarks data obtained")
-    except ClientResponseError as e:
-        logger.warning(
-            f'ClientResponseError: {e.message} ({e.status}) on {e.request_info.method} to "{e.request_info.real_url}", headers:{e.headers}, history:{e.history}'
-        )
-        return task.error(f"Get bookmarks failed: {e.message} ({e.status})")
     except Exception as e:
-        logger.warning(f"{type(e)}: {e}")
-        return task.error(f"Get bookmarks {type(e)}: {e}")
+        msg, detail = daemon_utils.extract_error_message(
+            e, resp_text, resp_json, "Get bookmarks failed"
+        )
+        return task.error(msg, message_detailed=detail)

--- a/daemon/daemon_ratings.py
+++ b/daemon/daemon_ratings.py
@@ -26,15 +26,16 @@ async def get_rating(task: daemon_tasks.Task, request: web.Request) -> None:
     headers = daemon_utils.get_headers(task.data.get("api_key", ""))
     url = f'{daemon_globals.SERVER}/api/v1/assets/{task.data["asset_id"]}/rating/'
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/assets_rating_list
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("Rating data obtained")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get rating failed"
+            e, resp_text, resp_status, "Get rating failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -68,15 +69,16 @@ async def send_rating(task: daemon_tasks.Task, request: web.Request) -> None:
     )
     url = f'{daemon_globals.SERVER}/api/v1/assets/{task.data["asset_id"]}/rating/{task.data["rating_type"]}/'
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/assets_rating_update
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.put(url, headers=headers, json=data) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("Rating uploaded")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Send rating failed"
+            e, resp_text, resp_status, "Send rating failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -89,15 +91,16 @@ async def delete_rating(task: daemon_tasks.Task, request: web.Request) -> None:
     )
     url = f'{daemon_globals.SERVER}/api/v1/assets/{task.data["asset_id"]}/rating/{task.data["rating_type"]}/'
     try:  # https://www.blenderkit.com/api/v1/docs/#operation/assets_rating_delete
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.delete(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("rating deleted")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Delete rating failed"
+            e, resp_text, resp_status, "Delete rating failed"
         )
         return task.error(msg, message_detailed=detail)
 
@@ -118,14 +121,15 @@ async def get_bookmarks(task: daemon_tasks.Task, request: web.Request) -> None:
     headers = daemon_utils.get_headers(task.data.get("api_key", ""))
     url = f"{daemon_globals.SERVER}/api/v1/search/?query=bookmarks_rating:1"
     try:
-        resp_text, resp_json = None, None
+        resp_text, resp_status = None, -1
         async with session.get(url, headers=headers) as resp:
+            resp_status = resp.status
             resp_text = await resp.text()
-            task.result = resp_json = await resp.json()
+            task.result = await resp.json()
             resp.raise_for_status()
             return task.finished("Bookmarks data obtained")
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_json, "Get bookmarks failed"
+            e, resp_text, resp_status, "Get bookmarks failed"
         )
         return task.error(msg, message_detailed=detail)

--- a/daemon/daemon_ratings.py
+++ b/daemon/daemon_ratings.py
@@ -30,14 +30,14 @@ async def get_rating(task: daemon_tasks.Task, request: web.Request) -> None:
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
-            return task.finished("Rating data obtained")
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get rating failed"
         )
         return task.error(msg, message_detailed=detail)
+    return task.finished("Rating data obtained")
 
 
 async def send_rating_handler(request: web.Request):
@@ -73,14 +73,14 @@ async def send_rating(task: daemon_tasks.Task, request: web.Request) -> None:
         async with session.put(url, headers=headers, json=data) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
-            return task.finished("Rating uploaded")
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Send rating failed"
         )
         return task.error(msg, message_detailed=detail)
+    return task.finished("Rating uploaded")
 
 
 async def delete_rating(task: daemon_tasks.Task, request: web.Request) -> None:
@@ -95,14 +95,14 @@ async def delete_rating(task: daemon_tasks.Task, request: web.Request) -> None:
         async with session.delete(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
-            return task.finished("rating deleted")
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Delete rating failed"
         )
         return task.error(msg, message_detailed=detail)
+    return task.finished("rating deleted")
 
 
 async def get_bookmarks_handler(request: web.Request):
@@ -125,11 +125,11 @@ async def get_bookmarks(task: daemon_tasks.Task, request: web.Request) -> None:
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
-            return task.finished("Bookmarks data obtained")
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get bookmarks failed"
         )
         return task.error(msg, message_detailed=detail)
+    return task.finished("Bookmarks data obtained")

--- a/daemon/daemon_search.py
+++ b/daemon/daemon_search.py
@@ -150,8 +150,8 @@ async def do_search(request: web.Request, task: daemon_tasks.Task):
         async with session.get(task.data["urlquery"], headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            task.result = await resp.json()
             resp.raise_for_status()
+            task.result = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Search failed"
@@ -183,8 +183,8 @@ async def fetch_categories(request: web.Request) -> None:
         async with session.get(url, headers=headers) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get categories failed"

--- a/daemon/daemon_search.py
+++ b/daemon/daemon_search.py
@@ -144,7 +144,7 @@ async def do_search(request: web.Request, task: daemon_tasks.Task):
     headers = daemon_utils.get_headers(task.data["PREFS"]["api_key"])
     session = request.app["SESSION_API_REQUESTS"]
     try:
-        resp_text, resp_json = None,  None
+        resp_text, resp_json = None, None
         async with session.get(task.data["urlquery"], headers=headers) as resp:
             resp_text = await resp.text()
             task.result = resp_json = await resp.json()

--- a/daemon/daemon_tasks.py
+++ b/daemon/daemon_tasks.py
@@ -13,6 +13,7 @@ class Task:
         task_type: str,
         task_id: str = "",
         message: str = "",
+        message_detailed: str = "",
         progress: int = 0,
         status: str = "created",
         result: dict = {},
@@ -26,6 +27,7 @@ class Task:
         self.task_type = task_type
 
         self.message = message
+        self.message_detailed = message_detailed
         self.progress = progress
         self.status = status  # created / finished / error
         self.result = result.copy()
@@ -39,10 +41,12 @@ class Task:
         if status != "":
             self.status = status
 
-    def error(self, message: str, progress: int = -1):
+    def error(self, message: str, message_detailed: str = "", progress: int = -1):
         """End the task with error."""
-        self.message = message
         self.status = "error"
+        self.message = message
+        if message_detailed != "":
+            self.message_detailed = message_detailed
         if progress != -1:
             self.progress = progress
 

--- a/daemon/daemon_uploads.py
+++ b/daemon/daemon_uploads.py
@@ -69,9 +69,7 @@ async def upload_metadata(session: ClientSession, task: daemon_tasks.Task):
     if export_data["assetBaseId"] == "":
         try:
             resp_text, resp_json = None, None
-            async with session.post(
-                url, json=json_metadata, headers=headers
-            ) as resp:
+            async with session.post(url, json=json_metadata, headers=headers) as resp:
                 resp_text = await resp.text()
                 resp_json = await resp.json()
                 logger.info(f"Got response ({resp.status}) for {url}")

--- a/daemon/daemon_uploads.py
+++ b/daemon/daemon_uploads.py
@@ -73,9 +73,9 @@ async def upload_metadata(session: ClientSession, task: daemon_tasks.Task):
             async with session.post(url, json=json_metadata, headers=headers) as resp:
                 resp_status = resp.status
                 resp_text = await resp.text()
-                resp_json = await resp.json()
-                logger.info(f"Got response ({resp.status}) for {url}")
                 resp.raise_for_status()
+                logger.info(f"Got response ({resp.status}) for {url}")
+                resp_json = await resp.json()
                 return "", resp_json
         except Exception as e:
             msg, detail = daemon_utils.extract_error_message(
@@ -92,9 +92,9 @@ async def upload_metadata(session: ClientSession, task: daemon_tasks.Task):
         async with session.patch(url, json=json_metadata, headers=headers) as response:
             resp_status = response.status
             resp_text = await response.text()
-            resp_json = await response.json()
-            logger.info(f"Got response ({response.status}) for {url}")
             response.raise_for_status()
+            logger.info(f"Got response ({response.status}) for {url}")
+            resp_json = await response.json()
             return "", resp_json
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
@@ -246,8 +246,8 @@ async def get_S3_upload_JSON(
         resp_text, resp_json = None, None
         async with session.post(url, json=upload_info, headers=headers) as resp:
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
             return resp_json, True
     except Exception as e:
         logger.error(f"{type(e)}: {e}, {resp_text}, {resp_json}")

--- a/daemon/daemon_utils.py
+++ b/daemon/daemon_utils.py
@@ -202,8 +202,8 @@ async def blocking_request_handler(request: web.Request):
         ) as resp:
             resp_status = resp.status
             resp_text = await resp.text()
-            resp_json = await resp.json()
             resp.raise_for_status()
+            resp_json = await resp.json()
             return web.json_response(resp_json)
     except ClientResponseError as e:
         logger.warning(
@@ -243,8 +243,8 @@ async def make_request(request: web.Request, task: daemon_tasks.Task):
         ) as resp:
             resp_text = await resp.text()
             if resp.content_type == "application/json":
-                resp_json = await resp.json()
                 resp.raise_for_status()
+                resp_json = await resp.json()
                 task.result = resp_json
             else:
                 resp.raise_for_status()

--- a/upload.py
+++ b/upload.py
@@ -122,7 +122,7 @@ def check_missing_data(asset_type, props):
             f"can not be  longer than 40 letters.\n",
         )
     if len(props.name) > 40:
-        write_to_report(props, f"The name is too long. maximum is 40 letters")
+        write_to_report(props, "The name is too long. maximum is 40 letters")
 
     if (
         props.category == "NONE"
@@ -195,8 +195,6 @@ def get_upload_data(caller=None, context=None, asset_type=None):
 
     """
     user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    api_key = user_preferences.api_key
-
     export_data = {
         # "type": asset_type,
     }
@@ -235,8 +233,6 @@ def get_upload_data(caller=None, context=None, asset_type=None):
         style = props.style.lower()
         # if style == 'OTHER':
         #     style = props.style_other.lower()
-
-        pl_dict = {"FINISHED": "finished", "TEMPLATE": "template"}
 
         upload_data = {
             "assetType": "model",
@@ -325,8 +321,6 @@ def get_upload_data(caller=None, context=None, asset_type=None):
         style = props.style.lower()
         # if style == 'OTHER':
         #     style = props.style_other.lower()
-
-        pl_dict = {"FINISHED": "finished", "TEMPLATE": "template"}
 
         upload_data = {
             "assetType": "scene",
@@ -500,7 +494,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
     add_version(upload_data)
 
     # caller can be upload operator, but also asset bar called from tooltip generator
-    if caller and caller.properties.main_file == True:
+    if caller and caller.properties.main_file is True:
         upload_data["name"] = props.name
         upload_data["displayName"] = props.name
     else:
@@ -650,8 +644,6 @@ class FastMetadata(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        scene = bpy.context.scene
-        ui_props = bpy.context.window_manager.blenderkitUI
         return True
 
     def draw(self, context):
@@ -1029,7 +1021,6 @@ class UploadOperator(Operator):
             return {"CANCELLED"}
 
         if self.asset_type == "HDR":
-            props = utils.get_upload_props()
             # getting upload data for images ensures true_hdr check so users can be informed about their handling
             # simple 360 photos or renders with LDR are hidden by default..
             export_data, upload_data = get_upload_data(asset_type="HDR")
@@ -1058,8 +1049,6 @@ class AssetDebugPrint(Operator):
         return True
 
     def execute(self, context):
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
-
         if not global_vars.DATA["search results"]:
             print("no search results found")
             return {"CANCELLED"}
@@ -1151,16 +1140,14 @@ class AssetVerificationStatusChange(Operator):
 
 def handle_asset_upload(task: daemon_tasks.Task):
     asset = eval(f"{task.data['export_data']['eval_path']}.blenderkit")
-
     asset.upload_state = f"{task.progress}% - {task.message}"
-
     if task.status == "error":
         asset.uploading = False
-        return reports.add_report(f"Upload has failed: {task.message}", type="ERROR")
+        return reports.add_report(task.message, type="ERROR")
 
     if task.status == "finished":
         asset.uploading = False
-        return reports.add_report(f"Upload successfull")
+        return reports.add_report("Upload successfull")
 
 
 def handle_asset_metadata_upload(task: daemon_tasks.Task):


### PR DESCRIPTION
Hopefully this PR finally find the right way how to handle errors for requests:

1. it makes a request
2. saves resp_status and resp_text
3. if needed resp.json() is called by the function
4. !! runs resp.raise_for_status() which will raise Exception if status code was >= 400

5. in except we call function which extracts meaningful error message from: resp_text, resp_status and Exception, it works like:

- tries to convert resp_text into JSON,
- if JSON is doable, it tries to get "details" and from details get all keys and values (this is how server reports errors)
- if JSON is present, but details are not, this is probably error from S3 or other service and JSON as string is just used
- if JSON is not present, it combines information from Exception and from resp_text