### PR TITLE
#805 Improve logging around SSL certificates

### DIFF
--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -83,7 +83,7 @@ def handle_token_refresh_task(task: daemon_tasks.Task):
         reports.add_report(task.message, 5, "ERROR")
 
 
-def logout():
+def logout() -> None:
     """Logs out user from add-on."""
     bk_logger.info("Logging out.")
     preferences = bpy.context.preferences.addons["blenderkit"].preferences
@@ -95,7 +95,7 @@ def logout():
         del global_vars.DATA["bkit profile"]
 
 
-def login(signup):
+def login(signup: bool) -> None:
     """Logs user into the addon.
     Opens a browser with login page. Once user is logged it redirects to daemon handling access code via URL querry parameter.
     Using the access_code daemon then requests api_token and handles the results as a task with status finished/error.
@@ -110,9 +110,8 @@ def login(signup):
         authorize_url = f"{global_vars.SERVER}/accounts/register/?next={authorize_url}"
     else:
         authorize_url = f"{global_vars.SERVER}{authorize_url}"
-    open_new_tab(authorize_url)
-
-    return
+    ok = open_new_tab(authorize_url)
+    bk_logger.info(f"Login page in browser opened ({ok})")
 
 
 def generate_pkce_pair() -> tuple[str, str]:
@@ -200,7 +199,6 @@ class LoginOnline(bpy.types.Operator):
         preferences = bpy.context.preferences.addons["blenderkit"].preferences
         preferences.login_attempt = True
         login(self.signup)
-
         return {"FINISHED"}
 
     def invoke(self, context, event):

--- a/daemon/daemon_configurator.py
+++ b/daemon/daemon_configurator.py
@@ -21,7 +21,32 @@ async def debug_handler(request: web.Request):
     for configuration, result in results.items():
         text += f"{configuration}: {result}\n"
     text += await get_info()
+    text += await get_app_sessions_info(request)
     return web.Response(text=text)
+
+
+async def get_app_sessions_info(request: web.Request):
+    session = [
+        request.app["SESSION_API_REQUESTS"],
+        request.app["SESSION_SMALL_THUMBS"],
+        request.app["SESSION_BIG_THUMBS"],
+        request.app["SESSION_ASSETS"],
+        request.app["SESSION_UPLOADS"],
+    ]
+    text = "\n\nSESSIONS INFO:\n"
+    ssl_contexts = []
+    for session in session:
+        ssl_contexts.append(session.connector._ssl)
+
+    if len(set(ssl_contexts)) == 1:
+        text += f"SSL contexts are same:\n"
+        text += f"{ssl_contexts[0].get_ca_certs()}\n"
+    else:
+        text += f"SSL contexts are different:\n"
+        for ssl_context in ssl_contexts:
+            text += f"{ssl_context}: {ssl_context.get_ca_certs()}\n"
+
+    return text
 
 
 async def get_info():

--- a/daemon/daemon_oauth.py
+++ b/daemon/daemon_oauth.py
@@ -50,7 +50,9 @@ async def get_tokens(
         msg, detail = daemon_utils.extract_error_message(
             e, resp_text, resp_status, "Get tokens"
         )
-        logger.warning(detail)
+        logger.error(f"{msg}: {detail}.")
+        certs = session.connector._ssl.get_ca_certs()
+        logger.info(f"Certs used: {certs}")
         return {}, resp_status, msg
 
 


### PR DESCRIPTION
fixes #805 

- logs location from which daemon loads certificates (certifi, blenderkit cert chain, custo CA certs)
- in /debug it prints detected and used certificates