### PR TITLE
#1057 Reject old addons in Client, so they start daemon on their own

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -266,6 +266,13 @@ func reportHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if data.AddonVersion == "" {
+		msg := fmt.Sprintf("BlenderKit-Client running on port %s", *Port)
+		BKLog.Printf("%v Add-on (probably v3.11 or less) requesting /report rejected.", EmoWarning)
+		http.Error(w, msg, http.StatusForbidden) // 403
+		return
+	}
+
 	TasksMux.Lock()
 	if Tasks[data.AppID] == nil { // New add-on connected
 		SubscribeNewApp(data)


### PR DESCRIPTION
fixes #1057

This is a quick fix to solve problems with already released versions of the add-on. For the robust solution which will handle incompatibilities between different versions of the BK-Client, #1044 needs to be implemented.