### PR TITLE
#1168 Prevent asset download if mouse is in categories and over asset bar at the same time

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -24,7 +24,16 @@ import time
 import bpy
 from bpy.props import BoolProperty, StringProperty
 
-from . import comments_utils, global_vars, paths, ratings_utils, search, ui, utils
+from . import (
+    comments_utils,
+    global_vars,
+    paths,
+    ratings_utils,
+    search,
+    ui,
+    utils,
+    ui_panels,
+)
 from .bl_ui_widgets.bl_ui_button import BL_UI_Button
 from .bl_ui_widgets.bl_ui_drag_panel import BL_UI_Drag_Panel
 from .bl_ui_widgets.bl_ui_draw_op import BL_UI_OT_draw_operator
@@ -1293,6 +1302,12 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.update_bookmark_icon(widget)
 
     def drag_drop_asset(self, widget):
+
+        now = time.time()
+        # avoid double click to download assets under panels, mainly category panel
+        if now - ui_panels.last_time_dropdown_active < 0.5:
+            return
+        # start drag drop
         bpy.ops.view3d.asset_drag_drop(
             "INVOKE_DEFAULT",
             asset_search_index=widget.search_index + self.scroll_offset,

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -21,6 +21,7 @@ import logging
 import os
 import platform
 import random
+import time
 from webbrowser import open_new_tab
 
 import bpy
@@ -48,6 +49,8 @@ from . import (
 
 
 bk_logger = logging.getLogger(__name__)
+
+last_time_dropdown_active = 0.0
 
 
 def draw_not_logged_in(source, message="Please Login/Signup to use this feature"):
@@ -1421,6 +1424,10 @@ class VIEW3D_PT_blenderkit_categories(Panel):
         return ui_props.down_up == "SEARCH"
 
     def draw(self, context):
+        # measure time since last dropdown activation/ mouse hover e.t.c.
+        # this is then used in asset_bar_op.py to cancel asset drag drop if the time is too small and thus means double clicking.
+        global last_time_dropdown_active
+        last_time_dropdown_active = time.time()
         draw_panel_categories(self.layout, context)
 
 


### PR DESCRIPTION
fixes #1168 