### PR TITLE
#746 Use background Blenders with --factory-startup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -182,8 +182,11 @@ def scene_load(context):
     ui_props.turn_off = False
     if global_vars.DAEMON_ACCESSIBLE:
         ui_props.logo_status = "logo"
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    preferences.login_attempt = False
+    if (
+        bpy.app.factory_startup is False
+    ):  # factory_start is used in bg blender runs, but we want to run for tests in background mode
+        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences.login_attempt = False
 
 
 conditions = (
@@ -2276,7 +2279,6 @@ classes = (
 
 def register():
     reload(global_vars)
-    global_vars.VERSION = bl_info["version"]
     bpy.utils.register_class(BlenderKitAddonPreferences)
 
     addon_updater_ops.register(bl_info)
@@ -2327,10 +2329,12 @@ def register():
         type=BlenderKitBrushUploadProps
     )
 
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    global_vars.PREFS = utils.get_prefs_dir()
-    daemon_lib.reorder_ports(user_preferences.daemon_port)
-    utils.set_proxy()
+    global_vars.VERSION = bl_info["version"]
+    if bpy.app.factory_startup is False:
+        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        global_vars.PREFS = utils.get_prefs_dir()
+        daemon_lib.reorder_ports(user_preferences.daemon_port)
+        utils.set_proxy()
 
     search.register_search()
     asset_inspector.register_asset_inspector()
@@ -2347,7 +2351,6 @@ def register():
     tasks_queue.register()
     asset_bar_op.register()
     disclaimer_op.register()
-
     timer.register_timers()
 
     bpy.app.handlers.load_post.append(scene_load)

--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -28,7 +28,8 @@ import bpy
 from blenderkit import append_link, bg_blender, bg_utils, daemon_lib, utils
 
 
-BLENDERKIT_EXPORT_DATA = sys.argv[-1]
+BLENDERKIT_EXPORT_DATA = sys.argv[-2]
+BLENDERKIT_EXPORT_API_KEY = sys.argv[-1]
 
 
 def get_obnames():
@@ -86,8 +87,7 @@ if __name__ == "__main__":
     try:
         with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:
             data = json.load(s)
-
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        thumbnail_use_gpu = data.get("thumbnail_use_gpu")
 
         if data.get("do_download"):
             # if this isn't here, blender crashes.
@@ -101,7 +101,7 @@ if __name__ == "__main__":
             bg_blender.progress("Downloading asset")
             asset_data = data["asset_data"]
             has_url, asset_data = daemon_lib.get_download_url(
-                asset_data, utils.get_scene_id(), user_preferences.api_key
+                asset_data, utils.get_scene_id(), BLENDERKIT_EXPORT_API_KEY
             )
             if has_url is not True:
                 bg_blender.progress(
@@ -109,7 +109,7 @@ if __name__ == "__main__":
                 )
             bg_blender.progress("downloading asset")
             fpath = bg_utils.download_asset_file(
-                asset_data, api_key=user_preferences.api_key
+                asset_data, api_key=BLENDERKIT_EXPORT_API_KEY
             )
             data["filepath"] = fpath
             main_object, allobs = append_link.link_collection(
@@ -139,7 +139,7 @@ if __name__ == "__main__":
         bpy.context.scene.camera = bpy.data.objects[camdict[data["thumbnail_snap_to"]]]
         center_obs_for_thumbnail(allobs)
         bpy.context.scene.render.filepath = data["thumbnail_path"]
-        if user_preferences.thumbnail_use_gpu:
+        if thumbnail_use_gpu is True:
             bpy.context.scene.cycles.device = "GPU"
 
         fdict = {
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             file = {"type": "thumbnail", "index": 0, "file_path": fpath}
             upload_data = {
                 "name": data["asset_data"]["name"],
-                "token": user_preferences.api_key,
+                "token": BLENDERKIT_EXPORT_API_KEY,
                 "id": data["asset_data"]["id"],
             }
             bg_utils.upload_file(upload_data, file)

--- a/daemon/daemon_assets.py
+++ b/daemon/daemon_assets.py
@@ -314,6 +314,9 @@ async def send_to_bg(data, fpath, command="generate_resolutions", wait=True):
 
     args = [
         "--background",
+        "--factory-startup",  # disables user preferences, addons, etc.
+        "--addons",
+        "blenderkit",
         "-noaudio",
         # "--no-addons",
         fpath,

--- a/daemon/daemon_uploads.py
+++ b/daemon/daemon_uploads.py
@@ -145,6 +145,9 @@ async def pack_blend_file(task: daemon_tasks.Task, metadata_response: dict):
             process = await asyncio.create_subprocess_exec(
                 export_data["binary_path"],
                 "--background",
+                "--factory-startup",  # disables user preferences, addons, etc.
+                "--addons",
+                "blenderkit",
                 "-noaudio",
                 cleanfile_path,
                 "--python",

--- a/download.py
+++ b/download.py
@@ -1398,7 +1398,6 @@ def register_download():
     bpy.utils.register_class(BlenderkitKillDownloadOperator)
     bpy.app.handlers.load_post.append(scene_load)
     bpy.app.handlers.save_pre.append(scene_save)
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
 
 
 def unregister_download():

--- a/tasks_queue.py
+++ b/tasks_queue.py
@@ -32,10 +32,10 @@ bk_logger = logging.getLogger(__name__)
 
 @persistent
 def scene_load(context):
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    if not bpy.app.background:
-        if not (bpy.app.timers.is_registered(queue_worker)):
-            bpy.app.timers.register(queue_worker)
+    if bpy.app.background is True:
+        return
+    if not (bpy.app.timers.is_registered(queue_worker)):
+        bpy.app.timers.register(queue_worker)
 
 
 def get_queue():

--- a/test.py
+++ b/test.py
@@ -9,6 +9,7 @@ runner = unittest.TextTestRunner()
 suite = unittest.TestSuite()
 testLoader = unittest.TestLoader()
 
+suite.addTests(testLoader.discover(".", "test_init.py"))
 suite.addTests(testLoader.discover(".", "test_timer.py"))
 suite.addTests(testLoader.discover(".", "test_paths.py"))
 suite.addTests(testLoader.discover(".", "test_daemon_lib.py"))

--- a/test_init.py
+++ b/test_init.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+
+import bpy
+
+import blenderkit
+from blenderkit import global_vars
+
+
+class Test01Registration(unittest.TestCase):
+    def test01_global_vars_VERSION_set(self):
+        assert global_vars.VERSION is not None
+        assert global_vars.VERSION == blenderkit.bl_info["version"]
+
+    def test02_global_vars_PREFS_set(self):
+        assert global_vars.PREFS != {}
+        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        prefs = {
+            "debug_value": bpy.app.debug_value,
+            "binary_path": bpy.app.binary_path,
+            "api_key": user_preferences.api_key,
+            "api_key_refresh": user_preferences.api_key_refresh,
+            "system_id": user_preferences.system_id,
+            "global_dir": user_preferences.global_dir,
+            "project_subdir": user_preferences.project_subdir,
+            "directory_behaviour": user_preferences.directory_behaviour,
+            "is_saved": user_preferences.directory_behaviour,
+            "app_id": os.getpid(),
+            "ip_version": user_preferences.ip_version,
+            "ssl_context": user_preferences.ssl_context,
+            "proxy_which": user_preferences.proxy_which,
+            "proxy_address": user_preferences.proxy_address,
+            "proxy_ca_certs": user_preferences.proxy_ca_certs,
+            "unpack_files": user_preferences.unpack_files,
+            "models_resolution": user_preferences.models_resolution,
+            "mat_resolution": user_preferences.mat_resolution,
+            "hdr_resolution": user_preferences.hdr_resolution,
+        }
+        assert global_vars.PREFS == prefs

--- a/timer.py
+++ b/timer.py
@@ -291,7 +291,7 @@ def check_timers_timer():
 
 
 def on_startup_timer():
-    """Run once on the startup of add-on."""
+    """Run once on the startup of add-on (Blender start with enabled add-on, add-on enabled)."""
     addon_updater_ops.check_for_update_background()
     utils.check_globaldir_permissions()
     utils.ensure_system_ID()
@@ -326,7 +326,7 @@ def on_startup_daemon_online_timer():
 
 
 def register_timers():
-    """Registers all timers.
+    """Register all timers if add-on is not running in background (thumbnail rendering, upload, unpacking and also tests).
     It registers check_timers_timer which registers all other periodic non-ending timers.
     And individually it register all timers which are expected to end.
     """
@@ -347,9 +347,7 @@ def register_timers():
 def unregister_timers():
     """Unregister all timers at the very start of unregistration.
     This prevents the timers being called before the unregistration finishes.
-    Also reports unregistration to daemon.
     """
-
     if bpy.app.background:
         return
 

--- a/ui.py
+++ b/ui.py
@@ -1237,8 +1237,9 @@ def pre_load(context):
     ui_props = bpy.context.window_manager.blenderkitUI
     ui_props.assetbar_on = False
     ui_props.turn_off = True
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
-    preferences.login_attempt = False
+    # TODO: is this needed?
+    # preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    # preferences.login_attempt = False
 
 
 def register_ui():

--- a/utils.py
+++ b/utils.py
@@ -373,6 +373,7 @@ def get_active_brush():
     return brush
 
 
+# TODO: unused, remove?
 def load_XXXXXXXXXXXX_prefs():
     user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
     wm = bpy.context.window_manager
@@ -413,6 +414,7 @@ def get_scene_id():
     return bpy.context.scene["uuid"]
 
 
+# TODO: not used, remove with its setting in get_prefs_dir()?
 def save_resolutions(self, context):
     wm = bpy.context.window_manager
     user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
@@ -431,7 +433,7 @@ def get_prefs_dir():
     wm.blenderkit_models.resolution = user_preferences.models_resolution
     wm.blenderkit_mat.resolution = user_preferences.mat_resolution
     wm.blenderkit_HDR.resolution = user_preferences.hdr_resolution
-
+    # TODO: wm.blenderkit_models.resolution is not accessible, is it needed?
     prefs = {
         "debug_value": bpy.app.debug_value,
         "binary_path": bpy.app.binary_path,
@@ -465,32 +467,34 @@ def set_proxy():
 
 def save_prefs(self, context):
     # first check context, so we don't do this on registration or blender startup
-    if not bpy.app.background:  # (hasattr kills blender)
-        # print('saving prefs')
-        bpy.ops.wm.save_userpref()
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
-        # we test the api key for length, so not a random accidentally typed sequence gets saved.
-        lk = len(user_preferences.api_key)
-        if 0 < lk < 25:
-            # reset the api key in case the user writes some nonsense, e.g. a search string instead of the Key
-            user_preferences.api_key = ""
-            props = get_search_props()
-            props.report = "Login failed. Please paste a correct API Key."
-
-        prefs = get_prefs_dir()
-        global_vars.PREFS = prefs
-        set_proxy()
-
+    if bpy.app.background is True:  # (hasattr kills blender)
         return
-        try:
-            fpath = paths.BLENDERKIT_SETTINGS_FILENAME
 
-            if not os.path.exists(paths._presets):
-                os.makedirs(paths._presets)
-            with open(fpath, "w", encoding="utf-8") as s:
-                json.dump(prefs, s, ensure_ascii=False, indent=4)
-        except Exception as e:
-            print(e)
+    # print('saving prefs')
+    bpy.ops.wm.save_userpref()
+    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    # we test the api key for length, so not a random accidentally typed sequence gets saved.
+    lk = len(user_preferences.api_key)
+    if 0 < lk < 25:
+        # reset the api key in case the user writes some nonsense, e.g. a search string instead of the Key
+        user_preferences.api_key = ""
+        props = get_search_props()
+        props.report = "Login failed. Please paste a correct API Key."
+
+    prefs = get_prefs_dir()
+    global_vars.PREFS = prefs
+    set_proxy()
+
+    return
+    try:
+        fpath = paths.BLENDERKIT_SETTINGS_FILENAME
+
+        if not os.path.exists(paths._presets):
+            os.makedirs(paths._presets)
+        with open(fpath, "w", encoding="utf-8") as s:
+            json.dump(prefs, s, ensure_ascii=False, indent=4)
+    except Exception as e:
+        print(e)
 
 
 def uploadable_asset_poll():


### PR DESCRIPTION
fixes #746 

- starts background Blender instances with `--factory-startup` flag, which disables all non-default add-ons and ignores user preferences - this makes the Blender in background independent of individual user's configurations, addons, makes stable platform form our renderings of thumbnails, unpacking etc...
- uses flag `--addons blenderkit` to enable BlenderKit in the background Blender
- for some reason BlenderKit is not in list of enabled addons, meaning we cannot access preferences - so there are few changes so all code executed in the background (aka with --factory-startup) does not call preferences, uses bpy.app.factory_startup to detect situations when we need to turn off using preferences, using bpy.app.background was crashing the tests (as tests needed to use preferences which were saved to global_vars during registration)
- removes some unused code in the log.py
- adds tests


tested on: Blender 3.0.1, 3.6.1, 4.0.0-alpha