### PR TITLE
#667 Catch asyncio task giving CancelledError when calling task.exception()

### DIFF
--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -66,6 +66,7 @@ async def download_asset(request: web.Request):
     task.async_task = asyncio.ensure_future(
         daemon_assets.do_asset_download(request, task)
     )
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
 
     return web.json_response({"task_id": task_id})
@@ -84,6 +85,7 @@ async def search_assets(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(daemon_search.do_search(request, task))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
 
     return web.json_response({"task_id": task_id})
@@ -104,6 +106,7 @@ async def upload_asset(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(daemon_uploads.do_upload(request, task))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
 
     return web.json_response({"task_id": task_id})
@@ -151,9 +154,11 @@ async def subscribe_new_addon(request: web.Request, data: dict):
     """
     daemon_globals.active_apps.append(data["app_id"])
     disclaimer_task = asyncio.ensure_future(daemon_disclaimer.get_disclaimer(request))
+    disclaimer_task.set_name(f"get_disclaimer-{data['app_id']}")
     disclaimer_task.add_done_callback(daemon_tasks.handle_async_errors)
 
     categories_task = asyncio.ensure_future(daemon_search.fetch_categories(request))
+    categories_task.set_name(f"fetch_categories-{data['app_id']}")
     categories_task.add_done_callback(daemon_tasks.handle_async_errors)
     if data["api_key"] == "":
         return  # everything done, if not logged in
@@ -161,6 +166,7 @@ async def subscribe_new_addon(request: web.Request, data: dict):
     notifications_task = asyncio.ensure_future(
         daemon_disclaimer.get_notifications(request)
     )
+    notifications_task.set_name(f"get_notifications-{data['app_id']}")
     notifications_task.add_done_callback(daemon_tasks.handle_async_errors)
 
 

--- a/daemon/daemon_assets.py
+++ b/daemon/daemon_assets.py
@@ -145,9 +145,6 @@ async def download_asset(
                         message=f"Downloading {t} {task.data['resolution']}",
                     )
                     file.write(chunk)
-                    # if globals.tasks[data['task_id']].get('kill'):
-                    #   delete_unfinished_file(file_path)
-                    #   return
                 return True
 
     except Exception as e:
@@ -418,6 +415,7 @@ async def report_usages_handler(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(report_usages(request, task))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 

--- a/daemon/daemon_comments.py
+++ b/daemon/daemon_comments.py
@@ -27,6 +27,7 @@ async def comments_handler(request: web.Request):
     elif func == "mark_comment_private":
         task.async_task = asyncio.ensure_future(mark_comment_private(request, task))
 
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.json_response({"task_id": task.task_id})
 
@@ -105,8 +106,13 @@ async def create_comment(request: web.Request, task: daemon_tasks.Task) -> bool:
         task.data, task.data["app_id"], "comments/get_comments"
     )
     daemon_globals.tasks.append(followup_task)
-    get_comments_task = asyncio.ensure_future(get_comments(request, followup_task))
-    get_comments_task.add_done_callback(daemon_tasks.handle_async_errors)
+    followup_task.async_task = asyncio.ensure_future(
+        get_comments(request, followup_task)
+    )
+    followup_task.async_task.set_name(
+        f"{followup_task.task_type}-{followup_task.task_id}"
+    )
+    followup_task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
 
 
 async def feedback_comment(request: web.Request, task: daemon_tasks.Task):
@@ -136,8 +142,13 @@ async def feedback_comment(request: web.Request, task: daemon_tasks.Task):
         task.data, task.data["app_id"], "comments/get_comments"
     )
     daemon_globals.tasks.append(followup_task)
-    get_comments_task = asyncio.ensure_future(get_comments(request, followup_task))
-    get_comments_task.add_done_callback(daemon_tasks.handle_async_errors)
+    followup_task.async_task = asyncio.ensure_future(
+        get_comments(request, followup_task)
+    )
+    followup_task.async_task.set_name(
+        f"{followup_task.task_type}-{followup_task.task_id}"
+    )
+    followup_task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
 
 
 async def mark_comment_private(request: web.Request, task: daemon_tasks.Task) -> None:
@@ -166,8 +177,13 @@ async def mark_comment_private(request: web.Request, task: daemon_tasks.Task) ->
         task.data, task.data["app_id"], "comments/get_comments"
     )
     daemon_globals.tasks.append(followup_task)
-    get_comments_task = asyncio.ensure_future(get_comments(request, followup_task))
-    get_comments_task.add_done_callback(daemon_tasks.handle_async_errors)
+    followup_task.async_task = asyncio.ensure_future(
+        get_comments(request, followup_task)
+    )
+    followup_task.async_task.set_name(
+        f"{followup_task.task_type}-{followup_task.task_id}"
+    )
+    followup_task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return None
 
 
@@ -179,6 +195,7 @@ async def mark_notification_read_handler(request: web.Request) -> web.Response:
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(mark_notification_read(request, task))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.json_response({"task_id": task.task_id})
 

--- a/daemon/daemon_oauth.py
+++ b/daemon/daemon_oauth.py
@@ -3,6 +3,7 @@
 import asyncio
 import typing
 from logging import getLogger
+from uuid import uuid4
 
 import daemon_globals
 import daemon_tasks
@@ -93,5 +94,6 @@ async def refresh_tokens(request: web.Request) -> None:
 async def refresh_token(request: web.Request):
     """Create asyncio task for refreshal of the API key token of the add-on."""
     atask = asyncio.ensure_future(refresh_tokens(request))
+    atask.set_name(f"refresh_token-{uuid4()}")
     atask.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")

--- a/daemon/daemon_profiles.py
+++ b/daemon/daemon_profiles.py
@@ -28,6 +28,7 @@ async def fetch_gravatar_image_handler(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(fetch_gravatar_image(task, request))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 
@@ -42,6 +43,7 @@ async def get_user_profile_handler(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(get_user_profile(task, request))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 

--- a/daemon/daemon_ratings.py
+++ b/daemon/daemon_ratings.py
@@ -17,6 +17,7 @@ async def get_rating_handler(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(get_rating(task, request))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 
@@ -56,6 +57,7 @@ async def send_rating_handler(request: web.Request):
         task.async_task = asyncio.ensure_future(delete_rating(task, request))
     else:
         task.async_task = asyncio.ensure_future(send_rating(task, request))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 
@@ -121,6 +123,7 @@ async def get_bookmarks_handler(request: web.Request):
     )
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(get_bookmarks(task, request))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.Response(text="ok")
 

--- a/daemon/daemon_utils.py
+++ b/daemon/daemon_utils.py
@@ -225,6 +225,7 @@ async def nonblocking_request_handler(request: web.Request):
     task = daemon_tasks.Task(data, data["app_id"], "wrappers/nonblocking_request")
     daemon_globals.tasks.append(task)
     task.async_task = asyncio.ensure_future(make_request(request, task))
+    task.async_task.set_name(f"{task.task_type}-{task.task_id}")
     task.async_task.add_done_callback(daemon_tasks.handle_async_errors)
     return web.json_response({"task_id": task.task_id})
 


### PR DESCRIPTION
fixes #667 

not really fixing the #667 as the download sometimes continues after network is reconnected, but sometimes it does not continue and fails after a while. We would need really sofisticated code to handle this, which we might add in the future. During the investigation I've found some ways to improve, which I add in this PR.

- catching the asyncio.CancelledError in handle_async_errors
- set_name for all asyncio tasks, so they are tied with the daemon.Task
- in comments async tasks was not save into daemon.task.async_task, setting it now so they can error the task on failure
