### PR TITLE
Update tooltip size correctly when scaling window

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -494,7 +494,9 @@ class BlenderKitUIProps(PropertyGroup):
     #### rating UI props
     rating_ui_scale = ui_scale
 
-    header_menu_fold: BoolProperty(name="Header menu fold", default=False)
+    header_menu_fold: BoolProperty(
+        name="Header menu fold", default=False, update=ui_panels.update_header_menu_fold
+    )
     rating_button_on: BoolProperty(name="Rating Button On", default=True)
     rating_menu_on: BoolProperty(name="Rating Menu On", default=False)
     rating_on: BoolProperty(name="Rating on", default=True)

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -684,7 +684,8 @@ def updater_run_install_popup_handler(scene):
             bpy.app.handlers.depsgraph_update_post.remove(
                 updater_run_install_popup_handler
             )
-    except:
+    except Exception as e:
+        print(e)
         pass
 
     if "ignore" in updater.json and updater.json["ignore"]:

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -155,8 +155,8 @@ def modal_inside(self, context, event):
             self.scroll_update()
             return {"RUNNING_MODAL"}
         if self.check_ui_resized(context) or self.check_new_search_results(context):
-            self.update_ui_size(context)
-            self.update_layout(context, event)
+            self.update_assetbar_sizes(context)
+            self.update_assetbar_layout(context)
             self.scroll_update(
                 always=True
             )  # one extra update for scroll for correct redraw, updates all buttons
@@ -230,6 +230,8 @@ BL_UI_Button.mouse_down_right = mouse_down_right
 BL_UI_Button.set_mouse_down_right = set_mouse_down_right
 
 asset_bar_operator = None
+
+
 # BL_UI_Button.handle_event = handle_event
 
 
@@ -334,6 +336,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
     def init_tooltip(self):
         self.tooltip_widgets = []
+        self.tooltip_scale = 1.0
         self.tooltip_height = self.tooltip_size
         self.tooltip_width = self.tooltip_size
         ui_props = bpy.context.window_manager.blenderkitUI
@@ -355,14 +358,14 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.tooltip_image = tooltip_image
         self.tooltip_widgets.append(tooltip_image)
 
-        bottom_panel_fraction = 0.15
-        labels_start = self.tooltip_height * (1 - bottom_panel_fraction)
+        self.bottom_panel_fraction = 0.15
+        self.labels_start = self.tooltip_height * (1 - self.bottom_panel_fraction)
 
         dark_panel = BL_UI_Widget(
             0,
-            labels_start,
+            self.labels_start,
             self.tooltip_width,
-            self.tooltip_height * bottom_panel_fraction,
+            self.tooltip_height * self.bottom_panel_fraction,
         )
         dark_panel.bg_color = (0.0, 0.0, 0.0, 0.7)
         self.tooltip_dark_panel = dark_panel
@@ -370,8 +373,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
         name_label = self.new_text(
             "",
-            self.margin,
-            labels_start + self.margin,
+            self.tooltip_margin,
+            self.labels_start + self.tooltip_margin,
             height=self.asset_name_text_size,
             text_size=self.asset_name_text_size,
         )
@@ -379,14 +382,14 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.tooltip_widgets.append(name_label)
 
         self.gravatar_size = int(
-            self.tooltip_height * bottom_panel_fraction - self.margin
+            self.tooltip_height * self.bottom_panel_fraction - self.tooltip_margin
         )
 
         authors_name = self.new_text(
             "author",
-            self.tooltip_width - self.gravatar_size - self.margin,
-            self.tooltip_height - self.author_text_size - self.margin,
-            labels_start,
+            self.tooltip_width - self.gravatar_size - self.tooltip_margin,
+            self.tooltip_height - self.author_text_size - self.tooltip_margin,
+            self.labels_start,
             height=self.author_text_size,
             text_size=self.author_text_size,
             halign="RIGHT",
@@ -403,7 +406,10 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         img_path = paths.get_addon_thumbnail_path("thumbnail_notready.jpg")
         gravatar_image.set_image(img_path)
         gravatar_image.set_image_size(
-            (self.gravatar_size - 1 * self.margin, self.gravatar_size - 1 * self.margin)
+            (
+                self.gravatar_size - 1 * self.tooltip_margin,
+                self.gravatar_size - 1 * self.tooltip_margin,
+            )
         )
         gravatar_image.set_image_position((0, 0))
         gravatar_image.set_image_colorspace("")
@@ -411,8 +417,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.tooltip_widgets.append(gravatar_image)
 
         quality_star = BL_UI_Image(
-            self.margin,
-            self.tooltip_height - self.margin - self.asset_name_text_size,
+            self.tooltip_margin,
+            self.tooltip_height - self.tooltip_margin - self.asset_name_text_size,
             1,
             1,
         )
@@ -426,8 +432,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.tooltip_widgets.append(quality_star)
         quality_label = self.new_text(
             "",
-            2 * self.margin + self.asset_name_text_size,
-            self.tooltip_height - int(self.asset_name_text_size + self.margin),
+            2 * self.tooltip_margin + self.asset_name_text_size,
+            self.tooltip_height - int(self.asset_name_text_size + self.tooltip_margin),
             height=self.asset_name_text_size,
             text_size=self.asset_name_text_size,
         )
@@ -443,8 +449,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             # this is shown only to users who don't know yet about the popup card.
             label = self.new_text(
                 "Right click for menu.",
-                self.margin,
-                self.tooltip_height + self.margin,
+                self.tooltip_margin,
+                self.tooltip_height + self.tooltip_margin,
                 height=self.author_text_size,
                 text_size=self.author_text_size,
             )
@@ -453,8 +459,10 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         # version warning
         version_warning = self.new_text(
             "",
-            self.margin,
-            self.tooltip_height + self.margin + int(self.author_text_size * offset),
+            self.tooltip_margin,
+            self.tooltip_height
+            + self.tooltip_margin
+            + int(self.author_text_size * offset),
             height=self.author_text_size,
             text_size=self.author_text_size,
         )
@@ -526,7 +534,44 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             return True
         return False
 
-    def update_ui_size(self, context):
+    def update_tooltip_size(self, context):
+        """Calculate all important sizes for the tooltip"""
+        region = context.region
+        ui_props = bpy.context.window_manager.blenderkitUI
+        ui_scale = bpy.context.preferences.view.ui_scale
+
+        if hasattr(self, "tooltip_panel"):
+            tooltip_y_offset = abs(region.height - self.tooltip_panel.y_screen)
+        else:
+            tooltip_y_offset = abs(region.height - (self.bar_height + self.bar_y))
+        self.tooltip_scale = min(
+            1.0, tooltip_y_offset / (self.tooltip_base_size_pixels * ui_scale)
+        )
+
+        self.asset_name_text_size = int(
+            0.039 * self.tooltip_base_size_pixels * ui_scale * self.tooltip_scale
+        )
+        self.author_text_size = int(self.asset_name_text_size * 0.8)
+        self.tooltip_size = int(
+            self.tooltip_base_size_pixels * ui_scale * self.tooltip_scale
+        )
+        self.tooltip_margin = int(
+            0.017 * self.tooltip_base_size_pixels * ui_scale * self.tooltip_scale
+        )
+
+        if ui_props.asset_type == "HDR":
+            self.tooltip_width = self.tooltip_size * 2
+            self.tooltip_height = self.tooltip_size
+        else:
+            self.tooltip_width = self.tooltip_size
+            self.tooltip_height = self.tooltip_size
+
+        self.gravatar_size = int(
+            self.tooltip_height * self.bottom_panel_fraction - self.tooltip_margin
+        )
+
+    def update_assetbar_sizes(self, context):
+        """Calculate all important sizes for the asset bar"""
         region = context.region
         area = context.area
 
@@ -534,19 +579,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
         ui_scale = bpy.context.preferences.view.ui_scale
 
-        # self.margin = int(ui_props.bl_rna.properties['margin'].default * ui_scale)
-        self.margin = int(9 * ui_scale)
+        # assetbar scaling
         self.button_margin = int(0 * ui_scale)
-        self.asset_name_text_size = int(20 * ui_scale)
-        self.author_text_size = int(self.asset_name_text_size * 0.8)
         self.assetbar_margin = int(2 * ui_scale)
-        self.tooltip_size = int(512 * ui_scale)
-
-        if ui_props.asset_type == "HDR":
-            self.tooltip_width = self.tooltip_size * 2
-        else:
-            self.tooltip_width = self.tooltip_size
-
         self.thumb_size = int(user_preferences.thumb_size * ui_scale)
         self.button_size = 2 * self.button_margin + self.thumb_size
         self.other_button_size = int(30 * ui_scale)
@@ -566,7 +601,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 ui_width = r.width * reg_multiplier
             if r.type == "TOOLS":
                 tools_width = r.width * reg_multiplier
-        self.bar_x = int(tools_width + self.margin + ui_props.bar_x_offset * ui_scale)
+        self.bar_x = int(
+            tools_width + self.button_margin + ui_props.bar_x_offset * ui_scale
+        )
         self.bar_end = int(ui_width + 180 * ui_scale + self.other_button_size)
         self.bar_width = int(region.width - self.bar_x - self.bar_end)
 
@@ -604,8 +641,15 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             self.reports_x = self.bar_x
             ui_props.reports_x = self.bar_x
 
-    def update_layout(self, context, event):
-        # restarting asset_bar completely since the widgets are too hard to get working with updates.
+    def update_ui_size(self, context):
+        """Calculate all important sizes for the asset bar and tooltip"""
+
+        self.update_assetbar_sizes(context)
+        self.update_tooltip_size(context)
+
+    def update_assetbar_layout(self, context):
+        """Update the layout of the asset bar"""
+        # usually restarting asset_bar completely since the widgets are too hard to get working with updates.
 
         self.scroll_update(always=True)
         self.position_and_hide_buttons()
@@ -621,22 +665,73 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
         self.panel.set_location(self.bar_x, self.panel.y)
 
-        # update Tooltip size
-        if self.tooltip_dark_panel.width != self.tooltip_width:
-            self.tooltip_dark_panel.width = self.tooltip_width
-            self.tooltip_panel.width = self.tooltip_width
-            self.tooltip_image.width = self.tooltip_width
-            self.tooltip_image.set_image_size((self.tooltip_width, self.tooltip_height))
-            self.gravatar_image.set_location(
-                self.tooltip_width - self.gravatar_size,
-                self.tooltip_height - self.gravatar_size,
-            )
-            self.authors_name.set_location(
-                self.tooltip_width - self.gravatar_size - self.margin,
-                self.tooltip_height - self.author_text_size - self.margin,
-            )
+    def update_tooltip_layout(self, context):
+        # update Tooltip size /scale for HDR or if area too small
 
-        # to hide arrows accordingly
+        self.tooltip_panel.width = self.tooltip_width
+        self.tooltip_panel.height = self.tooltip_height
+        self.tooltip_image.width = self.tooltip_width
+        self.tooltip_image.height = self.tooltip_height
+
+        self.labels_start = self.tooltip_height * (1 - self.bottom_panel_fraction)
+
+        self.tooltip_image.set_image_size((self.tooltip_width, self.tooltip_height))
+        self.tooltip_image.set_location(0, 0)
+        # print(self.tooltip_image.width, self.tooltip_image.height)
+
+        self.gravatar_image.set_location(
+            self.tooltip_width - self.gravatar_size,
+            self.tooltip_height - self.gravatar_size,
+        )
+        self.gravatar_image.set_image_size(
+            (
+                self.gravatar_size - 1 * self.tooltip_margin,
+                self.gravatar_size - 1 * self.tooltip_margin,
+            )
+        )
+
+        self.authors_name.set_location(
+            self.tooltip_width - self.gravatar_size - self.tooltip_margin,
+            self.tooltip_height - self.author_text_size - self.tooltip_margin,
+        )
+        self.authors_name.text_size = self.author_text_size
+        self.authors_name.height = self.author_text_size
+
+        self.asset_name.set_location(
+            self.tooltip_margin,
+            self.labels_start + self.tooltip_margin,
+        )
+        self.asset_name.text_size = self.asset_name_text_size
+        self.asset_name.height = self.asset_name_text_size
+
+        self.tooltip_dark_panel.set_location(
+            0,
+            self.labels_start,
+        )
+        self.tooltip_dark_panel.height = (
+            self.tooltip_height * self.bottom_panel_fraction
+        )
+        self.tooltip_dark_panel.width = self.tooltip_width
+
+        self.quality_label.set_location(
+            2 * self.tooltip_margin + self.asset_name_text_size,
+            self.tooltip_height - int(self.asset_name_text_size + self.tooltip_margin),
+        )
+        self.quality_label.text_size = self.asset_name_text_size
+        self.quality_label.height = self.asset_name_text_size
+
+        self.quality_star.set_location(
+            self.tooltip_margin,
+            self.tooltip_height - self.tooltip_margin - self.asset_name_text_size,
+        )
+        self.quality_star.set_image_size(
+            (self.asset_name_text_size, self.asset_name_text_size)
+        )
+
+    def update_layout(self, context, event):
+        """update UI sizes after their recalculation"""
+        self.update_assetbar_layout(context)
+        self.update_tooltip_layout(context)
 
     def asset_button_init(self, asset_x, asset_y, button_idx):
         button_bg_color = (0.2, 0.2, 0.2, 0.1)
@@ -918,6 +1013,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         super().__init__()
 
     def on_init(self, context):
+        self.tooltip_base_size_pixels = 512
+        self.tooltip_scale = 1.0
+        self.bottom_panel_fraction = 0.15
         self.update_ui_size(bpy.context)
 
         # todo move all this to update UI size
@@ -1130,7 +1228,11 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             # need to set image here because of context issues.
             img_path = paths.get_addon_thumbnail_path("star_grey.png")
             self.quality_star.set_image(img_path)
-            # self.init_tooltip()
+
+            # set location twice for size calculations updates.
+            self.tooltip_panel.set_location(tooltip_x, tooltip_y)
+            self.update_tooltip_size(bpy.context)
+            self.update_tooltip_layout(bpy.context)
             self.tooltip_panel.set_location(tooltip_x, tooltip_y)
             self.tooltip_panel.layout_widgets()
             # show bookmark button - always on mouse enter

--- a/autothumb.py
+++ b/autothumb.py
@@ -513,8 +513,8 @@ class ReGenerateThumbnailOperator(bpy.types.Operator):
             "thumbnail_samples": self.thumbnail_samples,
             "thumbnail_denoising": self.thumbnail_denoising,
         }
-        args_dict.update(thumbnail_args)
 
+        args_dict.update(thumbnail_args)
         start_model_thumbnailer(self, json_args=args_dict, wait=False)
         return {"FINISHED"}
 

--- a/bg_utils.py
+++ b/bg_utils.py
@@ -62,6 +62,7 @@ def upload_file(upload_data, f):
 
 def download_asset_file(asset_data, resolution="blend", api_key=""):
     """This is a simple non-threaded way to download files for background resolution geneneration tool."""
+
     file_names = paths.get_download_filepaths(asset_data, resolution)
     if len(file_names) == 0:
         return None

--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -74,8 +74,8 @@ class BL_UI_Button(BL_UI_Widget):
             bpy.context.region.tag_redraw()
         self._select_bg_color = value
 
-    def set_image_size(self, imgage_size):
-        self.__image_size = imgage_size
+    def set_image_size(self, image_size):
+        self.__image_size = image_size
 
     def set_image_position(self, image_position):
         self.__image_position = image_position

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -15,8 +15,8 @@ class BL_UI_Image(BL_UI_Widget):
         self.__image_size = (24, 24)
         self.__image_position = (4, 2)
 
-    def set_image_size(self, imgage_size):
-        self.__image_size = imgage_size
+    def set_image_size(self, image_size):
+        self.__image_size = image_size
 
     def set_image_position(self, image_position):
         self.__image_position = image_position

--- a/bl_ui_widgets/bl_ui_widget.py
+++ b/bl_ui_widgets/bl_ui_widget.py
@@ -101,6 +101,7 @@ class BL_UI_Widget:
             self.shader = gpu.shader.from_builtin("2D_UNIFORM_COLOR")
         else:
             self.shader = gpu.shader.from_builtin("UNIFORM_COLOR")
+
         self.batch_panel = batch_for_shader(
             self.shader, "TRIS", {"pos": vertices}, indices=indices
         )

--- a/paths.py
+++ b/paths.py
@@ -146,6 +146,7 @@ def get_download_dirs(asset_type):
     }
 
     dirs = []
+
     if global_vars.PREFS["directory_behaviour"] in ("BOTH", "GLOBAL"):
         ddir = global_vars.PREFS["global_dir"]
         if ddir.startswith("//"):

--- a/ui.py
+++ b/ui.py
@@ -1300,5 +1300,8 @@ def unregister_ui():
     km = wm.keyconfigs.addon.keymaps.get("Window")
     if km:
         for kmi in addon_keymapitems:
-            km.keymap_items.remove(kmi)
+            try:
+                km.keymap_items.remove(kmi)
+            except:
+                pass
     del addon_keymapitems[:]

--- a/ui_bgl.py
+++ b/ui_bgl.py
@@ -94,7 +94,12 @@ def draw_image(x, y, width, height, image, transparency, crop=(0, 0, 1, 1), batc
         return
     ci = cached_images.get(image.filepath)
     if ci is not None:
-        if ci["x"] == x and ci["y"] == y:
+        if (
+            ci["x"] == x
+            and ci["y"] == y
+            and ci["width"] == width
+            and ci["height"] == height
+        ):
             batch = ci["batch"]
             image_shader = ci["image_shader"]
             texture = ci["texture"]
@@ -122,6 +127,8 @@ def draw_image(x, y, width, height, image, transparency, crop=(0, 0, 1, 1), batc
         cached_images[image.filepath] = {
             "x": x,
             "y": y,
+            "width": width,
+            "height": height,
             "batch": batch,
             "image_shader": image_shader,
             "texture": texture,

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -30,6 +30,7 @@ from bpy.types import Menu, Panel
 
 from . import (
     addon_updater_ops,
+    asset_bar_op,
     autothumb,
     categories,
     comments_utils,
@@ -3228,6 +3229,14 @@ class VIEW3D_PT_blenderkit_downloads(Panel):
                 layout.separator()
 
 
+def update_header_menu_fold(self, context):
+    ui_props = bpy.context.window_manager.blenderkitUI
+    if ui_props.header_menu_fold and asset_bar_op.asset_bar_operator is not None:
+        bpy.ops.view3d.run_assetbar_fix_context(keep_running=False, do_search=False)
+    elif not ui_props.header_menu_fold and asset_bar_op.asset_bar_operator is None:
+        bpy.ops.view3d.run_assetbar_fix_context(keep_running=True, do_search=False)
+
+
 def header_search_draw(self, context):
     """Top bar menu in 3D view"""
     if not utils.guard_from_crash():
@@ -3269,17 +3278,32 @@ def header_search_draw(self, context):
     # if context.space_data.show_region_tool_header == True or context.mode[:4] not in ('EDIT', 'OBJE'):
     # layout.separator_spacer()
     row = layout.row(align=True)
-    row.scale_x = 0.85
+    row.scale_x = 0.9
 
     if ui_props.header_menu_fold:
         row.prop(ui_props, "header_menu_fold", text="", icon="RIGHTARROW", emboss=False)
-        row.label(text="", icon_value=pcoll[ui_props.logo_status].icon_id)
+        row.prop(
+            ui_props,
+            "header_menu_fold",
+            text="",
+            icon_value=pcoll[ui_props.logo_status].icon_id,
+            emboss=False,
+        )
         return
     else:
         row.prop(
             ui_props, "header_menu_fold", text="", icon="DOWNARROW_HLT", emboss=False
         )
-    row.label(text="", icon_value=pcoll[ui_props.logo_status].icon_id)
+
+    # draw logo as part of the folding UI, it is better clickable.
+    row.prop(
+        ui_props,
+        "header_menu_fold",
+        text="",
+        icon_value=pcoll[ui_props.logo_status].icon_id,
+        emboss=False,
+    )
+    # row.label(text="", icon_value=pcoll[ui_props.logo_status].icon_id)
 
     layout = layout.row(align=True)
     # layout.separator()


### PR DESCRIPTION
restructure several functions to update sizes in assetbar (split them) update the size on each enter button, so we're sure the tooltip has correct size. Works nicely now!