### PR TITLE
#1018 Revoke OAuth2 tokens during logout

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -187,6 +187,7 @@ func main() {
 	mux.HandleFunc("/consumer/exchange/", consumerExchangeHandler)
 	mux.HandleFunc("/refresh_token", RefreshTokenHandler)
 	mux.HandleFunc("/oauth2/verification_data", OAuth2VerificationDataHandler)
+	mux.HandleFunc("/oauth2/logout", OAuth2LogoutHandler)
 
 	// BLENDER SPECIFIC HANDLERS
 	mux.HandleFunc("/blender/unsubscribe_addon", blenderUnsubscribeAddonHandler)

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -456,6 +456,16 @@ def refresh_token(refresh_token, old_api_key):
         return resp
 
 
+def oauth2_logout():
+    """Logout from OAUTH2. BlenderKit-Client will revoke the token on the server."""
+    data = ensure_minimal_data()
+    data["refresh_token"] = global_vars.PREFS["api_key_refresh"]
+    with requests.Session() as session:
+        url = get_address() + "/oauth2/logout"
+        resp = session.get(url, json=data, timeout=TIMEOUT, proxies=NO_PROXIES)
+        return resp
+
+
 def unsubscribe_addon():
     """Unsubscribe the add-on from the BlenderKit-Client. Called when the add-on is disabled, uninstalled or when Blender is closed."""
     address = get_address()

--- a/timer.py
+++ b/timer.py
@@ -232,6 +232,10 @@ def handle_task(task: daemon_tasks.Task):
     if task.task_type == "token_refresh":
         return bkit_oauth.handle_token_refresh_task(task)
 
+    # HANDLE OAUTH LOGOUT
+    if task.task_type == "oauth2/logout":
+        return bkit_oauth.handle_logout_task(task)
+
     # HANDLE CLIENT STATUS REPORT
     if task.task_type == "client_status":
         return daemon_lib.handle_client_status_task(task)


### PR DESCRIPTION
fixes #1018

Successful example:
```
⬡  2024/03/25 16:49:49 BlenderKit-Client v0.0.5 starting from add-on v3.12.0.240319
   port=62485
   server=https://www.blenderkit.com
   proxy_which=SYSTEM
   proxy_address=http://localhost:8899
   trusted_ca_certs=
   ssl_context=ENABLED
⬡  2024/03/25 16:49:49 ✅ Using system proxy settings
⬡  2024/03/25 16:49:49 🔒 SSL verification is enabled
⬡  2024/03/25 16:49:49 🤝 New add-on connected: 30826
<- 2024/03/25 16:49:50 ✅ disclaimer (11535200-65b0-4e49-989c-125bf91692c2)
<- 2024/03/25 16:49:50 ✅ categories_update (f1e637d9-7e16-4d3f-9730-13e8a13932b8)
⬡  2024/03/25 16:49:56 🆔 Add-on (30826) has created OAuth2 session (code_verifier=redacted, state=redacted).
⬡  2024/03/25 16:49:59 🆔 Token retrieval OK (grant type: authorization_code)
<- 2024/03/25 16:50:00 ✅ profiles/get_user_profile (37e783e0-944f-49c9-90eb-c11ba927426d)
<- 2024/03/25 16:50:00 ✅ profiles/fetch_gravatar_image (a1fe5c1b-dac0-4c6a-9bd4-4db0fa4fa0d0)
⬡  2024/03/25 16:50:07 🆔 api_key revoked successfully
⬡  2024/03/25 16:50:07 🆔 refresh_token revoked successfully
<- 2024/03/25 16:50:07 ✅ oauth2/logout (1cfe2776-823f-4205-9b01-beaaa2a6c37f)
⬡  2024/03/25 16:50:12 👐 Add-on unsubscribed: 30826
⬡  2024/03/25 16:50:12 ⚠️  No add-ons left, shutting down...
⬡  2024/03/25 16:50:12 Bye!
```

Failing example (offline):
```
⬡  2024/03/25 16:52:53 BlenderKit-Client v0.0.5 starting from add-on v3.12.0.240319
   port=62485
   server=https://www.blenderkit.com
   proxy_which=SYSTEM
   proxy_address=http://localhost:8899
   trusted_ca_certs=
   ssl_context=ENABLED
⬡  2024/03/25 16:52:53 ✅ Using system proxy settings
⬡  2024/03/25 16:52:53 🔒 SSL verification is enabled
⬡  2024/03/25 16:52:54 🤝 New add-on connected: 31085
<- 2024/03/25 16:52:54 ✅ categories_update (7b6f1d4f-0ab9-4dc2-8144-3a23e25f1f2e)
<- 2024/03/25 16:52:54 ✅ disclaimer (9a79b70a-e344-49e6-85aa-5ddf86a37555)
⬡  2024/03/25 16:52:59 🆔 Add-on (31085) has created OAuth2 session (code_verifier=t4KAjFAG2y2chDRPPfjnOgkxnrg5VUQtS7Eluu8YrKMN5D1C53HEF6nc18I7y5CdlsIA5DXgPxDAfB7CgSsqqRjroqynntSfZ0KibiETuzKCDt5lDnbAZfz7nLIYEYOA, state=HLAECHlvHOMKZNjGhBlKyToEfU-0X8NeJBxQn2_6jcE).
⬡  2024/03/25 16:53:01 🆔 Token retrieval OK (grant type: authorization_code)
<- 2024/03/25 16:53:02 ✅ profiles/get_user_profile (5ede0b4d-6316-44be-a78b-e48316522058)
<- 2024/03/25 16:53:02 ✅ profiles/fetch_gravatar_image (1c9bf823-b9b5-4d58-959f-6aa484b82ab3)
<- 2024/03/25 16:53:42 ❌ in search (ecb2cbe8-01ba-4b84-8fb5-672ce2d2f836): Get "https://www.blenderkit.com/api/v1/search/?query=+asset_type:model+order:-last_upload&dict_parameters=1&page_size=15&addon_version=3.12.0&blender_version=4.2.0": read tcp 10.0.1.13:60492->104.26.4.20:443: read: can't assign requested address
<- 2024/03/25 16:53:42 ❌ oauth2/logout (9b485be1-b1d3-491a-94b8-9ef325599f2a): Logout partially OK, failed to revoke tokens: ['api_key: Post "https://www.blenderkit.com/o/revoke_token/": read tcp 10.0.1.13:60492->104.26.4.20:443: read: can't assign requested address' 'refresh_token: Post "https://www.blenderkit.com/o/revoke_token/": read tcp 10.0.1.13:60492->104.26.4.20:443: read: can't assign requested address']
⬡  2024/03/25 16:53:49 👐 Add-on unsubscribed: 31085
⬡  2024/03/25 16:53:49 ⚠️  No add-ons left, shutting down...
⬡  2024/03/25 16:53:49 Bye!
```