### PR TITLE
#1147 Ensure filepath is not longer than 250 on Windows, sync Slugify in Python and Go

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -401,8 +402,20 @@ func GetDownloadFilepaths(data DownloadData, filename string) []string {
 		filePath := filepath.Join(assetDirPath, filename)
 		filePaths = append(filePaths, filePath)
 	}
-	// TODO: check on Windows if path is not too long
-	return filePaths
+
+	// For Mac and Linux, we can return the file paths as they are.
+	if runtime.GOOS != "windows" {
+		return filePaths
+	}
+
+	// On Windows we need to check if path is not too long
+	var filteredWinPaths []string
+	for _, filePath := range filePaths {
+		if len(filePath) < 259 {
+			filteredWinPaths = append(filteredWinPaths, filePath)
+		}
+	}
+	return filteredWinPaths
 }
 
 // Get the download URL for the asset file.

--- a/client/main.go
+++ b/client/main.go
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	ReportTimeout    = 3 * time.Minute
-	OAUTH_CLIENT_ID  = "IdFRwa3SGA8eMpzhRVFMg5Ts8sPK93xBjif93x0F"
-	WindowsPathLimit = 250
+	ReportTimeout   = 3 * time.Minute
+	OAUTH_CLIENT_ID = "IdFRwa3SGA8eMpzhRVFMg5Ts8sPK93xBjif93x0F"
 
 	// PATHS
 	server_default     = "https://www.blenderkit.com" // default address to production blenderkit server

--- a/client/utils.go
+++ b/client/utils.go
@@ -100,6 +100,7 @@ type AddonVersion struct {
 }
 
 // Extract the filename from a URL, used for thumbnails.
+// Mirrors utils.py/extract_filename_from_url()
 func ExtractFilenameFromURL(urlStr string) (string, error) {
 	if urlStr == "" {
 		return "", fmt.Errorf("empty URL")
@@ -160,30 +161,30 @@ func DeleteFileAndParentIfEmpty(filePath string) {
 	}
 }
 
-// Files on server are saved in format: "resolution_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend" for resolution files, or "blend_d5368c9d-092e-4319-afe1-dd765de6da01.blend" for original files,
-// but locally we want to store them as "asset-name_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend".
-// This is for better human readability.
-func ServerToLocalFilename(filename, assetName string) string {
-	filename = strings.Replace(filename, "blend_", "", -1)
-	filename = strings.Replace(filename, "resolution_", "", -1)
-	lfn := Slugify(assetName) + "_" + filename
-	return lfn
+// Convert server format filename to human readable local filename. Function mirrors: paths.py/serverToLocalFilename()
+//
+// "resolution_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend" > "asset-name_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend"
+//
+// "blend_d5368c9d-092e-4319-afe1-dd765de6da01.blend" > "asset-name_d5368c9d-092e-4319-afe1-dd765de6da01.blend"
+func ServerToLocalFilename(serverFilename, assetName string) string {
+	serverFilename = strings.Replace(serverFilename, "blend_", "", -1)
+	serverFilename = strings.Replace(serverFilename, "resolution_", "", -1)
+	localFilename := Slugify(assetName) + "_" + serverFilename
+
+	return localFilename
 }
 
 // Slugify converts a string to a URL-friendly slug.
-// It removes non-alphanumeric characters, and replaces spaces with hyphens.
+// Converts to lowercase, replaces non-alphanumeric characters with hyphens.
+// Ensures only one hyphen between words and that string starts and ends with a letter or number.
 // It also ensures that the slug does not exceed 50 characters.
 func Slugify(slug string) string {
-	slug = strings.ToLower(slug) // Normalize string: convert to lowercase
-	characters := "<>:\"/\\|?*., ()#"
-	for _, ch := range characters {
-		slug = strings.ReplaceAll(slug, string(ch), "_")
-	}
+	// Normalize string: convert to lowercase
+	slug = strings.ToLower(slug)
 
 	// Remove non-alpha characters, and convert spaces to hyphens.
 	reg := regexp.MustCompile(`[^a-z0-9]+`)
 	slug = reg.ReplaceAllString(slug, "-")
-	slug = strings.Trim(slug, "-")
 
 	// Replace multiple hyphens with a single one
 	reg = regexp.MustCompile(`[-]+`)
@@ -193,6 +194,9 @@ func Slugify(slug string) string {
 	if len(slug) > 50 {
 		slug = slug[:50]
 	}
+
+	// Ensure the slug starts and ends with a letter or number.
+	slug = strings.Trim(slug, "-")
 
 	return slug
 }

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -101,7 +101,7 @@ func TestSlugify(t *testing.T) {
 		{"My--Username", "my-username"},
 		{"My__Username, 123", "my-username-123"},
 		{"My? Name! Is: Dada", "my-name-is-dada"},
-		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit.", "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing <-50th char is space, ending hyphen will be remove, leading to 49chars. Consectetur ante hendrerit.", "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing"},
 	}
 
 	for _, test := range tests {
@@ -149,10 +149,12 @@ func TestServerToLocalFilename(t *testing.T) {
 		assetName string
 		expected  string
 	}{
-		{"2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend", "Cat on Books Statue 3D Scan", "cat-on-books-statue-3d-scan_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend"},
-		{"2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend", "Apple iPad With Keyboard", "apple-ipad-with-keyboard_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend"},
-		{"934e424b-d890-4ba7-98c3-85b733cdc94a.blend", "Gray Carpet (Procedural)", "gray-carpet-procedural_934e424b-d890-4ba7-98c3-85b733cdc94a.blend"},
-		{"6ab98d58-8502-4087-a007-f3bd23f393a7.blend", "White minimal product mockups", "white-minimal-product-mockups_6ab98d58-8502-4087-a007-f3bd23f393a7.blend"},
+		{"resolution_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend", "Cat on Books Statue 3D Scan", "cat-on-books-statue-3d-scan_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend"},
+		{"resolution_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend", "Apple iPad With Keyboard", "apple-ipad-with-keyboard_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend"},
+		{"resolution_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend", "Ikea pendant light", "ikea-pendant-light_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend"},
+		{"resolution_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend", "Ikea pendant light", "ikea-pendant-light_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend"},
+		{"blend_934e424b-d890-4ba7-98c3-85b733cdc94a.blend", "Gray Carpet (Procedural)", "gray-carpet-procedural_934e424b-d890-4ba7-98c3-85b733cdc94a.blend"},
+		{"blend_6ab98d58-8502-4087-a007-f3bd23f393a7.blend", "White minimal product mockups", "white-minimal-product-mockups_6ab98d58-8502-4087-a007-f3bd23f393a7.blend"},
 		{"blend_1234567890.blend", "Some Very Very Extremely Long Asset Name Which Needs To Be Shortened In the Final Blend File Name Or It Will Cause Problems on Windows", "some-very-very-extremely-long-asset-name-which-nee_1234567890.blend"},
 	}
 

--- a/paths.py
+++ b/paths.py
@@ -49,6 +49,7 @@ BLENDERKIT_SIGNUP_URL = f"{global_vars.SERVER}/accounts/register"
 
 WINDOWS_PATH_LIMIT = 250
 
+
 def cleanup_old_folders():
     """function to clean up any historical folders for BlenderKit. By now removes the temp folder."""
     orig_temp = os.path.join(os.path.expanduser("~"), "blenderkit_data", "temp")
@@ -162,15 +163,22 @@ def get_download_dirs(asset_type):
             os.makedirs(subdir)
         dirs.append(subdir)
 
-    if global_vars.PREFS["directory_behaviour"] in ("BOTH", "LOCAL") and bpy.data.is_saved:  # it's important local get's solved as second, since for the linking process only last filename will be taken. For download process first name will be taken and if 2 filenames were returned, file will be copied to the 2nd path.
+    if (
+        global_vars.PREFS["directory_behaviour"] in ("BOTH", "LOCAL")
+        and bpy.data.is_saved
+    ):  # it's important local get's solved as second, since for the linking process only last filename will be taken. For download process first name will be taken and if 2 filenames were returned, file will be copied to the 2nd path.
         ddir = global_vars.PREFS["project_subdir"]
         ddir = bpy.path.abspath(ddir)
         subdir = os.path.join(ddir, subdmapping[asset_type])
         if sys.platform == "win32" and len(subdir) > WINDOWS_PATH_LIMIT:
-            bk_logger.warning(f"Skipping LOCAL download directory. Over 250 characters: {ddir}")
-            return dirs # project subdir is over 250, no space for adding filenames later
+            bk_logger.warning(
+                f"Skipping LOCAL download directory. Over 250 characters: {ddir}"
+            )
+            return (
+                dirs  # project subdir is over 250, no space for adding filenames later
+            )
         if not os.path.exists(subdir):
-            os.makedirs(subdir) # this would fail if path was over 260
+            os.makedirs(subdir)  # this would fail if path was over 260
         dirs.append(subdir)
 
     return dirs
@@ -193,7 +201,7 @@ def slugify(input: str) -> str:
     # Replace multiple hyphens with a single one
     slug = re.sub(r"[-]+", "-", slug)
 
-	# Ensure the slug does not exceed 50 characters
+    # Ensure the slug does not exceed 50 characters
     if len(slug) > 50:
         slug = slug[:50]
 
@@ -207,7 +215,7 @@ def extract_filename_from_url(url):
     """Mirrors utils.go/ExtractFilenameFromURL()"""
     if url is None:
         return ""
-    
+
     filename = url.split("/")[-1]
     filename = filename.split("?")[0]
     return filename
@@ -289,7 +297,7 @@ def get_res_file(asset_data, resolution, find_closest_with_url=False):
 def server_to_local_filename(server_filename: str, asset_name: str) -> str:
     """
     Convert server format filename to human readable local filename. Function mirrors: utils.go/ServerToLocalFilename()
-    
+
     "resolution_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend" > "asset-name_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend"
 
     "blend_d5368c9d-092e-4319-afe1-dd765de6da01.blend" > "asset-name_d5368c9d-092e-4319-afe1-dd765de6da01.blend"

--- a/test_paths.py
+++ b/test_paths.py
@@ -53,52 +53,119 @@ class TestGlobalDict(unittest.TestCase):
         path = pathlib.Path(result)
         self.assertTrue(path.is_dir(), msg=path)
 
+
 class TestSlugify(unittest.TestCase):
     """Same test data as in utils_test.go/TestSlugify()"""
+
     data = (
         ("", ""),
-		("Jane Doe", "jane-doe"),
-		("John A. Doe", "john-a-doe"),
-		("Anezka92", "anezka92"),
-		("My--Username", "my-username"),
-		("My__Username, 123", "my-username-123"),
-		("My? Name! Is: Dada", "my-name-is-dada"),
-		("Lorem ipsum dolor sit amet, consectetur adipiscing <-50th char is space, ending hyphen will be remove, leading to 49chars. Consectetur ante hendrerit.", "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing")
+        ("Jane Doe", "jane-doe"),
+        ("John A. Doe", "john-a-doe"),
+        ("Anezka92", "anezka92"),
+        ("My--Username", "my-username"),
+        ("My__Username, 123", "my-username-123"),
+        ("My? Name! Is: Dada", "my-name-is-dada"),
+        (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing <-50th char is space, ending hyphen will be remove, leading to 49chars. Consectetur ante hendrerit.",
+            "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing",
+        ),
     )
+
     def test_slugify(self):
         for asset_name, expected in self.data:
             result = paths.slugify(asset_name)
-            self.assertEqual(result, expected, msg=f'slugify("{asset_name}")="{result}"; expected:"{expected}"')
+            self.assertEqual(
+                result,
+                expected,
+                msg=f'slugify("{asset_name}")="{result}"; expected:"{expected}"',
+            )
+
 
 class TestServerToLocalFilename(unittest.TestCase):
     """Same test data as in utils_test.go/TestServerToLocalFilename()"""
+
     data = (
-	    ("resolution_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend", "Cat on Books Statue 3D Scan", "cat-on-books-statue-3d-scan_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend"),
-		("resolution_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend", "Apple iPad With Keyboard", "apple-ipad-with-keyboard_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend"),
-		("resolution_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend", "Ikea pendant light", "ikea-pendant-light_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend"),
-		("resolution_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend", "Ikea pendant light", "ikea-pendant-light_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend"),
-		("blend_934e424b-d890-4ba7-98c3-85b733cdc94a.blend", "Gray Carpet (Procedural)", "gray-carpet-procedural_934e424b-d890-4ba7-98c3-85b733cdc94a.blend"),
-		("blend_6ab98d58-8502-4087-a007-f3bd23f393a7.blend", "White minimal product mockups", "white-minimal-product-mockups_6ab98d58-8502-4087-a007-f3bd23f393a7.blend"),
-		("blend_1234567890.blend", "Some Very Very Extremely Long Asset Name Which Needs To Be Shortened In the Final Blend File Name Or It Will Cause Problems on Windows", "some-very-very-extremely-long-asset-name-which-nee_1234567890.blend"),
+        (
+            "resolution_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend",
+            "Cat on Books Statue 3D Scan",
+            "cat-on-books-statue-3d-scan_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend",
+        ),
+        (
+            "resolution_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend",
+            "Apple iPad With Keyboard",
+            "apple-ipad-with-keyboard_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend",
+        ),
+        (
+            "resolution_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend",
+            "Ikea pendant light",
+            "ikea-pendant-light_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend",
+        ),
+        (
+            "resolution_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend",
+            "Ikea pendant light",
+            "ikea-pendant-light_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend",
+        ),
+        (
+            "blend_934e424b-d890-4ba7-98c3-85b733cdc94a.blend",
+            "Gray Carpet (Procedural)",
+            "gray-carpet-procedural_934e424b-d890-4ba7-98c3-85b733cdc94a.blend",
+        ),
+        (
+            "blend_6ab98d58-8502-4087-a007-f3bd23f393a7.blend",
+            "White minimal product mockups",
+            "white-minimal-product-mockups_6ab98d58-8502-4087-a007-f3bd23f393a7.blend",
+        ),
+        (
+            "blend_1234567890.blend",
+            "Some Very Very Extremely Long Asset Name Which Needs To Be Shortened In the Final Blend File Name Or It Will Cause Problems on Windows",
+            "some-very-very-extremely-long-asset-name-which-nee_1234567890.blend",
+        ),
     )
+
     def test_server_to_local_filename(self):
         for server_filename, asset_name, expected in self.data:
             result = paths.server_to_local_filename(server_filename, asset_name)
-            self.assertEqual(result, expected, msg=f'server_to_local_filename("{server_filename}", "{asset_name}")="{result}"; expected:"{expected}"')
+            self.assertEqual(
+                result,
+                expected,
+                msg=f'server_to_local_filename("{server_filename}", "{asset_name}")="{result}"; expected:"{expected}"',
+            )
+
 
 class TestExtractFilenameFromUrl(unittest.TestCase):
     """Same test data as in utils_test.go/TestExtractFilenameFromUrl()"""
+
     data = (
         ("https://example.com/file.txt", "file.txt"),
-		("https://example.com/path/to/file.jpg", "file.jpg"),
-		("https://example.com/path/to/file%2Cwith%2Ccomma.txt", "file%2Cwith%2Ccomma.txt"),
-		("https://public.blenderkit.com/thumbnails/assets/57ec74ff91b54b2ca5a540cda907cf7a/files/thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp?webp_generated=1701166007", "thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp"),
-		("https://public.blenderkit.com/thumbnails/assets/6144bbda83ca47ec8b9adb813c56f660/files/thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp?webp_generated=1709019959", "thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp"),
-		("https://public.blenderkit.com/public-assets/assets/76d2e7eaa0af42a8b33e1498c1da22f8/files/blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend", "blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend"),
-		("https://d255qm5a95hvrp.cloudfront.net/assets/0a00681c598c42259f67b69e6642f5dc/files/resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend?Expires=1709125449&Signature=LO-Gp1BfBe3maWncgvOep4ZNM9DJj0AdtMtjd9IN~OZQ5HPG1Cfy5408Bd0GskRTcgHuXjthLbhS3cWzksJrNrYA2L3zglK1ThSpdTtG4KwgGzlcyj7FXqmaKFul8Kpqu3weQaN1uazSzZSw5dN3Qxq0mb~7mPm6b8s7bJ6YeyUiWyL8qK8T-ff7hkzwb0tCIAyA3~9ZRImiwL0-OePg4I9Jl9LA32v2BuVJVkXp-kQkDb3VFRbhz9WCjFp0al7SqsFcpiIuJoFWp7UjTurqM85VX4jra9LQocA2svRk8fbrhTHkQRvMKJ3onqaA1Ou2Q71~-mL1aXxEfapDNk3euA__&Key-Pair-Id=KHZSXFBGJQRJ3", "resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend"),
-		("", ""),
+        ("https://example.com/path/to/file.jpg", "file.jpg"),
+        (
+            "https://example.com/path/to/file%2Cwith%2Ccomma.txt",
+            "file%2Cwith%2Ccomma.txt",
+        ),
+        (
+            "https://public.blenderkit.com/thumbnails/assets/57ec74ff91b54b2ca5a540cda907cf7a/files/thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp?webp_generated=1701166007",
+            "thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp",
+        ),
+        (
+            "https://public.blenderkit.com/thumbnails/assets/6144bbda83ca47ec8b9adb813c56f660/files/thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp?webp_generated=1709019959",
+            "thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp",
+        ),
+        (
+            "https://public.blenderkit.com/public-assets/assets/76d2e7eaa0af42a8b33e1498c1da22f8/files/blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend",
+            "blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend",
+        ),
+        (
+            "https://d255qm5a95hvrp.cloudfront.net/assets/0a00681c598c42259f67b69e6642f5dc/files/resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend?Expires=1709125449&Signature=LO-Gp1BfBe3maWncgvOep4ZNM9DJj0AdtMtjd9IN~OZQ5HPG1Cfy5408Bd0GskRTcgHuXjthLbhS3cWzksJrNrYA2L3zglK1ThSpdTtG4KwgGzlcyj7FXqmaKFul8Kpqu3weQaN1uazSzZSw5dN3Qxq0mb~7mPm6b8s7bJ6YeyUiWyL8qK8T-ff7hkzwb0tCIAyA3~9ZRImiwL0-OePg4I9Jl9LA32v2BuVJVkXp-kQkDb3VFRbhz9WCjFp0al7SqsFcpiIuJoFWp7UjTurqM85VX4jra9LQocA2svRk8fbrhTHkQRvMKJ3onqaA1Ou2Q71~-mL1aXxEfapDNk3euA__&Key-Pair-Id=KHZSXFBGJQRJ3",
+            "resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend",
+        ),
+        ("", ""),
     )
+
     def test_extract_filename_from_url(self):
         for url, expected in self.data:
             result = paths.extract_filename_from_url(url)
-            self.assertEqual(result, expected, msg=f'extract_filename_from_url("{url}")="{result}"; expected:"{expected}"')
+            self.assertEqual(
+                result,
+                expected,
+                msg=f'extract_filename_from_url("{url}")="{result}"; expected:"{expected}"',
+            )

--- a/test_paths.py
+++ b/test_paths.py
@@ -52,3 +52,53 @@ class TestGlobalDict(unittest.TestCase):
         result = paths.default_global_dict()
         path = pathlib.Path(result)
         self.assertTrue(path.is_dir(), msg=path)
+
+class TestSlugify(unittest.TestCase):
+    """Same test data as in utils_test.go/TestSlugify()"""
+    data = (
+        ("", ""),
+		("Jane Doe", "jane-doe"),
+		("John A. Doe", "john-a-doe"),
+		("Anezka92", "anezka92"),
+		("My--Username", "my-username"),
+		("My__Username, 123", "my-username-123"),
+		("My? Name! Is: Dada", "my-name-is-dada"),
+		("Lorem ipsum dolor sit amet, consectetur adipiscing <-50th char is space, ending hyphen will be remove, leading to 49chars. Consectetur ante hendrerit.", "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing")
+    )
+    def test_slugify(self):
+        for asset_name, expected in self.data:
+            result = paths.slugify(asset_name)
+            self.assertEqual(result, expected, msg=f'slugify("{asset_name}")="{result}"; expected:"{expected}"')
+
+class TestServerToLocalFilename(unittest.TestCase):
+    """Same test data as in utils_test.go/TestServerToLocalFilename()"""
+    data = (
+	    ("resolution_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend", "Cat on Books Statue 3D Scan", "cat-on-books-statue-3d-scan_2K_a5cbcda4-d00c-4494-bbbc-be205a9eb5ca.blend"),
+		("resolution_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend", "Apple iPad With Keyboard", "apple-ipad-with-keyboard_2K_0d0e0897-8649-4c8d-8b0c-296b15c3f7a8.blend"),
+		("resolution_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend", "Ikea pendant light", "ikea-pendant-light_0_5K_0ee98e49-98be-4b38-8c5e-a0eb4d99766d.blend"),
+		("resolution_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend", "Ikea pendant light", "ikea-pendant-light_1K_e4248d23-fedb-4aa4-ac4d-b824bc5d0da2.blend"),
+		("blend_934e424b-d890-4ba7-98c3-85b733cdc94a.blend", "Gray Carpet (Procedural)", "gray-carpet-procedural_934e424b-d890-4ba7-98c3-85b733cdc94a.blend"),
+		("blend_6ab98d58-8502-4087-a007-f3bd23f393a7.blend", "White minimal product mockups", "white-minimal-product-mockups_6ab98d58-8502-4087-a007-f3bd23f393a7.blend"),
+		("blend_1234567890.blend", "Some Very Very Extremely Long Asset Name Which Needs To Be Shortened In the Final Blend File Name Or It Will Cause Problems on Windows", "some-very-very-extremely-long-asset-name-which-nee_1234567890.blend"),
+    )
+    def test_server_to_local_filename(self):
+        for server_filename, asset_name, expected in self.data:
+            result = paths.server_to_local_filename(server_filename, asset_name)
+            self.assertEqual(result, expected, msg=f'server_to_local_filename("{server_filename}", "{asset_name}")="{result}"; expected:"{expected}"')
+
+class TestExtractFilenameFromUrl(unittest.TestCase):
+    """Same test data as in utils_test.go/TestExtractFilenameFromUrl()"""
+    data = (
+        ("https://example.com/file.txt", "file.txt"),
+		("https://example.com/path/to/file.jpg", "file.jpg"),
+		("https://example.com/path/to/file%2Cwith%2Ccomma.txt", "file%2Cwith%2Ccomma.txt"),
+		("https://public.blenderkit.com/thumbnails/assets/57ec74ff91b54b2ca5a540cda907cf7a/files/thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp?webp_generated=1701166007", "thumbnail_99e43644-30de-4361-9a7e-605eaf7d6795.jpg.256x256_q85_crop-%2C.jpg.webp"),
+		("https://public.blenderkit.com/thumbnails/assets/6144bbda83ca47ec8b9adb813c56f660/files/thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp?webp_generated=1709019959", "thumbnail_59686100-7ad0-4b38-b6fd-5158a6192a31.png.256x256_q85_crop-%2C.png.webp"),
+		("https://public.blenderkit.com/public-assets/assets/76d2e7eaa0af42a8b33e1498c1da22f8/files/blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend", "blend_0551adba-93bf-4f0e-aaeb-73927db46f88.blend"),
+		("https://d255qm5a95hvrp.cloudfront.net/assets/0a00681c598c42259f67b69e6642f5dc/files/resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend?Expires=1709125449&Signature=LO-Gp1BfBe3maWncgvOep4ZNM9DJj0AdtMtjd9IN~OZQ5HPG1Cfy5408Bd0GskRTcgHuXjthLbhS3cWzksJrNrYA2L3zglK1ThSpdTtG4KwgGzlcyj7FXqmaKFul8Kpqu3weQaN1uazSzZSw5dN3Qxq0mb~7mPm6b8s7bJ6YeyUiWyL8qK8T-ff7hkzwb0tCIAyA3~9ZRImiwL0-OePg4I9Jl9LA32v2BuVJVkXp-kQkDb3VFRbhz9WCjFp0al7SqsFcpiIuJoFWp7UjTurqM85VX4jra9LQocA2svRk8fbrhTHkQRvMKJ3onqaA1Ou2Q71~-mL1aXxEfapDNk3euA__&Key-Pair-Id=KHZSXFBGJQRJ3", "resolution_2K_02dacc88-532e-4b68-b8cb-4f1b8df1814b.blend"),
+		("", ""),
+    )
+    def test_extract_filename_from_url(self):
+        for url, expected in self.data:
+            result = paths.extract_filename_from_url(url)
+            self.assertEqual(result, expected, msg=f'extract_filename_from_url("{url}")="{result}"; expected:"{expected}"')


### PR DESCRIPTION
fixes #1147 

- Make sure in Client that filepath is not longer than 250
- Make sure it is not longer even at the start of download when add-on checks download dirs - if LOCAL/assets/models is longer, then there is no need to send it to Client - it will not get shorter by appneding another dir and filename, both with UUIDs
- Synces Slugify in Python with Go implementation
- Adds python tests for slugify, server_to_local_filename and extract_filename_from_url, test data are the same as in Go tests for go variants of these functions, so we can be sure they behave the same