### PR TITLE
Fix fluid thumbnailer

### DIFF
--- a/autothumb_material_bg.py
+++ b/autothumb_material_bg.py
@@ -109,6 +109,14 @@ if __name__ == "__main__":
         for ob in bpy.context.visible_objects:
             if ob.name[:15] == "MaterialPreview":
                 utils.activate(ob)
+                if bpy.app.version >= (3, 3, 0):
+                    bpy.ops.object.transform_apply(
+                        location=False, rotation=False, scale=True, isolate_users=True
+                    )
+                else:
+                    bpy.ops.object.transform_apply(
+                        location=False, rotation=False, scale=True
+                    )
                 bpy.ops.object.transform_apply(
                     location=False, rotation=False, scale=True
                 )


### PR DESCRIPTION
this fix is only from blender 3.3 (since it uses the new apply transform operator option to separate instances), but I'd say let's survive that in blender 3.2 there can't be fluid preview rendered.