### PR TITLE
#955 Call bpy.ops.script.reload() during post_update_callback to fix …

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -27,7 +27,7 @@ import traceback
 import bpy
 from bpy.app.handlers import persistent
 
-from . import daemon_lib
+from . import asset_bar_op, daemon_lib, disclaimer_op
 
 
 # Safely import the updater.
@@ -498,8 +498,8 @@ class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
         # we need to restart BlenderKit daemon after update
         try:
             daemon_lib.kill_daemon_server()
-        except:
-            pass
+        except Exception as e:
+            print(f"Failed to kill daemon server: {e}")
         return context.window_manager.invoke_props_popup(self, event)
 
     def draw(self, context):
@@ -759,6 +759,12 @@ def post_update_callback(module_name, res=None):
         updater.print_verbose(
             "{} updater: Running post update callback".format(updater.addon)
         )
+
+        # BK: Have to remove all running modals before script reload
+        bpy.utils.unregister_class(disclaimer_op.BlenderKitDisclaimerOperator)
+        bpy.utils.unregister_class(asset_bar_op.BlenderKitAssetBarOperator)
+        bpy.ops.script.reload()  # BK: Reload scripts so the updated add-on is loaded
+        updater.print_verbose(f"{updater.addon} updater: Reloaded scripts")
 
         atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
         getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -53,9 +53,10 @@ class BL_UI_OT_draw_operator(Operator):
         )
 
     def unregister_handlers(self, context):
-        context.window_manager.event_timer_remove(self.draw_event)
-
-        bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, "WINDOW")
+        if self.draw_event is not None:
+            context.window_manager.event_timer_remove(self.draw_event)
+        if self.draw_handle is not None:
+            bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, "WINDOW")
 
         self.draw_handle = None
         self.draw_event = None


### PR DESCRIPTION
fixes #955 

Sometimes (1 out of 20 runs) ends with Blender crash. So not sure if this a viable option or not.