### PR TITLE
#937 Add social links to authors' profiles

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1285,3 +1285,21 @@ def check_globaldir_permissions():
         15,
         type="ERROR",
     )
+
+
+def shorten_text(text: str, max_len: int = -1) -> str:
+    """Shorten text to max_len characters and end it with '…' (horizontal elipsis) if the text was shortened
+    (max_len-1 characters will be used, last one will be '…').
+    If max_len is -1, then no shortening is done."""
+    if max_len == -1:
+        return text
+    if len(text) > max_len:
+        text = text[: max_len - 1] + "…"
+    return text
+
+
+def remove_url_protocol(text: str) -> str:
+    """Remove http:// or https:// from the beginning of the text. Useful for cleaner presentation of URLs to users."""
+    text = text.lstrip("https://")
+    text = text.lstrip("http://")
+    return text


### PR DESCRIPTION
fixes #937 

- adding socialNetworks on profile where available (does not add row if they are not available)
- aboutMeUrl now does not add row if it is not available to keep proper padding (some creators now can be accepted with social portfolios)
- aboutMeUrl is now stripped of http:// https:// prefixes to save space and show the interesting part - the address, not the boring protocol.

![Screenshot 2024-01-12 at 12 51 34](https://github.com/BlenderKit/blenderkit/assets/22000268/7f76e79a-c245-4dc8-a94f-a3e2415e66c3)

