### PR TITLE
#702 Add property for search field width, clean preferences menu

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1898,11 +1898,18 @@ class BlenderKitAddonPreferences(AddonPreferences):
     )
 
     global_dir: StringProperty(
-        name="Global Files Directory",
-        description="Global storage for your assets, will use subdirectories for the contents. Daemon will place its files in subdirectory 'daemon'.",
+        name="Global Directory",
+        description="Global storage for your assets, will use subdirectories for the contents. Daemon will place its files in subdirectory 'daemon'",
         subtype="DIR_PATH",
         default=default_global_dict,
         update=utils.save_prefs,
+    )
+
+    project_subdir: StringProperty(
+        name="Project Subdirectory",
+        description="Subdirectory for asset data storage in the project (provide relative path)",
+        default="//assets",
+        update=fix_subdir,
     )
 
     daemon_port: EnumProperty(
@@ -1920,14 +1927,6 @@ class BlenderKitAddonPreferences(AddonPreferences):
         ),
         default="62485",
         update=timer.save_prefs_cancel_all_tasks_and_restart_daemon,
-    )
-
-    project_subdir: StringProperty(
-        name="Project Assets Subdirectory",
-        description="where data will be stored for individual projects",
-        # subtype='DIR_PATH',
-        default="//assets",
-        update=fix_subdir,
     )
 
     unpack_files: BoolProperty(
@@ -2106,7 +2105,7 @@ In this case you should also set path to your system CA bundle containing proxy 
         min=0,
         max=100,
         update=utils.save_prefs,
-        description="Width of the search field in the assetbar in 3D view. 0 means automatic width.",
+        description="Width of the search field in the assetbar in 3D view. 0 means automatic width",
     )
 
     # counts usages so it can encourage user after some time to do things.
@@ -2126,7 +2125,7 @@ In this case you should also set path to your system CA bundle containing proxy 
 
     asset_popup_counter: IntProperty(
         name="Asset Popup Card Counter",
-        description="Counts Asset popup card counter. To enable hiding of the tooltip after some time.",
+        description="Counts Asset popup card counter. To enable hiding of the tooltip after some time",
         default=0,
         min=0,
         max=6,
@@ -2206,10 +2205,10 @@ We welcome your feedback. If you encounter any issues or have ideas for improvem
         if utils.profile_is_validator():
             layout.prop(self, "categories_fix")
 
-        # LOCATIONS SETTINGS
+        # FILE PATHS
         locations_settings = layout.box()
         locations_settings.alignment = "EXPAND"
-        locations_settings.label(text="Locations settings")
+        locations_settings.label(text="File paths")
         locations_settings.prop(self, "directory_behaviour")
         locations_settings.prop(self, "global_dir")
         if self.directory_behaviour in ("BOTH", "LOCAL"):

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy, A. Gajdosik",
-    "version": (3, 7, 0, 230601),  # X.Y.Z.yymmdd
+    "version": (3, 8, 0, 230622),  # X.Y.Z.yymmdd
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Online BlenderKit library (materials, models, brushes and more). Connects to the internet.",

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -43,6 +43,12 @@ def get_daemon_directory_path() -> str:
     return path.abspath(directory)
 
 
+def get_daemon_log_path() -> str:
+    """Get path to daemon log file in blenderkit_data directory."""
+    log_path = path.join(get_daemon_directory_path(), f"daemon-{get_port()}.log")
+    return path.abspath(log_path)
+
+
 def get_reports(app_id: str, api_key=""):
     """Get reports for all tasks of app_id Blender instance at once.
     If few last calls failed, then try to get reports also from other than default ports.
@@ -500,7 +506,7 @@ def check_daemon_exit_code() -> tuple[int, str]:
 def start_daemon_server():
     """Start daemon server in separate process."""
     daemon_dir = get_daemon_directory_path()
-    log_path = f"{daemon_dir}/daemon-{get_port()}.log"
+    log_path = get_daemon_log_path()
     blenderkit_path = path.dirname(__file__)
     daemon_path = path.join(blenderkit_path, "daemon/daemon.py")
     preinstalled_deps = dependencies.get_preinstalled_deps_path()

--- a/timer.py
+++ b/timer.py
@@ -83,7 +83,7 @@ def daemon_communication_timer():
         return handle_failed_reports(e)
 
     if global_vars.DAEMON_ACCESSIBLE is False:
-        reports.add_report(f"Daemon is running on port {global_vars.DAEMON_PORTS[0]}!")
+        bk_logger.info(f"Daemon is running on port {global_vars.DAEMON_PORTS[0]}!")
         global_vars.DAEMON_ACCESSIBLE = True
         wm = bpy.context.window_manager
         wm.blenderkitUI.logo_status = "logo"

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -157,14 +157,6 @@ def draw_upload_common(layout, props, asset_type, context):
         layout.prop(props, "tags")
 
 
-def poll_local_panels():
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    return (
-        user_preferences.panel_behaviour == "BOTH"
-        or user_preferences.panel_behaviour == "LOCAL"
-    )
-
-
 def prop_needed(layout, props, name, value="", is_not_filled=""):
     row = layout.row()
     if value == is_not_filled:
@@ -638,8 +630,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
                 "wm.url_open", text="See my uploads", icon="URL"
             ).url = paths.BLENDERKIT_USER_ASSETS_URL
 
-        if user_preferences.enable_oauth:
-            draw_login_buttons(layout)
+        draw_login_buttons(layout)
 
         addon_updater_ops.update_notice_box_ui(self, context)
 
@@ -1020,15 +1011,12 @@ class VIEW3D_PT_blenderkit_login(Panel):
         if not global_vars.DAEMON_RUNNING:
             layout.label(text="Daemon not running")
             return
-
         user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-
         if user_preferences.login_attempt:
             draw_login_progress(layout)
             return
 
-        if user_preferences.enable_oauth:
-            draw_login_buttons(layout)
+        draw_login_buttons(layout)
 
 
 def draw_panel_material_upload(self, context):
@@ -1489,14 +1477,6 @@ class VIEW3D_PT_blenderkit_unified(Panel):
     }
     bl_label = ""
 
-    @classmethod
-    def poll(cls, context):
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-        return (
-            user_preferences.panel_behaviour == "BOTH"
-            or user_preferences.panel_behaviour == "UNIFIED"
-        )
-
     def draw_header(self, context):
         layout = self.layout
         ui_props = bpy.context.window_manager.blenderkitUI
@@ -1560,15 +1540,7 @@ class VIEW3D_PT_blenderkit_unified(Panel):
             return
 
         if len(user_preferences.api_key) < 20 and user_preferences.asset_counter > 20:
-            if user_preferences.enable_oauth:
-                draw_login_buttons(layout)
-            else:
-                op = layout.operator(
-                    "wm.url_open", text="Get your API Key", icon="QUESTION"
-                )
-                op.url = paths.BLENDERKIT_SIGNUP_URL
-                layout.label(text="Paste your API Key:")
-                layout.prop(user_preferences, "api_key", text="")
+            draw_login_buttons(layout)
             layout.separator()
         # if bpy.data.filepath == '':
         #     layout.alert = True
@@ -3283,6 +3255,12 @@ def header_search_draw(self, context):
     row = layout.row()
     if (context.region.width) > 700:
         row.ui_units_x = 5 + int(context.region.width / 200)
+    search_field_width = bpy.context.preferences.addons[
+        "blenderkit"
+    ].preferences.search_field_width
+    if search_field_width > 0:
+        row.ui_units_x = search_field_width
+
     row.prop(props, "search_keywords", text="", icon="VIEWZOOM")
 
     draw_assetbar_show_hide(layout, props)

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3266,11 +3266,13 @@ def header_search_draw(self, context):
     draw_assetbar_show_hide(layout, props)
     if utils.experimental_enabled():
         layout.prop(ui_props, "search_bookmarks", text="", icon="BOOKMARKS")
-    if props.search_category == ui_props.asset_type.lower() or props.search_category=="":
+    if (
+        props.search_category == ui_props.asset_type.lower()
+        or props.search_category == ""
+    ):
         icon_id = pcoll["categories"].icon_id
     else:
         icon_id = pcoll["categories_active"].icon_id
-
 
     layout.popover(
         panel="VIEW3D_PT_blenderkit_categories",


### PR DESCRIPTION
fixes #702 

- groups preferences into three groups: locations settings, gui settings and networking settings, beside that there are login stuff in the begining and autoupdater in the end.
- adds greyed list of important paths in the end of preferences - users will know which directories to delete to clean the add-on, or for whatever other reasons, I think this could be quite useful.
- adds option to set search field width - default 0 keeps the width automatic, anything higher sets it to fixed value.
- removes some unused properties