### PR TITLE
#754 Enable Bookmarks outside experimental features

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2145,13 +2145,8 @@ In this case you should also set path to your system CA bundle containing proxy 
     )
 
     experimental_features: BoolProperty(
-        name="Enable experimental features: Bookmarks",
-        description="""Enable experimental features of BlenderKit:
-
-BOOKMARKS:
-This feature lets logged-in users save their favorite assets and search for them later. To mark or unmark an asset, click on the bookmark icon located in the top right corner of the asset thumbnail. You can filter search results to display only bookmarked assets by clicking on the bookmark icon in the search panel.
-
-We welcome your feedback. If you encounter any issues or have ideas for improvements, please let us know. However, please note that these experimental features may not function as expected""",
+        name="Enable experimental features",
+        description="""Enable experimental features of BlenderKit. There are no experimental features available in this version.""",
         default=False,
         update=utils.save_prefs,
     )
@@ -2208,7 +2203,6 @@ We welcome your feedback. If you encounter any issues or have ideas for improvem
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "show_on_start")
         if self.api_key.strip() == "":
             ui_panels.draw_login_buttons(layout)
         else:
@@ -2232,6 +2226,7 @@ We welcome your feedback. If you encounter any issues or have ideas for improvem
         gui_settings = layout.box()
         gui_settings.alignment = "EXPAND"
         gui_settings.label(text="GUI settings")
+        gui_settings.prop(self, "show_on_start")
         gui_settings.prop(self, "thumb_size")
         gui_settings.prop(self, "max_assetbar_rows")
         gui_settings.prop(self, "search_field_width")
@@ -2253,6 +2248,8 @@ We welcome your feedback. If you encounter any issues or have ideas for improvem
 
         # UPDATER SETTINGS
         addon_updater_ops.update_settings_ui(self, context)
+
+        # RUNTIME INFO
         addondir_row = layout.row()
         addondir_row.label(text=f"Installed at: {path.dirname(__file__)}")
         addondir_row.enabled = False

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1137,8 +1137,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             self.tooltip_panel.set_location(tooltip_x, tooltip_y)
             self.tooltip_panel.layout_widgets()
             # show bookmark button - always on mouse enter
-            if utils.experimental_enabled():
-                widget.bookmark_button.visible = True
+            widget.bookmark_button.visible = True
 
             # bpy.ops.wm.blenderkit_asset_popup('INVOKE_DEFAULT')
 
@@ -1204,9 +1203,6 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         search.search(get_next=True)
 
     def update_bookmark_icon(self, bookmark_button):
-        if not utils.experimental_enabled():
-            bookmark_button.visible = False
-            return
         asset_data = global_vars.DATA["search results"][bookmark_button.asset_index]
         r = ratings_utils.get_rating_local(asset_data["id"], "bookmarks")
         if r == 1:

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1169,8 +1169,7 @@ class VIEW3D_PT_blenderkit_advanced_model_search(Panel):
         # if props.search_engine == 'OTHER':
         #     layout.prop(props, "search_engine_keyword")
         row = layout.row()
-        if utils.experimental_enabled():
-            row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
+        row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
         row = layout.row()
         layout.prop(ui_props, "free_only")
@@ -1249,8 +1248,7 @@ class VIEW3D_PT_blenderkit_advanced_material_search(Panel):
         layout.separator()
 
         row = layout.row()
-        if utils.experimental_enabled():
-            row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
+        row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
 
         layout.label(text="Texture:")
@@ -1300,8 +1298,7 @@ class VIEW3D_PT_blenderkit_advanced_scene_search(Panel):
         layout.separator()
 
         row = layout.row()
-        if utils.experimental_enabled():
-            row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
+        row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
 
         layout.prop(ui_props, "free_only")
@@ -1335,8 +1332,7 @@ class VIEW3D_PT_blenderkit_advanced_HDR_search(Panel):
         layout.separator()
 
         row = layout.row()
-        if utils.experimental_enabled():
-            row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
+        row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
         layout.prop(ui_props, "free_only")
         layout.prop(props, "true_hdr")
@@ -1365,8 +1361,7 @@ class VIEW3D_PT_blenderkit_advanced_brush_search(Panel):
         layout.separator()
 
         row = layout.row()
-        if utils.experimental_enabled():
-            row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
+        row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
         layout.prop(ui_props, "free_only")
 
@@ -1701,13 +1696,10 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
 
 def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
     ui_props = context.window_manager.blenderkitUI
-
     author_id = str(asset_data["author"].get("id"))
-    wm = bpy.context.window_manager
-
     layout.operator_context = "INVOKE_DEFAULT"
 
-    if utils.experimental_enabled() and utils.user_logged_in():
+    if utils.user_logged_in():
         r = ratings_utils.get_rating_local(asset_data["id"], "bookmarks")
         if r == 1:
             text = "Delete Bookmark"
@@ -3275,8 +3267,7 @@ def header_search_draw(self, context):
     row.prop(props, "search_keywords", text="", icon="VIEWZOOM")
 
     draw_assetbar_show_hide(layout, props)
-    if utils.experimental_enabled():
-        layout.prop(ui_props, "search_bookmarks", text="", icon="BOOKMARKS")
+    layout.prop(ui_props, "search_bookmarks", text="", icon="BOOKMARKS")
     if (
         props.search_category == ui_props.asset_type.lower()
         or props.search_category == ""

--- a/utils.py
+++ b/utils.py
@@ -66,8 +66,8 @@ supported_material_drag = (
 # supported_material_drag = ('MESH')
 
 
-def experimental_enabled():
-    """experimental features will always be enabled for staff and validators"""
+def experimental_enabled() -> bool:
+    """Check if experimental features are enabled. Experimental features are always be enabled for staff and validators."""
     preferences = bpy.context.preferences.addons["blenderkit"].preferences
     return preferences.experimental_features or profile_is_validator()
 


### PR DESCRIPTION
fixes #754 

- enables Bookmarks
- remove bookmarks from text of experimental_features property
- add info, that there are no experimental features available in this version into experimental_features
- moves asset bar's show_on_start to GUI part of settings