### PR TITLE
#777 Pass Cycles compute_device_type via JSON to background Blender

### DIFF
--- a/autothumb.py
+++ b/autothumb.py
@@ -21,6 +21,7 @@ import logging
 import os
 import subprocess
 import tempfile
+from pathlib import Path
 
 import bpy
 from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty
@@ -174,6 +175,11 @@ def start_model_thumbnailer(
     datafile = os.path.join(json_args["tempdir"], BLENDERKIT_EXPORT_DATA_FILE)
     user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
     json_args["thumbnail_use_gpu"] = user_preferences.thumbnail_use_gpu
+    if user_preferences.thumbnail_use_gpu is True:
+        json_args["cycles_compute_device_type"] = bpy.context.preferences.addons[
+            "cycles"
+        ].preferences.compute_device_type
+
     try:
         with open(datafile, "w", encoding="utf-8") as s:
             json.dump(json_args, s, ensure_ascii=False, indent=4)
@@ -186,11 +192,17 @@ def start_model_thumbnailer(
         datafile,
         user_preferences.api_key,
     )
+    blender_user_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+    )  # scripts/addons/blenderkit/autothumb.py
+    env = {"BLENDER_USER_SCRIPTS": str(blender_user_scripts_dir)}
+    env.update(os.environ)
     proc = subprocess.Popen(
         args,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
         creationflags=utils.get_process_flags(),
+        env=env,
     )
     bk_logger.info(f"Started Blender executing {SCRIPT_NAME} on file {datafile}")
     eval_path_computing = f"bpy.data.objects['{json_args['asset_name']}'].blenderkit.is_generating_thumbnail"
@@ -238,6 +250,10 @@ def start_material_thumbnailer(
     datafile = os.path.join(json_args["tempdir"], BLENDERKIT_EXPORT_DATA_FILE)
     user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
     json_args["thumbnail_use_gpu"] = user_preferences.thumbnail_use_gpu
+    if user_preferences.thumbnail_use_gpu is True:
+        json_args["cycles_compute_device_type"] = bpy.context.preferences.addons[
+            "cycles"
+        ].preferences.compute_device_type
     try:
         with open(datafile, "w", encoding="utf-8") as s:
             json.dump(json_args, s, ensure_ascii=False, indent=4)
@@ -251,11 +267,17 @@ def start_material_thumbnailer(
         datafile,
         user_preferences.api_key,
     )
+    blender_user_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+    )  # scripts/addons/blenderkit/autothumb.py
+    env = {"BLENDER_USER_SCRIPTS": str(blender_user_scripts_dir)}
+    env.update(os.environ)
     proc = subprocess.Popen(
         args,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
         creationflags=utils.get_process_flags(),
+        env=env,
     )
     bk_logger.info(f"Started Blender executing {SCRIPT_NAME} on file {datafile}")
 

--- a/autothumb_material_bg.py
+++ b/autothumb_material_bg.py
@@ -137,6 +137,13 @@ if __name__ == "__main__":
 
         if thumbnail_use_gpu is True:
             bpy.context.scene.cycles.device = "GPU"
+            compute_device_type = data.get("cycles_compute_device_type")
+            if compute_device_type is not None:
+                # DOCS:https://github.com/dfelinto/blender/blob/master/intern/cycles/blender/addon/properties.py
+                bpy.context.preferences.addons[
+                    "cycles"
+                ].preferences.compute_device_type = compute_device_type
+                bpy.context.preferences.addons["cycles"].preferences.refresh_devices()
 
         s.cycles.samples = data["thumbnail_samples"]
         bpy.context.view_layer.cycles.use_denoising = data["thumbnail_denoising"]

--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -141,6 +141,13 @@ if __name__ == "__main__":
         bpy.context.scene.render.filepath = data["thumbnail_path"]
         if thumbnail_use_gpu is True:
             bpy.context.scene.cycles.device = "GPU"
+            compute_device_type = data.get("cycles_compute_device_type")
+            if compute_device_type is not None:
+                # DOCS:https://github.com/dfelinto/blender/blob/master/intern/cycles/blender/addon/properties.py
+                bpy.context.preferences.addons[
+                    "cycles"
+                ].preferences.compute_device_type = compute_device_type
+                bpy.context.preferences.addons["cycles"].preferences.refresh_devices()
 
         fdict = {
             "DEFAULT": 1,

--- a/daemon/daemon_assets.py
+++ b/daemon/daemon_assets.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 from logging import getLogger
+from pathlib import Path
 
 import aiohttp
 import daemon_globals
@@ -323,12 +324,18 @@ async def send_to_bg(data, fpath, command="generate_resolutions", wait=True):
         datafile,
     ]
     logger.info(f"Running in BG: {command}")
+    blender_user_scripts_dir = (
+        Path(__file__).resolve().parents[3]
+    )  # scripts/addons/blenderkit/daemon/daemon_uploads.py
+    env = {"BLENDER_USER_SCRIPTS": str(blender_user_scripts_dir)}
+    env.update(os.environ)
     proc = await asyncio.create_subprocess_exec(
         binary_path,
         *args,
         creationflags=daemon_utils.get_process_flags(),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        env=env,
     )
     if wait:
         stdout, _ = await proc.communicate()


### PR DESCRIPTION
fixes #777

- gets compute_device_type when starting background thumbnail render
- passes it via JSON to background Blender
- sets Cycles compute_device_type in the background Blender