### PR TITLE
#1231 Fix imports in background scripts and tests

### DIFF
--- a/.github/make-tests-matrix.py
+++ b/.github/make-tests-matrix.py
@@ -46,10 +46,10 @@ jobs = [
         "download_url": "https://download.blender.org/release/Blender3.3/blender-3.3.0-linux-x64.tar.xz",
     },
     {
-        "version": "3.3.10",
+        "version": "3.3.20",
         "version_x_y": "3.3",
         "sha": "released",
-        "download_url": "https://download.blender.org/release/Blender3.3/blender-3.3.10-linux-x64.tar.xz",
+        "download_url": "https://download.blender.org/release/Blender3.3/blender-3.3.20-linux-x64.tar.xz",
     },
     {
         "version": "3.4.0",
@@ -82,10 +82,34 @@ jobs = [
         "download_url": "https://download.blender.org/release/Blender3.6/blender-3.6.0-linux-x64.tar.xz",
     },
     {
-        "version": "3.6.2",
+        "version": "3.6.13",
         "version_x_y": "3.6",
         "sha": "released",
-        "download_url": "https://download.blender.org/release/Blender3.6/blender-3.6.2-linux-x64.tar.xz",
+        "download_url": "https://download.blender.org/release/Blender3.6/blender-3.6.13-linux-x64.tar.xz",
+    },
+    {
+        "version": "4.0.0",
+        "version_x_y": "4.0",
+        "sha": "released",
+        "download_url": "https://download.blender.org/release/Blender4.0/blender-4.0.0-linux-x64.tar.xz",
+    },
+    {
+        "version": "4.0.2",
+        "version_x_y": "4.0",
+        "sha": "released",
+        "download_url": "https://download.blender.org/release/Blender4.0/blender-4.0.2-linux-x64.tar.xz",
+    },
+    {
+        "version": "4.1.0",
+        "version_x_y": "4.1",
+        "sha": "released",
+        "download_url": "https://download.blender.org/release/Blender4.1/blender-4.1.0-linux-x64.tar.xz",
+    },
+    {
+        "version": "4.1.1",
+        "version_x_y": "4.1",
+        "sha": "released",
+        "download_url": "https://download.blender.org/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz",
     },
     # {'version': '', 'version_x_y': '', 'download_url': ''},
 ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,16 @@ Script `dev.py` provides handy option `--install-at` to copy the `out/blenderkit
 Just specify path to addons directory in `--install-at` flag.
 Script will then remove old `blenderkit` directory in addons location and replace it with current build.
 
-To build and copy to Blender 4.0.x addons directory and also clean blenderkit_data, run:
+To build and copy to Blender 4.2.x addons directory and also clean blenderkit_data, run:
 
 ```
-python dev.py build --install-at /path/to/blender/4.0/scripts/addons --clean-dir /Users/username/blenderkit_data
+python dev.py build --install-at /path/to/blender/4.2/scripts/addons --clean-dir /Users/username/blenderkit_data
+```
+
+To build and copy to Blender 4.2.x as extension, run:
+
+```
+python dev.py build --install-at /path/to/blender/4.2/extensions/user_default --clean-dir /Users/username/blenderkit_data
 ```
 
 NOTE: --clean-dir is required if you change anything in the blenderkit-client, otherwise add-on will not copy the new binaries over the old ones.
@@ -89,10 +95,10 @@ python dev.py build --install-at /path/to/blender/4.0/scripts/addons --clean-dir
 
 ## Releasing
 
-Before release update the add-on version in `__init__.py` and `client/VERSION`, make sure it is merged in `main` branch.
+Before release update the add-on version in `__init__.py` (in bl_info and VERSION variable) and `client/VERSION`, make sure it is merged in `main` branch.
 
 1. go to Github Actions, choose `Release` workflow
-2. insert the version in format `X.Y.Z.YYMMDD` (e.g. `3.8.0.2306220`), this has to be same as in `__init__.py`.
+2. insert the version in format `X.Y.Z.YYMMDD` (e.g. `3.12.2.240722`), this has to be same as in `__init__.py`.
 3. set Release Stage to `alpha`, `beta`, `rc` or `gold` for final release
 4. once finished, the release draft is available in Github Releases
 
@@ -107,14 +113,20 @@ The tests are defined in files `test_<name-of-tested-file>.py` and their startin
 ### Local testing
 
 To test the add-on locally, make sure you have a Blender on your PATH.
-Then run:
+Then run to test as legacy add-on:
 
 ```
-python dev.py test --install-at /path/to/blender/3.2/scripts/addons
+python dev.py test --install-at /path/to/blender/4.2/scripts/addons
+```
+
+Or to test as extension:
+
+```
+python dev.py test --install-at /path/to/blender/4.2/extensions/user_default
 ```
 
 NOTE: please make sure that version in the `--install-at` path must match the version of the Blender version you have on your PATH.
-Otherwise the add-on with test files will be copied to Blender version 3.x, but tests will run on different Blender version 3.a with outdated BlenderKit build.
+Otherwise the add-on with test files will be copied to Blender version 4.x, but tests will run on different Blender version 4.a with outdated (or missing) BlenderKit build.
 
 ### Pull Requests
 

--- a/autothumb.py
+++ b/autothumb.py
@@ -146,6 +146,9 @@ def update_upload_brush_preview(self, context):
 
 
 def get_thumbnailer_args(script_name, thumbnailer_filepath, datafile, api_key):
+    """Get the arguments to start Blender in background to render model or material thumbnails.
+    Watch out: the ending arguments must match order of those in: autothumb_model_bg.py and autothumb_material_bg.py.
+    """
     script_path = os.path.dirname(os.path.realpath(__file__))
     script_path = os.path.join(script_path, script_name)
     args = [
@@ -153,7 +156,7 @@ def get_thumbnailer_args(script_name, thumbnailer_filepath, datafile, api_key):
         "--background",
         "--factory-startup",
         "--addons",
-        "blenderkit",
+        __package__,
         "-noaudio",
         thumbnailer_filepath,
         "--python",
@@ -161,6 +164,7 @@ def get_thumbnailer_args(script_name, thumbnailer_filepath, datafile, api_key):
         "--",
         datafile,
         api_key,
+        __package__,  # Legacy has it as "blenderkit", extensions have it like bl_ext.user_default.blenderkit or anything else
     ]
     return args
 

--- a/autothumb_material_bg.py
+++ b/autothumb_material_bg.py
@@ -21,16 +21,10 @@ import json
 import logging
 import os
 import sys
+from traceback import print_exc
 from pathlib import Path
 
 import bpy
-
-from blenderkit import append_link, bg_blender, bg_utils, daemon_lib, utils
-
-
-BLENDERKIT_EXPORT_DATA = sys.argv[-2]
-BLENDERKIT_EXPORT_API_KEY = sys.argv[-1]
-bk_logger = logging.getLogger(__name__)
 
 
 def render_thumbnails():
@@ -46,6 +40,14 @@ def unhide_collection(cname):
 
 if __name__ == "__main__":
     try:
+        # args order must match the order in blenderkit/autothumb.py:get_thumbnailer_args()!
+        BLENDERKIT_EXPORT_DATA = sys.argv[-3]
+        BLENDERKIT_EXPORT_API_KEY = sys.argv[-2]
+        __package__ = sys.argv[
+            -1
+        ]  # otherwise would be None -> aaand relative import fails
+        from . import append_link, bg_blender, bg_utils, daemon_lib, utils
+
         bg_blender.progress("preparing thumbnail scene")
         with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:
             data = json.load(s)
@@ -206,9 +208,6 @@ if __name__ == "__main__":
         )
 
     except Exception as e:
-        bk_logger.fatal(f"{e}")
-        import traceback
-
-        traceback.print_exc()
-
+        print(f"background autothumbnailer failed: {e}")
+        print_exc()
         sys.exit(1)

--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -1,3 +1,5 @@
+print("authothum_model_bg.py STARTED")
+
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
 #  This program is free software; you can redistribute it and/or
@@ -25,14 +27,8 @@ from traceback import print_exc
 
 import bpy
 
-from blenderkit import append_link, bg_blender, bg_utils, daemon_lib, utils
 
-
-BLENDERKIT_EXPORT_DATA = sys.argv[-2]
-BLENDERKIT_EXPORT_API_KEY = sys.argv[-1]
-
-
-def get_obnames():
+def get_obnames(BLENDERKIT_EXPORT_DATA: str):
     with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:
         data = json.load(s)
     obnames = eval(data["models"])
@@ -85,6 +81,14 @@ def render_thumbnails():
 
 if __name__ == "__main__":
     try:
+        # args order must match the order in blenderkit/autothumb.py:get_thumbnailer_args()!
+        BLENDERKIT_EXPORT_DATA = sys.argv[-3]
+        BLENDERKIT_EXPORT_API_KEY = sys.argv[-2]
+        __package__ = sys.argv[
+            -1
+        ]  # otherwise would be None -> aaand relative import fails
+        from . import append_link, bg_blender, bg_utils, daemon_lib, utils
+
         with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:
             data = json.load(s)
         thumbnail_use_gpu = data.get("thumbnail_use_gpu")
@@ -125,7 +129,7 @@ if __name__ == "__main__":
             allobs = [main_object]
         else:
             bg_blender.progress("preparing thumbnail scene")
-            obnames = get_obnames()
+            obnames = get_obnames(BLENDERKIT_EXPORT_DATA)
             main_object, allobs = append_link.append_objects(
                 file_name=data["filepath"], obnames=obnames, link=True
             )

--- a/client/download.go
+++ b/client/download.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/gookit/color"
@@ -252,17 +253,21 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 	cmd := exec.Command(
 		data.BinaryPath,
 		"--background",
-		"--factory-startup", // disables user preferences, addons, etc.
-		"--addons", "blenderkit",
+		"--factory-startup",                    // disables user preferences, addons, etc.
+		"--addons", data.PREFS.AddonModuleName, // For extensions we need to enable by dynamic bl_ext.user_default.blenderkit
 		"-noaudio",
 		blendPath,
 		"--python", unpackScriptPath,
 		"--",
 		dataFile,
+		data.PREFS.AddonModuleName, // Legacy has it as "blenderkit", extensions have it like bl_ext.user_default.blenderkit or anything else
 	)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("BLENDER_USER_SCRIPTS=%v", blenderUserScripts))
 	out, err := cmd.CombinedOutput()
-	color.FgGray.Println("(Background) Unpacking logs:\n", string(out))
+	color.FgGray.Printf("└> backgroung unpacking '%+v' logs:\n", cmd)
+	for _, line := range strings.Split(string(out), "\n") {
+		color.FgGray.Printf("   %s\n", line)
+	}
 	if err != nil {
 		return err
 	}

--- a/client/structs.go
+++ b/client/structs.go
@@ -194,10 +194,11 @@ type PREFS struct {
 	UnpackFiles   bool   `json:"unpack_files"`
 	Resolution    string `json:"resolution"` // "ORIGINAL", "resolution_0_5K", "resolution_1K", "resolution_2K", "resolution_4K", "resolution_8K"
 	// PATHS
-	ProjectSubdir string `json:"project_subdir"`
-	GlobalDir     string `json:"global_dir"`
-	BinaryPath    string `json:"binary_path"`
-	AddonDir      string `json:"addon_dir"`
+	ProjectSubdir   string `json:"project_subdir"`
+	GlobalDir       string `json:"global_dir"`
+	BinaryPath      string `json:"binary_path"`
+	AddonDir        string `json:"addon_dir"`
+	AddonModuleName string `json:"addon_module_name"` // __package__ of the add-on, for legacy addons was "blenderkit", extensions "bl_ext.user_default.blenderkit" or anything else!
 }
 
 // AssetFile represents a file in an asset.

--- a/dev.py
+++ b/dev.py
@@ -271,13 +271,17 @@ def do_build(
     print("Build done!")
 
 
-def run_tests():
+def run_tests(extension_format=False):
     print("\n=== Running Client Go unit tests ===")
     gotest = subprocess.Popen(["go", "test"], cwd="client")
     gotest.wait()
     if gotest.returncode != 0:
         exit(1)
     print("Go tests passed.\n")
+
+    addon_package_name = "blenderkit"
+    if extension_format:  # Here we expect default settings
+        addon_package_name = "bl_ext.user_default.blenderkit"
 
     print("=== Running add-on integration tests in Blender tests ===")
     test = subprocess.Popen(
@@ -289,6 +293,8 @@ def run_tests():
             "1",
             "--python",
             "test.py",
+            "--",
+            addon_package_name,
         ]
     )
     test.wait()
@@ -365,7 +371,12 @@ elif args.command == "test":
         clean_dir=args.clean_dir,
         client_binaries_path=args.client_build,
     )
-    run_tests()
+    # Best effort here to keep it simple and detect automatically, other option would be to add it as a flag
+    if "extensions/user_default" in args.install_at:
+        extension_format = True
+    else:
+        extension_format = False
+    run_tests(extension_format)
 elif args.command == "format":
     format_code()
 else:

--- a/test.py
+++ b/test.py
@@ -17,11 +17,13 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import unittest
+import sys
 
 import addon_utils
 
-
-addon_utils.enable("blenderkit", default_set=True)
+print("----- Tests preparation -----")
+addon_utils.enable(sys.argv[-1], default_set=True)
+print(f"- addon enabled: {sys.argv[-1]}")
 
 runner = unittest.TextTestRunner()
 suite = unittest.TestSuite()
@@ -33,7 +35,9 @@ suite.addTests(testLoader.discover(".", "test_timer.py"))
 suite.addTests(testLoader.discover(".", "test_paths.py"))
 suite.addTests(testLoader.discover(".", "test_utils.py"))
 suite.addTests(testLoader.discover(".", "test_daemon_lib.py"))
+print(f"- {len(suite._tests)} tests discovered and loaded")
 
+print(f"----- Running tests --------------------------------------------------")
 result = runner.run(suite)
 errors = len(result.errors)
 failures = len(result.failures)

--- a/test_daemon_lib.py
+++ b/test_daemon_lib.py
@@ -24,7 +24,11 @@ from urllib.parse import urlparse
 import bpy
 import requests
 
-from blenderkit import daemon_lib, download, global_vars, paths, utils
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import daemon_lib, download, global_vars, paths, utils
 
 
 def client_is_responding() -> tuple[bool, str]:

--- a/test_init.py
+++ b/test_init.py
@@ -21,23 +21,35 @@ import unittest
 
 import bpy
 
-import blenderkit
-from blenderkit import daemon_lib, global_vars
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import daemon_lib, global_vars
 
 
 class Test01Registration(unittest.TestCase):
     def test01_global_vars_VERSION_set(self):
         assert global_vars.VERSION is not None
-        assert global_vars.VERSION == blenderkit.bl_info["version"]
+        if __package__ == "blenderkit":
+            import blenderkit  # relative import .. would go outside the package, so we need to import oldschool here
+
+            version = blenderkit.bl_info["version"]
+        else:
+            from .. import blenderkit
+
+            version = blenderkit.VERSION
+        assert global_vars.VERSION == version
 
     def test02_global_vars_PREFS_set(self):
         assert global_vars.PREFS != {}
-        user_preferences = bpy.context.preferences.addons["blenderkit"].preferences
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
         prefs = {
             # SYSTEM STUFF
             "debug_value": bpy.app.debug_value,
             "binary_path": bpy.app.binary_path,
             "addon_dir": daemon_lib.get_addon_dir(),
+            "addon_module_name": __package__,
             "app_id": os.getpid(),
             # STATISTICS
             "download_counter": user_preferences.download_counter,

--- a/test_paths.py
+++ b/test_paths.py
@@ -19,7 +19,13 @@
 import pathlib
 import unittest
 
-from blenderkit import paths
+import bpy
+
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import paths
 
 
 class TestDownloadDirs(unittest.TestCase):

--- a/test_upload.py
+++ b/test_upload.py
@@ -1,6 +1,12 @@
 import unittest
 
-from blenderkit import upload
+import bpy
+
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import upload
 
 
 class TestCheckTagsFormat(unittest.TestCase):

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,6 +1,12 @@
 import unittest
 
-from blenderkit import utils
+import bpy
+
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import utils
 
 
 class FileSizeToTextTestCase(unittest.TestCase):

--- a/unpack_asset_bg.py
+++ b/unpack_asset_bg.py
@@ -21,14 +21,8 @@ import json
 import logging
 import os
 import sys
-import time
 
 import bpy
-
-from blenderkit import paths, utils
-
-
-bk_logger = logging.getLogger(__name__)
 
 
 def get_texture_filepath(tex_dir_path, image, resolution="blend"):
@@ -38,8 +32,6 @@ def get_texture_filepath(tex_dir_path, image, resolution="blend"):
         image_file_name = bpy.path.basename(image.filepath)
     if image_file_name == "":
         image_file_name = image.name.split(".")[0]
-
-    suffix = paths.resolution_suffix[resolution]
 
     fp = os.path.join(tex_dir_path, image_file_name)
     # check if there is allready an image with same name and thus also assigned path
@@ -76,7 +68,7 @@ def get_resolution_from_file_path(file_path):
 
 
 def unpack_asset(data):
-    utils.p("unpacking asset")
+    print("🗃️  unpacking asset")
     asset_data = data["asset_data"]
     resolution = get_resolution_from_file_path(bpy.data.filepath)
 
@@ -93,8 +85,7 @@ def unpack_asset(data):
         if image.name != "Render Result":
             # suffix = paths.resolution_suffix(data['suffix'])
             fp = get_texture_filepath(tex_dir_path, image, resolution=resolution)
-            utils.p("unpacking file", image.name)
-            utils.p(image.filepath, fp)
+            print(f"🖼️  unpacking file: {image.name} - {image.filepath}, {fp}")
 
             for pf in image.packed_files:
                 pf.filepath = fp  # bpy.path.abspath(fp)
@@ -153,8 +144,11 @@ def unpack_asset(data):
     sys.exit()
 
 
-with open(sys.argv[-1], "r", encoding="utf-8") as f:
-    data = json.load(f)
-
 if __name__ == "__main__":
+    JSON_PATH = sys.argv[-2]
+    __package__ = sys.argv[-1]
+    from . import paths
+
+    with open(JSON_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
     unpack_asset(data)

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -23,12 +23,15 @@ import sys
 
 import bpy
 
-from . import append_link
-
-
-BLENDERKIT_EXPORT_DATA = sys.argv[-1]
 
 if __name__ == "__main__":
+    # args order must match the order in blenderkit/client/main.go:PackBlendFile()!
+    BLENDERKIT_EXPORT_DATA = sys.argv[-2]
+    __package__ = sys.argv[-1]  # otherwise would be None -> relative import fails
+    from . import (
+        append_link,
+    )  # we can do relative import because we set the __package__
+
     try:
         # bg_blender.progress('preparing scene - append data')
         with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:

--- a/utils.py
+++ b/utils.py
@@ -390,10 +390,11 @@ def get_scene_id():
 def get_preferences_as_dict():
     user_preferences = bpy.context.preferences.addons[__package__].preferences
     prefs = {
-        # SYSTEM STUFF - TODO: is this needed in here? (Why to save this into JSON?) But is used for sending data to client.
+        # SYSTEM STUFF - TODO: is this needed in here? (Why to save this into JSON?) Is used for sending data to client, but really should be separate parameter.
         "debug_value": bpy.app.debug_value,
         "binary_path": bpy.app.binary_path,
         "addon_dir": os.path.dirname(__file__),
+        "addon_module_name": __package__,  # refers to name of the add-on, legacy=blenderkit, extensions=bl_ext.user_default.blenderkit or anything else
         "app_id": os.getpid(),
         # STATISTICS
         "download_counter": user_preferences.download_counter,


### PR DESCRIPTION
fixes #1231 

- due to extensions, we cannot do from blenderkit import XYZ
- package name with extensions now depends on user settings
- start BG Blender with __package__ parameter
- set the __package__ to incoming package parameter, so relative imports can be used
- use relative imports in the background scripts
- in tests detect and set the __package__ by iterating over all addons
- update docs