### PR TITLE
fix #1238 Proper syncing of asset directories

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -173,6 +173,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 		}
 		return
 	}
+
 	// GET FILEPATHS TO WHICH WE DOWNLOAD
 	TaskProgressUpdateCh <- &TaskProgressUpdate{
 		AppID:    data.AppID,
@@ -302,7 +303,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 	}
 
-	result := map[string]interface{}{"file_paths": downloadFilePaths}
+	result := map[string]interface{}{"file_paths": downloadFilePaths, "url": downloadURL}
 	TaskFinishCh <- &TaskFinish{
 		AppID:   data.AppID,
 		TaskID:  taskID,

--- a/client/download.go
+++ b/client/download.go
@@ -218,7 +218,6 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 		action = "place"
 	case 1:
 		if len(downloadFilePaths) == 2 { // One file exists, but there are two download paths -> sync the missing file
-			// TODO: sync the missing file
 			action = "sync"
 		} else if len(downloadFilePaths) == 1 { // One file exists, and there is only one download path -> skip download
 			action = "place"
@@ -250,7 +249,8 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 		fmt.Println("PLACING THE FILE")
 	}
 
-	// UNPACKING (Only after download)
+	// UNPACKING (Only after download? By now unpack is triggered always,
+	// to ensure assets that weren't unpacked get unpacked for resolution switching )
 	if data.UnpackFiles {
 		// If there was no download, there's risk that the file to be unpacked
 		// is only in local, but not in global directory

--- a/client/download.go
+++ b/client/download.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -231,11 +230,11 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 			action = "place"
 		}
 	default: // Something unexpected happened -> delete and download
-		log.Println("Unexpected number of existing files:", len(existingFiles))
+		BKLog.Printf("%s Unexpected number of existing files: %s", EmoWarning, existingFiles)
 		for _, file := range downloadFilePaths {
 			err := DeleteFile(file)
 			if err != nil {
-				log.Println("Error deleting file:", err)
+				BKLog.Printf("%s Error deleting file: %v", EmoWarning, err)
 			}
 		}
 	}

--- a/client/structs.go
+++ b/client/structs.go
@@ -205,12 +205,15 @@ type PREFS struct {
 // Used in Download (downloading .blend file) and Search (downloading thumbnails).
 type AssetFile struct {
 	Created            string `json:"created"`
-	DownloadURL        string `json:"downloadUrl"`
+	DownloadURL        string `json:"downloadUrl"` // URL from which the real download URL can be retrieved
 	FileThumbnail      string `json:"fileThumbnail"`
 	FileThumbnailLarge string `json:"fileThumbnailLarge"`
 	FileType           string `json:"fileType"`
 	Modified           string `json:"modified"`
 	Resolution         int    `json:"resolution"` // null for asset (resolution) files, thumbnails, but is integer for videos
+
+	URL      string `json:"url"`      // retrieved URL to the actual file
+	Filename string `json:"filename"` // filename of the file to be saved.
 }
 
 type DownloadAssetData struct {

--- a/download.py
+++ b/download.py
@@ -1096,7 +1096,7 @@ def start_download(asset_data, **kwargs) -> bool:
 
     if ain and not kwargs.get("replace_resolution"):
         # this goes to appending asset - where it should duplicate the original asset already in scene.
-        print("try append or asset from drive without download")
+        bk_logger.info("try append or asset from drive without download")
         append_ok = try_finished_append(asset_data, **kwargs)
         if append_ok:
             return False


### PR DESCRIPTION
Proper syncing of asset directories, between global and local asset folders.

By now, unpack stays on for even downloaded files, which is kind of stupid and is a todo to be finished.

This was serious, since assets were not synced and it caused re-download, or errors during import.

Added:
assets reusing - the issue was really connected so I joined the PRs