### PR TITLE
Fix upload in case not all textures are packed correctly.

### DIFF
--- a/upload_bg.py
+++ b/upload_bg.py
@@ -72,10 +72,14 @@ if __name__ == "__main__":
             main_source = append_link.append_brush(
                 file_name=export_data["source_filepath"], brushname=brushname
             )
+        e1=None
         try:
+            # this needs to be in try statement because blender throws an error if not all textures aren't packed,
+            # and we want to ignore that. Blender sometimes wants to pack textures that aren't actually needed
+            # and are somehow still in the project.
             bpy.ops.file.pack_all()
-        except Exception as e:
-            print(e)
+        except Exception as e1:
+            print(e1)
 
         main_source.blenderkit.uploading = False
         # write ID here.
@@ -90,10 +94,17 @@ if __name__ == "__main__":
         if bpy.app.version >= (3, 0, 0):
             bpy.context.preferences.filepaths.file_preview_type = "NONE"
 
-        bpy.ops.wm.save_as_mainfile(filepath=fpath, compress=True, copy=False)
+        e2=None
+        try:
+            # this needs to be in try statement because blender throws an error if not all textures aren't packed,
+            # and we want to ignore that. Blender sometimes wants to pack textures that aren't actually needed
+            # and are somehow still in the project. The problem might be when file isn't saved for reasons like full disk,
+            # but it's much more rare.
+            bpy.ops.wm.save_as_mainfile(filepath=fpath, compress=True, copy=False)
+        except Exception as e2:
+            print(e2)
         os.remove(export_data["source_filepath"])
 
     except Exception as e:
         print(e)
-        # bg_blender.progress(e)
         sys.exit(1)

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -25,9 +25,7 @@ import bpy
 
 from blenderkit import append_link
 
-
 BLENDERKIT_EXPORT_DATA = sys.argv[-1]
-
 
 if __name__ == "__main__":
     try:
@@ -72,7 +70,6 @@ if __name__ == "__main__":
             main_source = append_link.append_brush(
                 file_name=export_data["source_filepath"], brushname=brushname
             )
-        e1=None
         try:
             # this needs to be in try statement because blender throws an error if not all textures aren't packed,
             # and we want to ignore that. Blender sometimes wants to pack textures that aren't actually needed
@@ -94,7 +91,6 @@ if __name__ == "__main__":
         if bpy.app.version >= (3, 0, 0):
             bpy.context.preferences.filepaths.file_preview_type = "NONE"
 
-        e2=None
         try:
             # this needs to be in try statement because blender throws an error if not all textures aren't packed,
             # and we want to ignore that. Blender sometimes wants to pack textures that aren't actually needed

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -25,6 +25,7 @@ import bpy
 
 from blenderkit import append_link
 
+
 BLENDERKIT_EXPORT_DATA = sys.argv[-1]
 
 if __name__ == "__main__":
@@ -75,8 +76,8 @@ if __name__ == "__main__":
             # and we want to ignore that. Blender sometimes wants to pack textures that aren't actually needed
             # and are somehow still in the project.
             bpy.ops.file.pack_all()
-        except Exception as e1:
-            print(e1)
+        except Exception as e:
+            print(f"Exception {type(e)} during pack_all(): {e}")
 
         main_source.blenderkit.uploading = False
         # write ID here.
@@ -97,10 +98,9 @@ if __name__ == "__main__":
             # and are somehow still in the project. The problem might be when file isn't saved for reasons like full disk,
             # but it's much more rare.
             bpy.ops.wm.save_as_mainfile(filepath=fpath, compress=True, copy=False)
-        except Exception as e2:
-            print(e2)
+        except Exception as e:
+            print(f"Exception {type(e)} during save_as_mainfile(): {e}")
         os.remove(export_data["source_filepath"])
-
     except Exception as e:
-        print(e)
+        print(f"Exception {type(e)} in upload_bg.py: {e}")
         sys.exit(1)


### PR DESCRIPTION
This is a blender issue where blender sometimes wants to pack textures that aren't actually needed and are somehow still in the project. This prevented upload completely, where the task of the creator is to check correct upload anyway. Not sure how to pass a warning to the user, since it's all in a bg process that is run from daemon.