### PR TITLE
#1105 Add Github action for Windows 7 build with go1.20

### DIFF
--- a/.github/workflows/win7-build.yml
+++ b/.github/workflows/win7-build.yml
@@ -1,0 +1,34 @@
+name: Win7
+# This workflow builds Windows7 compatible binaries using go1.20.
+# It packs the add-on with just these binaries. A workaround for users on Windows 7.
+
+on:
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20.14'
+          cache-dependency-path: './client/go.sum'
+        id: go
+      - name: Set version=1.20 in go.mod
+        run: go mod edit -go=1.17
+        working-directory: client
+      - name: Build add-on
+        run: python dev.py build
+      - name: Remove-binaries
+        run: rm -rf out/blenderkit/client/v*/blenderkit-client-{linux-arm64,linux-x86_64,macos-arm64,macos-x86_64,windows-arm64.exe}
+      - name: Store the build
+        uses: actions/upload-artifact@v4
+        with:
+          name: blenderkit-windows7-only-${{ github.sha }}
+          path: |
+            out
+            !out/blenderkit.zip

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/blenderkit/blenderkit/client
 
-go 1.21.6
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
fixes #1105 

Go 1.21 and 1.22 has dropped support for Windows 7. Even though Blender 3 nor 4 has support for Windows 7, we still have few users running hacked Blender on Windows 7. To let them use BlenderKit we can build the Client with go1.20 which supports Windows 7.

This PR adds github workflow to build the Client with go1.20. It then removes all other binaries and creates blenderkit-windows7-only-{hash}.zip artifact. We can upload this artifact to issue #1105 so users on Windows 7 can install it. No other binaries are added into the .zip, as this is meant only as hack for Windows 7 users.

In future if we add on-the-go download of binaries, we could add windows 7 as downloadable binaries. But for now this is enough.