### PR TITLE
#958 Finish disclaimer modal right away when context.area is None/False

### DIFF
--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -156,6 +156,7 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
         if not context.area:
             # end if area disappears
             self.finish()
+            return {"FINISHED"}  # so region.tag_redraw() is not called later
 
         if self.handle_widget_events(event):
             self.start_time = time.time()
@@ -164,6 +165,7 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
 
         if event.type in {"ESC"}:
             self.finish()
+            return {"FINISHED"}
 
         if event.type == "TIMER":
             run_time = time.time() - self.start_time


### PR DESCRIPTION
fixes #958 

Error: Python: Traceback (most recent call last):
  File "/Users/ag/Library/Application Support/Blender/4.0/scripts/addons/blenderkit/disclaimer_op.py", line 160, in modal
    if self.handle_widget_events(event):
  File "/Users/ag/Library/Application Support/Blender/4.0/scripts/addons/blenderkit/bl_ui_widgets/bl_ui_draw_op.py", line 67, in handle_widget_events
    if widget.handle_event(event):
  File "/Users/ag/Library/Application Support/Blender/4.0/scripts/addons/blenderkit/bl_ui_widgets/bl_ui_widget.py", line 132, in handle_event
    bpy.context.region.tag_redraw()
AttributeError: 'NoneType' object has no attribute 'tag_redraw'

Disclaimer checkoval, jestli neni region None, volal self.finish(), ale funkce pokracovala dal a bylo to chycene az v dalsim behu pri `if self._finished: return {"FINISHED"}`. Tohle ale zpusobilo, ze se potom dal volal tag_redraw(), no, jenze se volal na None a hazelo to error.

Tak jsem pridal return rovnou za volani self.finish(). Kdyztak prosim to zcheckni, jestli v tomhle nejsem mimo. Zbezne jsem to vyzkousel a nenachazim, ze by to delalo nejakou neplechu.