### PR TITLE
#1263 Fix background scripts when add-on is installed in external repository

### DIFF
--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -79,14 +79,46 @@ def render_thumbnails():
     bpy.ops.render.render(write_still=True, animation=False)
 
 
+def patch_imports(addon_module_name: str):
+    """Patch the python configuration, so the relative imports work as expected. There are few problems to fix:
+    1. Script is not recognized as module which would break at relative import. We need to set __package__ = "blenderkit" for legacy addon.
+    Or __package__ = "bl_ext.user_default.blenderkit"/"bl_ext.blenderkit_com.blenderkit_com". Otherwise we would see:
+       from . import paths
+       ImportError: attempted relative import with no known parent package
+    2. External repository (e.g. blenderkit_com) is not available as we start with --factory-startup, we need to enable it.
+    We can add it as LOCAL repo as the add-on is installed and we do not care about updates or anything in this BG script. Otherwise we would see:
+       from . import paths
+       ModuleNotFoundError: No module named 'bl_ext.blenderkit_com'; 'bl_ext' is not a package
+    """
+    print(f"- Setting __package__ = '{addon_module_name}'")
+    global __package__
+    __package__ = addon_module_name
+
+    if bpy.app.version < (4, 2, 0):
+        print(
+            f"- Skipping, Blender version {bpy.app.version} < (4,2,0), no need to handle repositories"
+        )
+        return
+
+    parts = addon_module_name.split(".")
+    if len(parts) != 3:
+        print("- Skipping, addon_module_name does not contain 3 parts")
+        return
+
+    bpy.ops.preferences.extension_repo_add(
+        name=parts[1], type="LOCAL"
+    )  # Local is enough
+    print(f"- Local repository {parts[1]} added")
+
+
 if __name__ == "__main__":
     try:
         # args order must match the order in blenderkit/autothumb.py:get_thumbnailer_args()!
         BLENDERKIT_EXPORT_DATA = sys.argv[-3]
         BLENDERKIT_EXPORT_API_KEY = sys.argv[-2]
-        __package__ = sys.argv[
-            -1
-        ]  # otherwise would be None -> aaand relative import fails
+        patch_imports(sys.argv[-1])
+        bpy.ops.preferences.addon_enable(module=sys.argv[-1])
+
         from . import append_link, bg_blender, bg_utils, daemon_lib, utils
 
         with open(BLENDERKIT_EXPORT_DATA, "r", encoding="utf-8") as s:

--- a/client/download.go
+++ b/client/download.go
@@ -348,8 +348,7 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 	cmd := exec.Command(
 		data.BinaryPath,
 		"--background",
-		"--factory-startup",                    // disables user preferences, addons, etc.
-		"--addons", data.PREFS.AddonModuleName, // For extensions we need to enable by dynamic bl_ext.user_default.blenderkit
+		"--factory-startup", // disables user preferences, addons, etc.
 		"-noaudio",
 		blendPath,
 		"--python", unpackScriptPath,

--- a/client/main.go
+++ b/client/main.go
@@ -44,10 +44,9 @@ const (
 	OAUTH_CLIENT_ID = "IdFRwa3SGA8eMpzhRVFMg5Ts8sPK93xBjif93x0F"
 
 	// PATHS
-	server_default     = "https://www.blenderkit.com" // default address to production blenderkit server
-	gravatar_dirname   = "bkit_g"                     // directory in safeTempDir() for gravatar images
-	cleanfile_path     = "blendfiles/cleaned.blend"   // relative path to clean blend file in add-on directory
-	upload_script_path = "upload_bg.py"               // relative path to upload script in add-on directory
+	server_default   = "https://www.blenderkit.com" // default address to production blenderkit server
+	gravatar_dirname = "bkit_g"                     // directory in safeTempDir() for gravatar images
+	cleanfile_path   = "blendfiles/cleaned.blend"   // relative path to clean blend file in add-on directory
 
 	// EMOJIS
 	EmoOK            = "✅"
@@ -2100,7 +2099,6 @@ func PackBlendFile(data AssetUploadRequestData, metadata AssetsCreateResponse, i
 				export_data.BinaryPath,
 				"--background",
 				"--factory-startup",
-				"--addons", addon_module_name, // In extensions we need to enable as bl_ext.user_default.blenderkit or similar
 				"-noaudio",
 				cleanfile_path,
 				"--python", script_path,

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -22,12 +22,47 @@ import os
 import sys
 
 import bpy
+import addon_utils
+
+
+def patch_imports(addon_module_name: str):
+    """Patch the python configuration, so the relative imports work as expected. There are few problems to fix:
+    1. Script is not recognized as module which would break at relative import. We need to set __package__ = "blenderkit" for legacy addon.
+    Or __package__ = "bl_ext.user_default.blenderkit"/"bl_ext.blenderkit_com.blenderkit_com". Otherwise we would see:
+       from . import paths
+       ImportError: attempted relative import with no known parent package
+    2. External repository (e.g. blenderkit_com) is not available as we start with --factory-startup, we need to enable it.
+    We can add it as LOCAL repo as the add-on is installed and we do not care about updates or anything in this BG script. Otherwise we would see:
+       from . import paths
+       ModuleNotFoundError: No module named 'bl_ext.blenderkit_com'; 'bl_ext' is not a package
+    """
+    print(f"- Setting __package__ = '{addon_module_name}'")
+    global __package__
+    __package__ = addon_module_name
+
+    if bpy.app.version < (4, 2, 0):
+        print(
+            f"- Skipping, Blender version {bpy.app.version} < (4,2,0), no need to handle repositories"
+        )
+        return
+
+    parts = addon_module_name.split(".")
+    if len(parts) != 3:
+        print("- Skipping, addon_module_name does not contain 3 parts")
+        return
+
+    bpy.ops.preferences.extension_repo_add(
+        name=parts[1], type="LOCAL"
+    )  # Local is enough
+    print(f"- Local repository {parts[1]} added")
 
 
 if __name__ == "__main__":
     # args order must match the order in blenderkit/client/main.go:PackBlendFile()!
     BLENDERKIT_EXPORT_DATA = sys.argv[-2]
-    __package__ = sys.argv[-1]  # otherwise would be None -> relative import fails
+    patch_imports(sys.argv[-1])
+    addon_utils.enable(sys.argv[-1])
+
     from . import (
         append_link,
     )  # we can do relative import because we set the __package__


### PR DESCRIPTION
fixes #1263

- external repository like bl_ext.blenderkit_com or bl_ext.my_local_repo are not available during --factory-startup
- only bl_ext.user_default and bl_ext.blender_org are available in factory startup
- thus local installation works, but BG scripts installed in bl_ext.blenderkit_com.blenderkit would fail
- background scripts now enables the addon and do stuff, instead of using --addons flag (it cannot enable external repository)
- background scripts now enables the repository by parsing its name from __package__
- background scripts now enables the add-on in a way that preferences are available

HOW TO TEST:
1. Create remote repository blenderkit_com
2. Copy the add-on into: 4.2/extensions/blenderkit_com/blenderkit (normally it would be installed in 4.2/extensions/user_default/blenderkit)
3. Try all the background scripts