### PR TITLE
Use quality limit for all assets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -389,6 +389,15 @@ class BlenderKitUIProps(PropertyGroup):
         description="Filter my bookmarked assets only",
         update=search.search_update,
     )
+    # moved from per-asset search properties
+    quality_limit: IntProperty(
+        name="Quality limit",
+        description="Only show assets with a higher quality",
+        default=0,
+        min=0,
+        max=10,
+        update=search.search_update_delayed,
+    )
 
     logo_status: StringProperty(name="", default="logo_offline")
     asset_type_fold: BoolProperty(name="Expand asset types", default=False)
@@ -662,14 +671,7 @@ class BlenderKitCommonSearchProps:
         default=False,
         update=search.search_update,
     )
-    quality_limit: IntProperty(
-        name="Quality limit",
-        description="Only show assets with a higher quality",
-        default=0,
-        min=0,
-        max=10,
-        update=search.search_update_delayed,
-    )
+
 
 
 def update_free(self, context):

--- a/__init__.py
+++ b/__init__.py
@@ -673,7 +673,6 @@ class BlenderKitCommonSearchProps:
     )
 
 
-
 def update_free(self, context):
     if self.is_free == "FULL":
         self.is_free = "FREE"

--- a/search.py
+++ b/search.py
@@ -705,10 +705,11 @@ def build_query_common(query, props):
         query_common["files_size_gte"] = props.search_file_size_min * 1024 * 1024
         query_common["files_size_lte"] = props.search_file_size_max * 1024 * 1024
 
-    if props.quality_limit > 0:
-        query["quality_gte"] = props.quality_limit
-
     ui_props = bpy.context.window_manager.blenderkitUI
+
+    if ui_props.quality_limit > 0:
+        query["quality_gte"] = ui_props.quality_limit
+
     if ui_props.search_bookmarks:
         query["bookmarks_rating"] = 1
     query.update(query_common)
@@ -1039,7 +1040,7 @@ def clean_filters():
     sprops.property_unset("search_file_size")
     sprops.property_unset("search_procedural")
     ui_props.property_unset("free_only")
-    sprops.property_unset("quality_limit")
+    ui_props.property_unset("quality_limit")
     ui_props.property_unset("search_bookmarks")
     if ui_props.asset_type == "MODEL":
         sprops.property_unset("search_style")
@@ -1081,7 +1082,7 @@ def update_filters():
         or sprops.search_file_size
         or sprops.search_procedural != "BOTH"
         or ui_props.free_only
-        or sprops.quality_limit > 0
+        or ui_props.quality_limit > 0
         or ui_props.search_bookmarks
     )
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1230,7 +1230,7 @@ class VIEW3D_PT_blenderkit_advanced_model_search(Panel):
             props, "search_animated", text="Animated"
         )  # , text ='condition of object new/old e.t.c.')
         layout.prop(
-            props, "quality_limit", slider=True
+            ui_props, "quality_limit", slider=True
         )  # , text ='condition of object new/old e.t.c.')
 
         # layout.prop(props, "search_procedural", expand=True)
@@ -1286,7 +1286,7 @@ class VIEW3D_PT_blenderkit_advanced_material_search(Panel):
             row = layout.row(align=True)
             row.prop(props, "search_file_size_min", text="Min")
             row.prop(props, "search_file_size_max", text="Max")
-        layout.prop(props, "quality_limit", slider=True)
+        layout.prop(ui_props, "quality_limit", slider=True)
 
     def draw(self, context):
         self.draw_layout(self.layout)
@@ -1319,6 +1319,7 @@ class VIEW3D_PT_blenderkit_advanced_scene_search(Panel):
         row.prop(ui_props, "own_only", icon="USER")
 
         layout.prop(ui_props, "free_only")
+        layout.prop(ui_props, "quality_limit", slider=True)
 
     def draw(self, context):
         self.draw_layout(self.layout)
@@ -1353,6 +1354,7 @@ class VIEW3D_PT_blenderkit_advanced_HDR_search(Panel):
         row.prop(ui_props, "own_only", icon="USER")
         layout.prop(ui_props, "free_only")
         layout.prop(props, "true_hdr")
+        layout.prop(ui_props, "quality_limit", slider=True)
 
 
 class VIEW3D_PT_blenderkit_advanced_brush_search(Panel):
@@ -1381,6 +1383,7 @@ class VIEW3D_PT_blenderkit_advanced_brush_search(Panel):
         row.prop(ui_props, "search_bookmarks", text="Bookmarks", icon="BOOKMARKS")
         row.prop(ui_props, "own_only", icon="USER")
         layout.prop(ui_props, "free_only")
+        layout.prop(ui_props, "quality_limit", slider=True)
 
     def draw(self, context):
         self.draw_layout(self.layout)


### PR DESCRIPTION
fixes #760 

- use quality for all asets
- also join it for all assets, so it's linked - quality limit filter is now shared between asset types