### PR TITLE
#1233 Set logging properly under the extension format

### DIFF
--- a/addon_updater.py
+++ b/addon_updater.py
@@ -142,7 +142,7 @@ class SingletonUpdater:
         """Print out a verbose logging message if verbose is true."""
         if not self._verbose:
             return
-        print("{} addon: ".format(self.addon) + msg)
+        print("🔄 {}: ".format(self.addon) + msg)
 
     # -------------------------------------------------------------------------
     # Getters and setters


### PR DESCRIPTION
fixes #1233 

- set the logging using `__name__.removesuffix` instead of hardcoded "blenderkit" in the log.py file
- add emojis for the levels of log message