### PR TITLE
#1246 Local communication browser-Client

### DIFF
--- a/client/structs.go
+++ b/client/structs.go
@@ -20,12 +20,15 @@ package main
 
 import "context"
 
-// MinimalTaskData is minimal data needed from add-on to schedule a task.
+// MinimalTaskData is minimal data needed from Blender add-on to schedule a task.
+// This is used only for communication with Blender add-on. Other add-on will not schedule a tasks.
+// From this also Software
 type MinimalTaskData struct {
-	AppID           int    `json:"app_id"`  // AppID is PID of Blender in which add-on runs
-	APIKey          string `json:"api_key"` // Can be empty for non-logged users
-	AddonVersion    string `json:"addon_version"`
-	PlatformVersion string `json:"platform_version"`
+	AppID           int    `json:"app_id"`           // AppID is PID of Blender in which add-on runs
+	APIKey          string `json:"api_key"`          // Can be empty for non-logged users
+	AddonVersion    string `json:"addon_version"`    // X.Y.Z version of add-on
+	BlenderVersion  string `json:"blender_version"`  // X.Y.X version of the Blender
+	PlatformVersion string `json:"platform_version"` // Result of platform.platform() in Python
 }
 
 // TaskStatusUpdate is a struct for updating the status of a task through a channel.

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -82,6 +82,9 @@ def get_reports(app_id: str):
     If few last calls failed, then try to get reports also from other than default ports.
     """
     data = ensure_minimal_data({"app_id": app_id})
+    data["blender_version"] = (
+        f"{bpy.app.version[0]}.{bpy.app.version[1]}.{bpy.app.version[2]}"
+    )
     if (
         global_vars.CLIENT_FAILED_REPORTS < 10
     ):  # on 10, there is second BlenderKit-Client start

--- a/download.py
+++ b/download.py
@@ -876,6 +876,44 @@ def download(asset_data, **kwargs):
     download_tasks[response["task_id"]] = data
 
 
+def handle_bkclientjs_get_asset(task: daemon_tasks.Task):
+    """Handle incoming bkclientjs/get_asset task. User asked for download in online gallery. How it goes:
+    1. Webpage tries to connect to Client, gets data about connected Softwares
+    2. User choosed Blender with appID of this Blender
+    2. Client gets asset data from API
+    3. Client creates finished task bkclientjs/get_asset containing asset data
+    4. We handle the task in here
+    5. We request the download of the asset as if user has clicked it inside Blender
+
+    TODO: #1262Implement append to universal search results instead.
+    """
+    """ UNUSED CODE for direct download:
+    prefs = utils.get_preferences_as_dict()
+    prefs["resolution"] = task.result["resolution"]
+    prefs["scene_id"] = utils.get_scene_id()
+    download_dirs = paths.get_download_dirs(task.result["asset_data"]["assetType"])
+    data = {
+        "asset_data": task.result["asset_data"],
+        "download_dirs": download_dirs,
+        "PREFS": prefs,
+        "progress": 0,
+        "text": f'Getting asset {task.result["asset_data"]["name"]}',
+        "downloaders": [{'location': (0.0, 0.0, 0.0), 'rotation': (0.0, 0.0, 0.0)}],
+        "cast_parent": "",
+        "target_object": task.result["asset_data"]["name"],
+        "material_target_slot": 0,
+        "model_location": (0.0, 0.0, 0.0),
+        "model_rotation": (0.0, 0.0, 0.0),
+        "replace": False,
+        "replace_resolution": False,
+        "resolution": task.result["resolution"],
+    }
+
+    response = daemon_lib.asset_download(data)
+    download_tasks[response["task_id"]] = data
+    """
+
+
 def check_downloading(asset_data, **kwargs) -> bool:
     """Check if the asset is already being downloaded.
     If not, return False.

--- a/timer.py
+++ b/timer.py
@@ -300,6 +300,10 @@ def handle_task(task: daemon_tasks.Task):
     if task.task_type == "wrappers/nonblocking_request":
         return utils.handle_nonblocking_request_task(task)
 
+    # BKCLIENTJS - Download from web
+    if task.task_type == "bkclientjs/get_asset":
+        return download.handle_bkclientjs_get_asset(task)
+
     # HANDLE MESSAGE FROM DAEMON
     if task.task_type == "message_from_daemon":
         level = task.result.get("level", "INFO").upper()


### PR DESCRIPTION
fixes #1246

- client manages list of connected softwares with their details
- client provides the list on /bkclientjs/status endpoint
- client accepts requests to download asset on /bkclientjs/get_asset
- then it creates task which is handled in add-on
- PR prepares this task type "bkclientjs/get_asset" on client and add-on sides
- Task "bkclientjs/get_asset" handling will be implemented in or after https://github.com/BlenderKit/BlenderKit/issues/1262