### PR TITLE
Enable uppercase in search. The question is why it was disabled

### DIFF
--- a/search.py
+++ b/search.py
@@ -658,11 +658,11 @@ def query_to_url(query={}, params={}):
     requeststring = "?query="
     #
     if query.get("query") not in ("", None):
-        requeststring += query["query"].lower()
+        requeststring += query["query"]#.lower()
     for i, q in enumerate(query):
         if q != "query" and q != "free_first":
             requeststring += "+"
-            requeststring += q + ":" + str(query[q]).lower()
+            requeststring += q + ":" + str(query[q])#.lower()
 
     # add dict_parameters to make results smaller
     # result ordering: _score - relevance, score - BlenderKit score


### PR DESCRIPTION
I think in the start, it badly influenced the search results, but now Ican't find any difference between upper/lower case search. Uppercase is needed if you want to try manually some parameters in the search