### PR TITLE
#755 Fix broken check for newer asset version

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1028,15 +1028,19 @@ def asset_from_newer_blender_version(asset_data):
     asset_ver = asset_data["sourceAppVersion"].split(".")
     while len(asset_ver) < 3:
         asset_ver.append("0")
+
     if bpy.app.version[0] < int(asset_ver[0]):
         return True, "major"
+    elif bpy.app.version[0] > int(asset_ver[0]):
+        return False, ""
 
     if bpy.app.version[1] < int(asset_ver[1]):
         return True, "minor"
+    elif bpy.app.version[1] > int(asset_ver[1]):
+        return False, ""
 
     if bpy.app.version[2] < int(asset_ver[2]):
         return True, "patch"
-
     return False, ""
 
 


### PR DESCRIPTION
fixes #755 

- if major version of running Blender is higher than asset's, return False and do not check more
- if minor version is higher, return False and not check more