### PR TITLE
fixes #979 where the new downloaders would throw error for objects thatdon't have 3d downloaders.

### DIFF
--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -880,7 +880,11 @@ class DownloadGizmoOperator(BL_UI_OT_draw_operator):
 
         a = bpy.context.area
 
-        if bpy.context.space_data is not None and hasattr(self, "downloader"):
+        if (
+            bpy.context.space_data is not None
+            and hasattr(self, "downloader")
+            and self.downloader is not None
+        ):
             loc = view3d_utils.location_3d_to_region_2d(
                 bpy.context.region,
                 bpy.context.space_data.region_3d,
@@ -966,7 +970,11 @@ class DownloadGizmoOperator(BL_UI_OT_draw_operator):
             self.finish()
 
         # if event.type == "MOUSEMOVE":
-        if bpy.context.space_data is not None:
+        if (
+            bpy.context.space_data is not None
+            and hasattr(self, "downloader")
+            and self.downloader is not None
+        ):
             loc = view3d_utils.location_3d_to_region_2d(
                 bpy.context.region,
                 bpy.context.space_data.region_3d,


### PR DESCRIPTION
fixes #979 where the new downloaders would throw error for objects thatdon't have 3d downloaders.