### PR TITLE
#1230 Add warning for public uploads from non-stable Blender releases

### DIFF
--- a/ui_panels.py
+++ b/ui_panels.py
@@ -97,6 +97,16 @@ def draw_upload_common(layout, props, asset_type, context):
     # if props.upload_state.find('Error') > -1:
     #     layout.label(text = props.upload_state)
 
+    # PRE-RELEASED WARNING
+    if props.is_private == "PUBLIC" and bpy.app.version_cycle != "release":
+        layout.row()
+        utils.label_multiline(
+            layout,
+            text="Uploading from Alpha, Beta, or Release Candidate versions of Blender is not recommended. Please use a Stable version.",
+            icon="ERROR",
+            width=210,
+        )
+
     if props.asset_base_id == "":
         optext = "Upload %s" % asset_type.lower()
         op = layout.operator("object.blenderkit_upload", text=optext, icon="EXPORT")


### PR DESCRIPTION
fixes #1230 

During public asset upload on Blender 4.2-Beta:
<img width="243" alt="image" src="https://github.com/BlenderKit/BlenderKit/assets/22000268/d8b7f122-49c9-4c2b-a7d4-3e34e4f1c9dd">
