### PR TITLE
#955 only for testing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "BlenderKit Online Asset Library",
     "author": "Vilem Duha, Petr Dlouhy, A. Gajdosik",
-    "version": (3, 8, 2, 230906),  # X.Y.Z.yymmdd
+    "version": (3, 1, 0, 231227),  # X.Y.Z.yymmdd
     "blender": (3, 0, 0),
     "location": "View3D > Properties > BlenderKit",
     "description": "Boost your workflow with drag&drop assets from the community driven library.",

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -52,9 +52,10 @@ class BL_UI_OT_draw_operator(Operator):
         )
 
     def unregister_handlers(self, context):
-        context.window_manager.event_timer_remove(self.draw_event)
-
-        bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, "WINDOW")
+        if self.draw_event is not None:
+            context.window_manager.event_timer_remove(self.draw_event)
+        if self.draw_handle is not None:
+            bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, "WINDOW")
 
         self.draw_handle = None
         self.draw_event = None


### PR DESCRIPTION
THIS IS ONLY FOR TESTING

Changes for #955 on branch v3.8.0 versioned as 3.1.0, so you can try auto-update to 3.9.0 which no longer causes problems reported in https://github.com/BlenderKit/blenderkit/issues/939. Works on my computer, seems like running bpy.ops.script.reload() during post_update hook reloads the add-on successfully and prevents mixture of old and new code which caused the problem in #939. This way users who ignore the need to restart Blender should not be affected by bugs anymore.