### PR TITLE
#733 Improve handling of timed out API key token

### DIFF
--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -145,12 +145,6 @@ async def consumer_exchange(request: web.Request):
     return web.HTTPPermanentRedirect(redirect_url)
 
 
-async def refresh_token(request: web.Request):
-    atask = asyncio.ensure_future(daemon_oauth.refresh_tokens(request))
-    atask.add_done_callback(daemon_tasks.handle_async_errors)
-    return web.Response(text="ok")
-
-
 async def subscribe_new_addon(request: web.Request, data: dict):
     """Subscribe new add-on into list of active applications.
     Also run all tasks which are needed on add-on startup - will be reported back to add-on once finished.
@@ -421,7 +415,7 @@ if __name__ == "__main__":
             web.view("/shutdown", shutdown),
             web.view("/report_blender_quit", report_blender_quit),
             web.get("/consumer/exchange/", consumer_exchange),
-            web.get("/refresh_token", refresh_token),
+            web.get("/refresh_token", daemon_oauth.refresh_token),
             web.post("/code_verifier", code_verifier),
             web.post("/report_usages", daemon_assets.report_usages_handler),
             web.post("/comments/{func}", daemon_comments.comments_handler),

--- a/daemon/daemon_assets.py
+++ b/daemon/daemon_assets.py
@@ -152,7 +152,7 @@ async def download_asset(
 
     except Exception as e:
         msg, detail = daemon_utils.extract_error_message(
-            e, resp_text, resp_status, "Get download URL"
+            e, resp_text, resp_status, "Download asset"
         )
         task.error(msg, message_detailed=detail)
         return False

--- a/daemon/daemon_globals.py
+++ b/daemon/daemon_globals.py
@@ -24,3 +24,6 @@ VERSION = None
 code_verifier = None
 active_apps = []
 last_report_time: float = time()
+
+token_refresh_list = []
+"""List of tokens for which the refreshing is in progress."""

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -414,13 +414,19 @@ def send_code_verifier(code_verifier: str):
         return resp
 
 
-def refresh_token(refresh_token):
-    """Refresh authentication token."""
+def refresh_token(refresh_token, old_api_key):
+    """Refresh authentication token. Daemon will use refresh token to get new API key token to replace the old_api_key.
+    old_api_key is used later to replace token only in Blender instances with the same api_key. (User can be logged into multiple accounts.)
+    """
+    bk_logger.info("Calling API token refresh")
     with requests.Session() as session:
         url = get_address() + "/refresh_token"
         resp = session.get(
             url,
-            json={"refresh_token": refresh_token},
+            json={
+                "refresh_token": refresh_token,
+                "old_api_key": old_api_key,
+            },
             timeout=TIMEOUT,
             proxies=NO_PROXIES,
         )

--- a/search.py
+++ b/search.py
@@ -119,18 +119,9 @@ def undo_pre_end_assetbar(context):
 
 @persistent
 def scene_load(context):
-    """Load categories , check timers registration, and update scene asset data.
+    """Load categories, check timers registration, and update scene asset data.
     Should (probably) also update asset data from server (after user consent).
     """
-    if (
-        not bpy.app.timers.is_registered(bkit_oauth.refresh_token_timer)
-        and not bpy.app.background
-    ):
-        bpy.app.timers.register(
-            bkit_oauth.refresh_token_timer, persistent=True, first_interval=5
-        )
-        # bpy.app.timers.register(bkit_oauth.refresh_token_timer, persistent=True, first_interval=36000)
-
     update_assets_data()
 
 
@@ -316,7 +307,7 @@ def handle_search_task_error(task: daemon_tasks.Task) -> None:
     if len(search_tasks) == 0:
         props = utils.get_search_props()
         props.is_searching = False
-    return reports.add_report(task.message, 15, "ERROR")
+    return reports.add_report(task.message, 5, "ERROR")
 
 
 def handle_search_task(task: daemon_tasks.Task) -> bool:


### PR DESCRIPTION
fixes #733 

- refresh preventively 3 days before token expiration
- if any request fails due to wrong API key and refresh does not exist, unlog
- if refresh key exist, try to refresh and get fresh new tokens
- if refresh fails, unlog the user
- do not request refresh from server with same refresh token 2 times