### PR TITLE
#749 Use different tempdir for every user

### DIFF
--- a/daemon/daemon_profiles.py
+++ b/daemon/daemon_profiles.py
@@ -3,6 +3,7 @@ TODO: We should find a better vocabulary for this.
 """
 
 import asyncio
+import getpass
 import os
 import tempfile
 from logging import getLogger
@@ -52,8 +53,13 @@ async def fetch_gravatar_image(task: daemon_tasks.Task, request: web.Request):
     if "avatar128" not in task.data:
         return fetch_gravatar_image_old(task, request)
 
+    username = getpass.getuser()
+    safe_username = "".join(c for c in username if c.isalnum())
     gravatar_path = os.path.join(
-        tempfile.gettempdir(), "bkit_temp", "bkit_g", f'{task.data["id"]}.jpg'
+        tempfile.gettempdir(),
+        f"bktemp_{safe_username}",
+        "bkit_g",
+        f'{task.data["id"]}.jpg',
     )
     if os.path.exists(gravatar_path):
         task.result = {"gravatar_path": gravatar_path}
@@ -73,8 +79,13 @@ async def fetch_gravatar_image_old(task: daemon_tasks.Task, request: web.Request
     """Older way of getting gravatar image. May be needed for some users with old gravatars."""  # TODO: is this still in use?
     if task.data.get("gravatarHash") is None:
         return
+    username = getpass.getuser()
+    safe_username = "".join(c for c in username if c.isalnum())
     gravatar_path = os.path.join(
-        tempfile.gettempdir(), "bkit_temp", "bkit_g", f'{task.data["gravatarHash"]}.jpg'
+        tempfile.gettempdir(),
+        f"bktemp_{safe_username}",
+        "bkit_g",
+        f'{task.data["gravatarHash"]}.jpg',
     )
     if os.path.exists(gravatar_path):
         task.result = {"gravatar_path": gravatar_path}

--- a/paths.py
+++ b/paths.py
@@ -16,6 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+import getpass
 import logging
 import os
 import shutil
@@ -24,7 +25,7 @@ import tempfile
 
 import bpy
 
-from . import daemon_lib, global_vars, reports, tasks_queue, utils
+from . import daemon_lib, global_vars, reports, utils
 
 
 bk_logger = logging.getLogger(__name__)
@@ -105,9 +106,9 @@ def get_temp_dir(subdir=None):
         d = dirs_exist_dict.get("top")
         if d is not None:
             return d
-
-    # tempdir = user_preferences.temp_dir
-    tempdir = os.path.join(tempfile.gettempdir(), "bkit_temp")
+    username = getpass.getuser()
+    safe_username = "".join(c for c in username if c.isalnum())
+    tempdir = os.path.join(tempfile.gettempdir(), f"bktemp_{safe_username}")
     if tempdir.startswith("//"):
         tempdir = bpy.path.abspath(tempdir)
     try:


### PR DESCRIPTION
fixes #749 

- rename bkit_temp to bktemp_<username>
- adds username to BlenderKit temp directory, so two user can't share the same directory
- use only alpha numeric characters from the username
- fixes problem for UNIX, where default tempdir was /tmp for every user, now /tmp/bktemp_<username>