### PR TITLE
#1154 Make the add-on ready for extensions format

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,8 +25,6 @@ jobs:
         continue-on-error: true
       - name: BLACK
         run: python -m black . --check --diff
-      #- name: RUFF on ./daemon
-      #  run: python -m ruff daemon
       - name: Server set to production
         run: python3 -c 'from global_vars import SERVER; assert SERVER == "https://www.blenderkit.com"'
 
@@ -36,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check CLIENT_VERSION
         run: python -c 'from global_vars import CLIENT_VERSION; VERSION = open("client/VERSION").read().strip(); assert CLIENT_VERSION == f"v{VERSION}", "CLIENT_VERSION does not match the content of client/VERSION"'
+      - name: Check add-on VERSION
+        run: python -c "import re; f = open('__init__.py'); bl_info_version = re.search(r'\"version\":\s*(\(.*?\))', f.read()).group(1); f.seek(0); VERSION = re.search(r'VERSION =\s*(\(.*?\))', f.read()).group(1); f.close(); assert bl_info_version == VERSION"
 
   Client-Unit-Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -36,6 +36,8 @@ jobs:
         run: python -c 'from global_vars import CLIENT_VERSION; VERSION = open("client/VERSION").read().strip(); assert CLIENT_VERSION == f"v{VERSION}", "CLIENT_VERSION does not match the content of client/VERSION"'
       - name: Check add-on VERSION
         run: python -c "import re; f = open('__init__.py'); bl_info_version = re.search(r'\"version\":\s*(\(.*?\))', f.read()).group(1); f.seek(0); VERSION = re.search(r'VERSION =\s*(\(.*?\))', f.read()).group(1); f.close(); assert bl_info_version == VERSION"
+      - name: Check blender_manifest.toml
+        run: python -c "import re; f = open('__init__.py'); match = re.search(r'VERSION\s+=\s+\((\d+),\s+(\d+),\s+(\d+),\s+(\d{6})\)', f.read()); VERSION = (match.group(1), match.group(2), match.group(3), match.group(4)); f.close(); m = open('blender_manifest.toml'); match = re.search(r'version\s+=\s+\"(\d+)\.(\d+)\.(\d+)-(\d{6})\"', m.read()); manifest_version = (match.group(1), match.group(2), match.group(3), match.group(4)); m.close(); assert manifest_version == VERSION"
 
   Client-Unit-Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -28,6 +28,8 @@ jobs:
         run: python -c 'from global_vars import CLIENT_VERSION; VERSION = open("client/VERSION").read().strip(); assert CLIENT_VERSION == f"v{VERSION}", "CLIENT_VERSION does not match the content of client/VERSION"'
       - name: Check add-on VERSION
         run: python -c "import re; f = open('__init__.py'); bl_info_version = re.search(r'\"version\":\s*(\(.*?\))', f.read()).group(1); f.seek(0); VERSION = re.search(r'VERSION =\s*(\(.*?\))', f.read()).group(1); f.close(); assert bl_info_version == VERSION"
+      - name: Check blender_manifest.toml
+        run: python -c "import re; f = open('__init__.py'); match = re.search(r'VERSION\s+=\s+\((\d+),\s+(\d+),\s+(\d+),\s+(\d{6})\)', f.read()); VERSION = (match.group(1), match.group(2), match.group(3), match.group(4)); f.close(); m = open('blender_manifest.toml'); match = re.search(r'version\s+=\s+\"(\d+)\.(\d+)\.(\d+)-(\d{6})\"', m.read()); manifest_version = (match.group(1), match.group(2), match.group(3), match.group(4)); m.close(); assert manifest_version == VERSION"
 
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -17,8 +17,6 @@ jobs:
         continue-on-error: true
       - name: BLACK
         run: python -m black . --check --diff
-      #- name: RUFF on ./daemon
-      #  run: python -m ruff daemon
       - name: Server set to production
         run: python3 -c 'from global_vars import SERVER; assert SERVER == "https://www.blenderkit.com"'
 
@@ -28,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check CLIENT_VERSION
         run: python -c 'from global_vars import CLIENT_VERSION; VERSION = open("client/VERSION").read().strip(); assert CLIENT_VERSION == f"v{VERSION}", "CLIENT_VERSION does not match the content of client/VERSION"'
+      - name: Check add-on VERSION
+        run: python -c "import re; f = open('__init__.py'); bl_info_version = re.search(r'\"version\":\s*(\(.*?\))', f.read()).group(1); f.seek(0); VERSION = re.search(r'VERSION =\s*(\(.*?\))', f.read()).group(1); f.close(); assert bl_info_version == VERSION"
 
   Build:
     runs-on: ubuntu-latest

--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ bl_info = {
     "tracker_url": "https://github.com/BlenderKit/blenderkit/issues",
     "category": "3D View",
 }
-VERSION = (3, 12, 1, 240520)
+VERSION = (3, 12, 1, 240614)
 
 import logging
 import sys
@@ -2333,6 +2333,7 @@ classes = (
 
 def register():
     reload(global_vars)
+    global_vars.VERSION = VERSION
     bpy.utils.register_class(BlenderKitAddonPreferences)
 
     addon_updater_ops.register({"version": VERSION})
@@ -2383,7 +2384,6 @@ def register():
         type=BlenderKitBrushUploadProps
     )
 
-    global_vars.VERSION = VERSION
     if bpy.app.factory_startup is False:
         user_preferences = bpy.context.preferences.addons[__package__].preferences
         global_vars.PREFS = utils.get_preferences_as_dict()

--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,7 @@ bl_info = {
     "tracker_url": "https://github.com/BlenderKit/blenderkit/issues",
     "category": "3D View",
 }
+VERSION = (3, 12, 1, 240520)
 
 import logging
 import sys
@@ -189,7 +190,7 @@ def scene_load(context):
     if (
         bpy.app.factory_startup is False
     ):  # factory_start is used in bg blender runs, but we want to run for tests in background mode
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         preferences.login_attempt = False
 
 
@@ -1853,7 +1854,7 @@ def update_unpack(self, context):
 
 
 class BlenderKitAddonPreferences(AddonPreferences):
-    bl_idname = __name__
+    bl_idname = __package__
     default_global_dict = paths.default_global_dict()
 
     preferences_lock: BoolProperty(
@@ -2334,7 +2335,7 @@ def register():
     reload(global_vars)
     bpy.utils.register_class(BlenderKitAddonPreferences)
 
-    addon_updater_ops.register(bl_info)
+    addon_updater_ops.register({"version": VERSION})
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -2382,9 +2383,9 @@ def register():
         type=BlenderKitBrushUploadProps
     )
 
-    global_vars.VERSION = bl_info["version"]
+    global_vars.VERSION = VERSION
     if bpy.app.factory_startup is False:
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         global_vars.PREFS = utils.get_preferences_as_dict()
         daemon_lib.reorder_ports(user_preferences.daemon_port)
         timer.update_trusted_CA_certs(user_preferences.trusted_ca_certs)

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -72,7 +72,7 @@ BL_UI_Widget.get_area_height = get_area_height
 def modal_inside(self, context, event):
     try:
         ui_props = bpy.context.window_manager.blenderkitUI
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
 
         if ui_props.turn_off:
             ui_props.turn_off = False
@@ -466,7 +466,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.tooltip_widgets.append(quality_label)
         self.quality_label = quality_label
 
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         offset = 0
         if (
             user_preferences.asset_popup_counter
@@ -602,7 +602,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         area = context.area
 
         ui_props = bpy.context.window_manager.blenderkitUI
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         ui_scale = bpy.context.preferences.view.ui_scale
 
         # assetbar scaling

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -764,7 +764,7 @@ class AssetDragOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         dir_behaviour = bpy.context.preferences.addons[
-            "blenderkit"
+            __package__
         ].preferences.directory_behaviour
         if dir_behaviour == "LOCAL" and bpy.data.filepath == "":
             message = "Save the project to download in local directory mode."

--- a/autothumb.py
+++ b/autothumb.py
@@ -175,7 +175,7 @@ def start_model_thumbnailer(
         props.thumbnail_generating_state = "Saving .blend file"
 
     datafile = os.path.join(json_args["tempdir"], BLENDERKIT_EXPORT_DATA_FILE)
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     json_args["thumbnail_use_gpu"] = user_preferences.thumbnail_use_gpu
     if user_preferences.thumbnail_use_gpu is True:
         json_args["cycles_compute_device_type"] = bpy.context.preferences.addons[
@@ -250,7 +250,7 @@ def start_material_thumbnailer(
         props.thumbnail_generating_state = "Saving .blend file"
 
     datafile = os.path.join(json_args["tempdir"], BLENDERKIT_EXPORT_DATA_FILE)
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     json_args["thumbnail_use_gpu"] = user_preferences.thumbnail_use_gpu
     if user_preferences.thumbnail_use_gpu is True:
         json_args["cycles_compute_device_type"] = bpy.context.preferences.addons[
@@ -328,7 +328,7 @@ class GenerateThumbnailOperator(bpy.types.Operator):
         layout.prop(props, "thumbnail_samples")
         layout.prop(props, "thumbnail_resolution")
         layout.prop(props, "thumbnail_denoising")
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         layout.prop(preferences, "thumbnail_use_gpu")
 
     def execute(self, context):
@@ -484,7 +484,7 @@ class ReGenerateThumbnailOperator(bpy.types.Operator):
         layout.prop(props, "thumbnail_samples")
         layout.prop(props, "thumbnail_resolution")
         layout.prop(props, "thumbnail_denoising")
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         layout.prop(preferences, "thumbnail_use_gpu")
 
     def execute(self, context):
@@ -562,7 +562,7 @@ class GenerateMaterialThumbnailOperator(bpy.types.Operator):
         layout.prop(props, "thumbnail_samples")
         layout.prop(props, "thumbnail_denoising")
         layout.prop(props, "adaptive_subdivision")
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         layout.prop(preferences, "thumbnail_use_gpu")
 
     def execute(self, context):
@@ -726,7 +726,7 @@ class ReGenerateMaterialThumbnailOperator(bpy.types.Operator):
         layout.prop(props, "thumbnail_samples")
         layout.prop(props, "thumbnail_denoising")
         layout.prop(props, "adaptive_subdivision")
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         layout.prop(preferences, "thumbnail_use_gpu")
 
     def execute(self, context):

--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -61,7 +61,7 @@ def handle_token_refresh_task(task: daemon_tasks.Task):
     """Handle incoming task of type token_refresh. If the new token is meant for the current user, calls handle_login_task.
     Otherwise it ignores the incoming task.
     """
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     if task.data.get("old_api_key") != preferences.api_key:
         bk_logger.info("Refreshed token is not meant for current user. Ignoring.")
         return
@@ -98,7 +98,7 @@ def handle_logout_task(task: daemon_tasks.Task):
 
 
 def clean_login_data():
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     preferences.login_attempt = False
     preferences.api_key_refresh = ""
     preferences.api_key = ""
@@ -148,7 +148,7 @@ def generate_pkce_pair() -> tuple[str, str]:
 
 
 def write_tokens(auth_token, refresh_token, oauth_response):
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     preferences.api_key_timeout = int(time.time() + oauth_response["expires_in"])
     preferences.login_attempt = False
     preferences.api_key_refresh = refresh_token
@@ -159,7 +159,7 @@ def ensure_token_refresh() -> bool:
     """Check if API token needs refresh, call refresh and return True if so.
     Otherwise do nothing and return False.
     """
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     if preferences.api_key == "":  # Not logged in
         return False
 
@@ -203,14 +203,14 @@ class LoginOnline(bpy.types.Operator):
         utils.label_multiline(layout, text=self.message, width=300)
 
     def execute(self, context):
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         preferences.login_attempt = True
         login(self.signup)
         return {"FINISHED"}
 
     def invoke(self, context, event):
         wm = bpy.context.window_manager
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         preferences.api_key_refresh = ""
         preferences.api_key = ""
         return wm.invoke_props_dialog(self)
@@ -244,7 +244,7 @@ class CancelLoginOnline(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         preferences.login_attempt = False
         return {"FINISHED"}
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -5,7 +5,7 @@ type = "add-on"
 version = "3.12.0-beta2"
 
 name = "BlenderKit Online Asset Library"
-tagline = "Boost your workflow with drag & drop of assets from the community driven library. Access over 10,000 models, 10,000 materials, 250 scenes, 1,000 HDRIs, and 300 brushes for free, no login required. Or sign in with the Free Plan to bookmark and rate assets, for even faster workflow. And there's more! Unlock the complete potential (27,000+ models, 10,000+ materials, 750+ scenes, 1,500+ HDRIs, 850+ brushes) with a BlenderKit Full plan subscription, supporting the creators of all assets."
+tagline = "Drag & drop of assets from the community driven library"
 maintainer = "Vilém Duha <admin@blenderkit.com>"
 website = "https://blenderkit.com/"
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -2,7 +2,7 @@ schema_version = "1.0.0"
 
 id = "blenderkit"
 type = "add-on"
-version = "3.12.0-beta2"
+version = "3.12.1-240614" # X.Y.Z-YYYYMMDD, must have a dash instead of a dot
 
 name = "BlenderKit Online Asset Library"
 tagline = "Drag & drop of assets from the community driven library"

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -58,7 +58,7 @@ def ensure_minimal_data(data: dict = None) -> dict:
     av = global_vars.VERSION
     if "api_key" not in data:  # for BG instances, where preferences are not available
         data.setdefault(
-            "api_key", bpy.context.preferences.addons["blenderkit"].preferences.api_key
+            "api_key", bpy.context.preferences.addons[__package__].preferences.api_key
         )
     data.setdefault("app_id", os.getpid())
     data.setdefault("platform_version", platform.platform())
@@ -616,7 +616,7 @@ def decide_client_binary_name() -> str:
 
 def get_client_directory() -> str:
     """Get the path to the BlenderKit-Client directory located in global_dir."""
-    global_dir = bpy.context.preferences.addons["blenderkit"].preferences.global_dir
+    global_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
     directory = path.join(global_dir, "client")
     return directory
 

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -273,7 +273,7 @@ def handle_disclaimer_task(task: daemon_tasks.Task):
             return show_random_tip()
 
         disclaimer = task.result["results"][0]
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         if preferences.announcements_on_start is False:
             bk_logger.warning(
                 f"Online announcements are disabled! Message hidden from GUI: {disclaimer['message']}"
@@ -295,7 +295,7 @@ def handle_disclaimer_task(task: daemon_tasks.Task):
 
 def show_random_tip():
     """Shows random tip in the disclaimer popup if tips_on_start are enabled."""
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     if preferences.tips_on_start is False:
         return
     tip = random.choice(global_vars.TIPS)

--- a/download.py
+++ b/download.py
@@ -292,7 +292,7 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
     # link the group we are interested in( there are more groups in File!!!! , have to get the correct one!)
     s = bpy.context.scene
     wm = bpy.context.window_manager
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     user_preferences.download_counter += 1
 
     if asset_data["assetType"] == "scene":
@@ -1282,7 +1282,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
 
         # when not in scene nor in search results, we need to get it from the server
         params = {"asset_base_id": self.asset_base_id}
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         results = search.get_search_simple(
             params, page_size=1, max_results=1, api_key=preferences.api_key
         )
@@ -1290,7 +1290,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
         return asset_data
 
     def execute(self, context):
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
         self.asset_data = self.get_asset_data(context)
 
         if not has_asset_files(self.asset_data):
@@ -1381,7 +1381,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
         # only make a pop up in case of switching resolutions
         if self.invoke_resolution:
             self.asset_data = self.get_asset_data(context)
-            preferences = bpy.context.preferences.addons["blenderkit"].preferences
+            preferences = bpy.context.preferences.addons[__package__].preferences
 
             # set initial resolutions enum activation
             if preferences.resolution != "ORIGINAL" and int(

--- a/paths.py
+++ b/paths.py
@@ -97,7 +97,7 @@ dirs_exist_dict = {}  # cache these results since this is used very often
 # this causes the function to fail if user deletes the directory while blender is running,
 # but comes back when blender is restarted.
 def get_temp_dir(subdir=None):
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     # first try cached results
     if subdir is not None:
         d = dirs_exist_dict.get(subdir)
@@ -387,7 +387,7 @@ def get_download_filepaths(asset_data, resolution="blend", can_return_others=Fal
 
 def delete_asset_debug(asset_data):
     """TODO fix this for resolutions - should get ALL files from ALL resolutions."""
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     api_key = user_preferences.api_key
 
     _, download_url, file_name = daemon_lib.get_download_url(
@@ -460,7 +460,7 @@ def get_addon_thumbnail_path(name):
 
 def get_config_dir_path() -> str:
     """Get the path to the config directory in global_dir."""
-    global_dir = bpy.context.preferences.addons["blenderkit"].preferences.global_dir
+    global_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
     directory = os.path.join(global_dir, "config")
     return os.path.abspath(directory)
 

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -61,7 +61,7 @@ def load_preferences_from_JSON():
         os.remove(preferences_path)
         return utils.get_preferences_as_dict()
 
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     user_preferences.preferences_lock = True
 
     # STATISTICS

--- a/ratings.py
+++ b/ratings.py
@@ -59,7 +59,7 @@ def draw_ratings_menu(self, context, layout):
     pcoll = icons.icon_collections["main"]
 
     if not utils.user_logged_in():
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         if user_preferences.login_attempt:
             ui_panels.draw_login_progress(layout)
         else:

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -176,7 +176,7 @@ def update_ratings_work_hours(self, context):
 
 def update_quality_ui(self, context):
     """Converts the _ui the enum into actual quality number."""
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     # we need to check for matching value not to update twice/call the popup twice.
     if user_preferences.api_key == "" and self.rating_quality != int(
         self.rating_quality_ui
@@ -191,7 +191,7 @@ def update_quality_ui(self, context):
 
 
 def update_ratings_work_hours_ui(self, context):
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     if user_preferences.api_key == "" and self.rating_work_hours != float(
         self.rating_work_hours_ui
     ):

--- a/search.py
+++ b/search.py
@@ -937,7 +937,7 @@ def search(get_next=False, query=None, author_id=""):
         )
         return
 
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
 
     wm = bpy.context.window_manager
     ui_props = bpy.context.window_manager.blenderkitUI

--- a/test_init.py
+++ b/test_init.py
@@ -32,7 +32,7 @@ class Test01Registration(unittest.TestCase):
 
     def test02_global_vars_PREFS_set(self):
         assert global_vars.PREFS != {}
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         prefs = {
             # SYSTEM STUFF
             "debug_value": bpy.app.debug_value,

--- a/test_init.py
+++ b/test_init.py
@@ -32,7 +32,7 @@ class Test01Registration(unittest.TestCase):
 
     def test02_global_vars_PREFS_set(self):
         assert global_vars.PREFS != {}
-        user_preferences = bpy.context.preferences.addons[__package__].preferences
+        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
         prefs = {
             # SYSTEM STUFF
             "debug_value": bpy.app.debug_value,

--- a/timer.py
+++ b/timer.py
@@ -194,7 +194,7 @@ def cancel_all_tasks(self, context):
 def task_error_overdrive(task: daemon_tasks.Task) -> None:
     """Handle error task - overdrive some error messages, trigger functions common for all errors."""
     if task.message.count("Invalid token.") > 0 and utils.user_logged_in():
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
 
         # Invalid token and api_key_refresh present -> trying to refresh the token
         if preferences.api_key_refresh != "":
@@ -343,7 +343,7 @@ def on_startup_daemon_online_timer():
     if not global_vars.CLIENT_RUNNING:
         return 1
 
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     refresh_needed = bkit_oauth.ensure_token_refresh()
     if refresh_needed:  # called for new API token, lets wait for a while
         return 1

--- a/ui.py
+++ b/ui.py
@@ -132,7 +132,7 @@ def is_rating_possible():
     # TODO remove this, but first check and reuse the code for new rating system...
     ao = bpy.context.active_object
     ui = bpy.context.window_manager.blenderkitUI
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     # first test if user is logged in.
     if preferences.api_key == "":
         return False, False, None, None
@@ -472,7 +472,7 @@ def pre_load(context):
     ui_props.assetbar_on = False
     ui_props.turn_off = True
     # TODO: is this needed?
-    # preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    # preferences = bpy.context.preferences.addons[__package__].preferences
     # preferences.login_attempt = False
 
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -554,7 +554,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
     def draw_header(self, context):
         layout = self.layout
         layout.emboss = "NORMAL"
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         if user_preferences.api_key != "":
             layout.label(text="BlenderKit Profile", icon="USER")
         else:
@@ -568,7 +568,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
             layout.label(text="Client not running")
             return
 
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
 
         if user_preferences.login_attempt:
             draw_login_progress(layout)
@@ -749,7 +749,7 @@ class UpvoteComment(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         api_key = user_preferences.api_key
         comments = comments_utils.get_comments_local(self.asset_id)
         if comments is not None:
@@ -797,7 +797,7 @@ class SetPrivateComment(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         api_key = user_preferences.api_key
         comments = comments_utils.get_comments_local(self.asset_id)
         if comments is not None:
@@ -872,7 +872,7 @@ class PostComment(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         ui_props = bpy.context.window_manager.blenderkitUI
         api_key = user_preferences.api_key
         daemon_lib.create_comment(
@@ -1025,7 +1025,7 @@ class VIEW3D_PT_blenderkit_login(Panel):
         if not global_vars.CLIENT_RUNNING:
             layout.label(text="Client not running")
             return
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         if user_preferences.login_attempt:
             draw_login_progress(layout)
             return
@@ -1131,7 +1131,7 @@ def draw_panel_brush_search(self, context):
 
 
 def draw_login_buttons(layout, invoke=False):
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
 
     if user_preferences.login_attempt:
         draw_login_progress(layout)
@@ -1466,7 +1466,7 @@ class VIEW3D_PT_blenderkit_import_settings(Panel):
         s = context.scene
         wm = bpy.context.window_manager
         ui_props = bpy.context.window_manager.blenderkitUI
-        preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        preferences = bpy.context.preferences.addons[__package__].preferences
 
         if ui_props.asset_type == "MODEL":
             # noinspection PyCallByClass
@@ -1522,7 +1522,7 @@ class VIEW3D_PT_blenderkit_unified(Panel):
 
     def draw(self, context):
         ui_props = bpy.context.window_manager.blenderkitUI
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
 
         layout = self.layout
         # layout.prop_tabs_enum(ui_props, "asset_type", icon_only = True)
@@ -1689,7 +1689,7 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         if self.step == 0:
-            user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+            user_preferences = bpy.context.preferences.addons[__package__].preferences
 
             # message = "BlenderKit connects from Blender to an online, " \
             #           "community built shared library of models, " \
@@ -1724,7 +1724,7 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
         return {"FINISHED"}
 
     def invoke(self, context, event):
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         if user_preferences.welcome_operator_counter > 10:
             return {"FINISHED"}
         user_preferences.welcome_operator_counter += 1
@@ -2963,7 +2963,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             # pre-fill ratings
             self.prefill_ratings()
 
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         if (
             user_preferences.asset_popup_counter
             < user_preferences.asset_popup_counter_max
@@ -3198,7 +3198,7 @@ class LoginPopupDialog(bpy.types.Operator):
 
 def draw_panel_categories(layout, context):
     ui_props = bpy.context.window_manager.blenderkitUI
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
 
     search_props = utils.get_search_props()
     acat_search = search_props.search_category
@@ -3320,7 +3320,7 @@ def header_search_draw(self, context):
     if not utils.guard_from_crash():
         return
 
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     if not preferences.search_in_header:
         return
     if context.mode not in ("PAINT_TEXTURE", "OBJECT", "SCULPT", "POSE"):
@@ -3401,7 +3401,7 @@ def header_search_draw(self, context):
     if (context.region.width) > 700:
         row.ui_units_x = 5 + int(context.region.width / 200)
     search_field_width = bpy.context.preferences.addons[
-        "blenderkit"
+        __package__
     ].preferences.search_field_width
     if search_field_width > 0:
         row.ui_units_x = search_field_width
@@ -3563,7 +3563,7 @@ def header_draw(self, context):
 
 
 def object_context_draw(self, context):
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     layout = self.layout
     pcoll = icons.icon_collections["main"]
     if not preferences.show_VIEW3D_MT_blenderkit_model_properties:

--- a/upload.py
+++ b/upload.py
@@ -338,7 +338,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
     upload_data - asset_data generated from the ui properties
 
     """
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     export_data = {
         # "type": asset_type,
     }

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -23,7 +23,7 @@ import sys
 
 import bpy
 
-from blenderkit import append_link
+from . import append_link
 
 
 BLENDERKIT_EXPORT_DATA = sys.argv[-1]

--- a/utils.py
+++ b/utils.py
@@ -76,7 +76,7 @@ supported_material_drag = (
 
 def experimental_enabled() -> bool:
     """Check if experimental features are enabled. Experimental features are always be enabled for staff and validators."""
-    preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    preferences = bpy.context.preferences.addons[__package__].preferences
     return preferences.experimental_features or profile_is_validator()
 
 
@@ -388,7 +388,7 @@ def get_scene_id():
 
 
 def get_preferences_as_dict():
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     prefs = {
         # SYSTEM STUFF - TODO: is this needed in here? (Why to save this into JSON?) But is used for sending data to client.
         "debug_value": bpy.app.debug_value,
@@ -1008,7 +1008,7 @@ def update_tags(self, context):
 
 def user_logged_in():
     """User is currently logged in successfully"""
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     a = global_vars.DATA.get("bkit profile")
     # Check both profile and token, profile sometimes isn't cleaned up after logout
     # vilem - removed (a is not None) - the profile isn't always ready on start of blender,
@@ -1020,7 +1020,7 @@ def user_logged_in():
 
 def profile_is_validator():
     """currently logged in profile is validator"""
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     profile = global_vars.DATA.get("bkit profile")
     if profile is None or user_preferences.api_key == "":
         return False
@@ -1030,7 +1030,7 @@ def profile_is_validator():
 
 def user_is_owner(asset_data=None):
     """Checks if the current logged in user is owner of the asset"""
-    user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+    user_preferences = bpy.context.preferences.addons[__package__].preferences
     profile = global_vars.DATA.get("bkit profile")
     if profile is None or user_preferences.api_key == "":
         return False
@@ -1067,9 +1067,9 @@ def guard_from_crash():
      This function is used in these functions (like draw callbacks)
      so these don't run during unregistration.
     """
-    if bpy.context.preferences.addons.get("blenderkit") is None:
+    if bpy.context.preferences.addons.get(__package__) is None:
         return False
-    if bpy.context.preferences.addons["blenderkit"].preferences is None:
+    if bpy.context.preferences.addons[__package__].preferences is None:
         return False
     return True
 
@@ -1284,7 +1284,7 @@ def list2string(lst: list) -> str:
 
 def check_globaldir_permissions():
     """Check if the user has the required permissions to upload assets."""
-    global_dir = bpy.context.preferences.addons["blenderkit"].preferences.global_dir
+    global_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
     if os.path.isfile(global_dir):
         reports.add_report(
             "Global dir is a file. Please remove it or change global dir path in preferences.",

--- a/version_checker.py
+++ b/version_checker.py
@@ -22,6 +22,7 @@ import os
 import bpy
 
 from . import paths
+from . import global_vars
 
 
 def get_blender_version() -> str:
@@ -32,9 +33,7 @@ def get_blender_version() -> str:
 
 def get_addon_version() -> str:
     """Get BlenderKit addon version as string."""
-    import blenderkit
-
-    ver = blenderkit.bl_info["version"]
+    ver = global_vars.VERSION
     return "%i.%i.%i" % (ver[0], ver[1], ver[2])
 
 


### PR DESCRIPTION
fixes #1154

- fixes import to new form required by extensions, it works with previous Blender versions
- uses version in format X.Y.Z-YYMMDD in blender manifest - it would not work with .
- adds tests for correctnes of version in bl_info, VERSION const in __init__.py and version in manifest

Tested in: Blender 4.1, Blender 4.2-alpha