### PR TITLE
#1203 Implement get_asset_directory_name() as rigid way how to get name of the directory

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -394,7 +394,7 @@ func downloadAsset(url, filePath string, data DownloadData, taskID string, ctx c
 func GetDownloadFilepaths(data DownloadData, filename string) []string {
 	filePaths := []string{}
 	filename = ServerToLocalFilename(filename, data.DownloadAssetData.Name)
-	assetDirName := fmt.Sprintf("%s_%s", Slugify(data.DownloadAssetData.Name), data.DownloadAssetData.ID)
+	assetDirName := GetAssetDirectoryName(data.DownloadAssetData.Name, data.DownloadAssetData.ID)
 	for _, dir := range data.DownloadDirs {
 		assetDirPath := filepath.Join(dir, assetDirName)
 		if _, err := os.Stat(assetDirPath); os.IsNotExist(err) {

--- a/client/utils.go
+++ b/client/utils.go
@@ -175,6 +175,17 @@ func ServerToLocalFilename(serverFilename, assetName string) string {
 	return localFilename
 }
 
+// GetAssetDirectoryName returns the name of the directory in which resolution files will be stored.
+// Function mirrors: paths.py/get_asset_directory_name()
+func GetAssetDirectoryName(assetName, assetID string) string {
+	slugifiedName := Slugify(assetName)
+	if len(slugifiedName) > 16 {
+		slugifiedName = slugifiedName[:16]
+	}
+
+	return fmt.Sprintf("%s_%s", slugifiedName, assetID)
+}
+
 // Slugify converts a string to a URL-friendly slug.
 // Converts to lowercase, replaces non-alphanumeric characters with hyphens.
 // Ensures only one hyphen between words and that string starts and ends with a letter or number.

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -89,6 +89,27 @@ func TestStringToBlenderVersion(t *testing.T) {
 	}
 }
 
+func TestGetAssetDirectoryName(t *testing.T) {
+	tests := []struct {
+		asset_name string
+		asset_id   string
+		expected   string
+	}{
+		{"CAT", "953ae6c1-7fcd-4521-8924-a092b5022a0a", "cat_953ae6c1-7fcd-4521-8924-a092b5022a0a"},
+		{"Soap Dispenser_2", "2cf7c1b7-ada9-421e-b5de-cf674b646893", "soap-dispenser-2_2cf7c1b7-ada9-421e-b5de-cf674b646893"},
+		{"domain.com", "5a5ab3b0-818a-4229-b39d-bd4d83272ad5", "domain-com_5a5ab3b0-818a-4229-b39d-bd4d83272ad5"},
+		{"Happy? Sad!", "c181edbd-de56-418b-ab7f-120c06ded48f", "happy-sad_c181edbd-de56-418b-ab7f-120c06ded48f"},
+		{"Beautiful Car With Very Long Name", "47992e4f-1091-46d2-aed0-2dd52b573411", "beautiful-car-wi_47992e4f-1091-46d2-aed0-2dd52b573411"},
+	}
+
+	for _, test := range tests {
+		actual := GetAssetDirectoryName(test.asset_name, test.asset_id)
+		if actual != test.expected {
+			t.Errorf("GetAssetDirectoryName(%q, %q) = %q; want %q", test.asset_name, test.asset_id, actual, test.expected)
+		}
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/paths.py
+++ b/paths.py
@@ -314,12 +314,18 @@ def get_texture_directory(asset_data, resolution="blend"):
     return tex_dir_path
 
 
-def get_asset_directories(asset_data):
-    """Only get path where all asset files are stored."""
-    name_slug = slugify(asset_data["name"])
+def get_asset_directory_name(asset_name: str, asset_id: str) -> str:
+    """Get name of the directory for the asset."""
+    name_slug = slugify(asset_name)
     if len(name_slug) > 16:
         name_slug = name_slug[:16]
-    asset_dir_name = f"{name_slug}_{asset_data['id']}"
+
+    return f"{name_slug}_{asset_id}"
+
+
+def get_asset_directories(asset_data):
+    """Only get path where all asset files are stored."""
+    asset_dir_name = get_asset_directory_name(asset_data["name"], asset_data["id"])
     dirs = get_download_dirs(asset_data["assetType"])
     asset_dirs = []
     for d in dirs:
@@ -334,10 +340,7 @@ def get_download_filepaths(asset_data, resolution="blend", can_return_others=Fal
     res_file, resolution = get_res_file(
         asset_data, resolution, find_closest_with_url=can_return_others
     )
-    name_slug = slugify(asset_data["name"])
-    if len(name_slug) > 16:
-        name_slug = name_slug[:16]
-    asset_dir_name = f"{name_slug}_{asset_data['id']}"
+    asset_dir_name = get_asset_directory_name(asset_data["name"], asset_data["id"])
 
     file_names = []
 

--- a/test_paths.py
+++ b/test_paths.py
@@ -54,6 +54,47 @@ class TestGlobalDict(unittest.TestCase):
         self.assertTrue(path.is_dir(), msg=path)
 
 
+class TestGetAssetDirectoryName(unittest.TestCase):
+    """Same test data as in utils_test.go/TestGetAssetDirectoryName()"""
+
+    data = (
+        (
+            "CAT",
+            "953ae6c1-7fcd-4521-8924-a092b5022a0a",
+            "cat_953ae6c1-7fcd-4521-8924-a092b5022a0a",
+        ),
+        (
+            "Soap Dispenser_2",
+            "2cf7c1b7-ada9-421e-b5de-cf674b646893",
+            "soap-dispenser-2_2cf7c1b7-ada9-421e-b5de-cf674b646893",
+        ),
+        (
+            "domain.com",
+            "5a5ab3b0-818a-4229-b39d-bd4d83272ad5",
+            "domain-com_5a5ab3b0-818a-4229-b39d-bd4d83272ad5",
+        ),
+        (
+            "Happy? Sad!",
+            "c181edbd-de56-418b-ab7f-120c06ded48f",
+            "happy-sad_c181edbd-de56-418b-ab7f-120c06ded48f",
+        ),
+        (
+            "Beautiful Car With Very Long Name",
+            "47992e4f-1091-46d2-aed0-2dd52b573411",
+            "beautiful-car-wi_47992e4f-1091-46d2-aed0-2dd52b573411",
+        ),
+    )
+
+    def test_get_asset_directory_name(self):
+        for asset_name, asset_id, expected in self.data:
+            result = paths.get_asset_directory_name(asset_name, asset_id)
+            self.assertEqual(
+                result,
+                expected,
+                msg=f'get_asset_directory_name("{asset_name}", "{asset_id}")="{result}"; expected: "{expected}"',
+            )
+
+
 class TestSlugify(unittest.TestCase):
     """Same test data as in utils_test.go/TestSlugify()"""
 


### PR DESCRIPTION
fixes #1203 

- implement in Python and Go, same functionality
- implement iidentical tests in Python and Go
- verify functionality by tests