### PR TITLE
#1246 Local communication between Client, Browser and other softwares

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -62,7 +62,22 @@ func assetDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	taskID := uuid.New().String()
-	go doAssetDownload(rJSON, downloadData, taskID)
+
+	go doAssetDownload(
+		rJSON,
+		taskID,
+		downloadData.AppID,
+		downloadData.SceneID,
+		downloadData.APIKey,
+		downloadData.AddonVersion,
+		downloadData.PlatformVersion,
+		downloadData.DownloadAssetData,
+		downloadData.DownloadDirs,
+		downloadData.UnpackFiles,
+		downloadData.BinaryPath,
+		downloadData.AddonDir,
+		downloadData.AddonModuleName,
+	)
 
 	// Response to add-on
 	resData := map[string]string{"task_id": taskID}
@@ -140,25 +155,39 @@ func syncDirsBidirectional(sourceDir, targetDir string) error {
 	return syncDirs(targetDir, sourceDir)
 }
 
-func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID string) {
+func doAssetDownload(
+	origJSON map[string]interface{},
+	taskID string,
+	appID int,
+	sceneID string,
+	apiKey string,
+	addonVersion string,
+	platformVersion string,
+	downloadAssetData DownloadAssetData,
+	downloadDirs []string,
+	unpackFiles bool,
+	binaryPath string,
+	addonDir string,
+	addonModuleName string,
+) {
 	TasksMux.Lock()
-	task := NewTask(origJSON, data.AppID, taskID, "asset_download")
+	task := NewTask(origJSON, appID, taskID, "asset_download")
 	task.Message = "Getting download URL"
 	Tasks[task.AppID][taskID] = task
 	TasksMux.Unlock()
 
 	// GET URL FOR BLEND FILE WITH CORRECT RESOLUTION
-	canDownload, downloadURL, err := GetDownloadURL(data)
+	canDownload, downloadURL, err := GetDownloadURL(sceneID, downloadAssetData.Files, downloadAssetData.Resolution, apiKey, addonVersion, platformVersion)
 	if err != nil {
 		TaskErrorCh <- &TaskError{
-			AppID:  data.AppID,
+			AppID:  appID,
 			TaskID: taskID,
 			Error:  err}
 		return
 	}
 	if !canDownload {
 		TaskErrorCh <- &TaskError{
-			AppID:  data.AppID,
+			AppID:  appID,
 			TaskID: taskID,
 			Error:  fmt.Errorf("user cannot download this file")}
 		return
@@ -166,7 +195,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 	// EXTRACT FILENAME FROM URL
 	TaskProgressUpdateCh <- &TaskProgressUpdate{
-		AppID:    data.AppID,
+		AppID:    appID,
 		TaskID:   taskID,
 		Progress: 0,
 		Message:  "Extracting filename",
@@ -174,7 +203,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 	fileName, err := ExtractFilenameFromURL(downloadURL)
 	if err != nil {
 		TaskErrorCh <- &TaskError{
-			AppID:  data.AppID,
+			AppID:  appID,
 			TaskID: taskID,
 			Error:  err,
 		}
@@ -183,16 +212,16 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 	// GET FILEPATHS TO WHICH WE DOWNLOAD
 	TaskProgressUpdateCh <- &TaskProgressUpdate{
-		AppID:    data.AppID,
+		AppID:    appID,
 		TaskID:   taskID,
 		Progress: 0,
 		Message:  "Getting filepaths",
 	}
-	downloadFilePaths := GetDownloadFilepaths(data, fileName)
+	downloadFilePaths := GetDownloadFilepaths(downloadAssetData, downloadDirs, fileName)
 
 	// CHECK IF FILE EXISTS ON HARD DRIVE
 	TaskProgressUpdateCh <- &TaskProgressUpdate{
-		AppID:    data.AppID,
+		AppID:    appID,
 		TaskID:   taskID,
 		Progress: 0,
 		Message:  "Checking files on disk",
@@ -242,11 +271,11 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 	// START DOWNLOAD IF NEEDED
 	fp := downloadFilePaths[0]
 	if action == "download" {
-		err = downloadAsset(downloadURL, fp, data, taskID, task.Ctx)
+		err = downloadAsset(downloadURL, fp, appID, addonVersion, platformVersion, taskID, task.Ctx)
 		if err != nil {
 			e := fmt.Errorf("error downloading asset: %w", err)
 			TaskErrorCh <- &TaskError{
-				AppID:  data.AppID,
+				AppID:  appID,
 				TaskID: taskID,
 				Error:  e,
 			}
@@ -258,17 +287,28 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 	// UNPACKING (Only after download? By now unpack is triggered always,
 	// to ensure assets that weren't unpacked get unpacked for resolution switching )
-	if data.UnpackFiles {
+	if unpackFiles {
 		// If there was no download, there's risk that the file to be unpacked
 		// is only in local, but not in global directory
 		if action != "download" {
 			fp = existingFiles[0]
 		}
-		err := UnpackAsset(fp, data, taskID)
+		//err := UnpackAsset(fp, data, taskID)
+		err := UnpackAsset(
+			fp,
+			taskID,
+			appID,
+			downloadAssetData.AssetType,
+			binaryPath,
+			addonDir,
+			addonModuleName,
+			downloadAssetData,
+			//prefs,
+		)
 		if err != nil {
 			e := fmt.Errorf("error unpacking asset: %w", err)
 			TaskErrorCh <- &TaskError{
-				AppID:  data.AppID,
+				AppID:  appID,
 				TaskID: taskID,
 				Error:  e,
 			}
@@ -290,7 +330,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 		if err != nil {
 			e := fmt.Errorf("error synchronizing global and local folders: %w", err)
 			TaskErrorCh <- &TaskError{
-				AppID:  data.AppID,
+				AppID:  appID,
 				TaskID: taskID,
 				Error:  e,
 			}
@@ -301,7 +341,7 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 	result := map[string]interface{}{"file_paths": downloadFilePaths, "url": downloadURL}
 	TaskFinishCh <- &TaskFinish{
-		AppID:   data.AppID,
+		AppID:   appID,
 		TaskID:  taskID,
 		Message: "Asset downloaded and ready",
 		Result:  result,
@@ -310,10 +350,20 @@ func doAssetDownload(origJSON map[string]interface{}, data DownloadData, taskID 
 
 // UnpackAsset unpacks the downloaded asset (.blend file).
 // It skips unpacking for HDRi files and returns nil immediately.
-func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
-	if data.AssetType == "hdr" { // Skip unpacking for HDRi files
+func UnpackAsset(
+	blendPath string,
+	taskID string,
+	appID int,
+	assetType string,
+	binaryPath string,
+	addonDir string,
+	addonModuleName string,
+	downloadAssetData DownloadAssetData,
+	//prefs PREFS,
+) error {
+	if assetType == "hdr" { // Skip unpacking for HDRi files
 		TaskMessageCh <- &TaskMessageUpdate{
-			AppID:   data.AppID,
+			AppID:   appID,
 			TaskID:  taskID,
 			Message: "HDRi file doesn't need unpacking",
 		}
@@ -321,19 +371,19 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 	}
 
 	TaskMessageCh <- &TaskMessageUpdate{
-		AppID:   data.AppID,
+		AppID:   appID,
 		TaskID:  taskID,
 		Message: "Unpacking files",
 	}
-	blenderUserScripts := filepath.Dir(filepath.Dir(data.PREFS.AddonDir)) // e.g.: /Users/username/Library/Application Support/Blender/4.1/scripts"
-	unpackScriptPath := filepath.Join(data.PREFS.AddonDir, "unpack_asset_bg.py")
+	blenderUserScripts := filepath.Dir(filepath.Dir(addonDir)) // e.g.: /Users/username/Library/Application Support/Blender/4.1/scripts"
+	unpackScriptPath := filepath.Join(addonDir, "unpack_asset_bg.py")
 	dataFile := filepath.Join(os.TempDir(), "resdata.json")
 
 	process_data := map[string]interface{}{
 		"fpath":      blendPath,
-		"asset_data": data.DownloadAssetData,
+		"asset_data": downloadAssetData,
 		"command":    "unpack",
-		"PREFS":      data.PREFS,
+		//"PREFS":      prefs,
 		//"debug_value": data.PREFS.DebugValue,
 	}
 	jsonData, err := json.Marshal(process_data)
@@ -346,7 +396,7 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 	}
 
 	cmd := exec.Command(
-		data.BinaryPath,
+		binaryPath,
 		"--background",
 		"--factory-startup", // disables user preferences, addons, etc.
 		"-noaudio",
@@ -354,7 +404,7 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 		"--python", unpackScriptPath,
 		"--",
 		dataFile,
-		data.PREFS.AddonModuleName, // Legacy has it as "blenderkit", extensions have it like bl_ext.user_default.blenderkit or anything else
+		addonModuleName, // Legacy has it as "blenderkit", extensions have it like bl_ext.user_default.blenderkit or anything else
 	)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("BLENDER_USER_SCRIPTS=%v", blenderUserScripts))
 	out, err := cmd.CombinedOutput()
@@ -369,9 +419,9 @@ func UnpackAsset(blendPath string, data DownloadData, taskID string) error {
 	return nil
 }
 
-func downloadAsset(url, filePath string, data DownloadData, taskID string, ctx context.Context) error {
+func downloadAsset(url, filePath string, appID int, addonVersion, platformVersion, taskID string, ctx context.Context) error {
 	TaskProgressUpdateCh <- &TaskProgressUpdate{
-		AppID:    data.AppID,
+		AppID:    appID,
 		TaskID:   taskID,
 		Progress: 0,
 		Message:  "Downloading",
@@ -388,7 +438,7 @@ func downloadAsset(url, filePath string, data DownloadData, taskID string, ctx c
 		return err
 	}
 
-	req.Header = getHeaders("", *SystemID, data.AddonVersion, data.PlatformVersion) // download needs no API key in headers
+	req.Header = getHeaders("", *SystemID, addonVersion, platformVersion) // download needs no API key in headers
 	resp, err := ClientDownloads.Do(req)
 	if err != nil {
 		e := DeleteFile(filePath)
@@ -441,7 +491,7 @@ func downloadAsset(url, filePath string, data DownloadData, taskID string, ctx c
 				downloadMessage = fmt.Sprintf("Downloading %.1fMB (%d%%)", sizeInMB, progress)
 			}
 			TaskProgressUpdateCh <- &TaskProgressUpdate{
-				AppID:    data.AppID,
+				AppID:    appID,
 				TaskID:   taskID,
 				Progress: progress,
 				Message:  downloadMessage,
@@ -490,11 +540,11 @@ func downloadAsset(url, filePath string, data DownloadData, taskID string, ctx c
 }
 
 // should return ['/Users/ag/blenderkit_data/models/kitten_0992088b-fb84-4c69-bb6e-426272970c8b/kitten_2K_d5368c9d-092e-4319-afe1-dd765de6da01.blend']
-func GetDownloadFilepaths(data DownloadData, filename string) []string {
+func GetDownloadFilepaths(downloadAssetData DownloadAssetData, downloadDirs []string, filename string) []string {
 	filePaths := []string{}
-	filename = ServerToLocalFilename(filename, data.DownloadAssetData.Name)
-	assetDirName := GetAssetDirectoryName(data.DownloadAssetData.Name, data.DownloadAssetData.ID)
-	for _, dir := range data.DownloadDirs {
+	filename = ServerToLocalFilename(filename, downloadAssetData.Name)
+	assetDirName := GetAssetDirectoryName(downloadAssetData.Name, downloadAssetData.ID)
+	for _, dir := range downloadDirs {
 		assetDirPath := filepath.Join(dir, assetDirName)
 		if _, err := os.Stat(assetDirPath); os.IsNotExist(err) {
 			os.MkdirAll(assetDirPath, os.ModePerm)
@@ -520,17 +570,17 @@ func GetDownloadFilepaths(data DownloadData, filename string) []string {
 
 // Get the download URL for the asset file.
 // Returns: canDownload, downloadURL, error.
-func GetDownloadURL(data DownloadData) (bool, string, error) {
+func GetDownloadURL(sceneID string, files []AssetFile, resolution string, apiKey, addonVersion, platformVersion string) (bool, string, error) {
 	reqData := url.Values{}
-	reqData.Set("scene_uuid", data.SceneID)
+	reqData.Set("scene_uuid", sceneID)
 
-	file, _ := GetResolutionFile(data.Files, data.PREFS.Resolution)
+	file, _ := GetResolutionFile(files, resolution)
 
 	req, err := http.NewRequest("GET", file.DownloadURL, nil)
 	if err != nil {
 		return false, "", err
 	}
-	req.Header = getHeaders(data.APIKey, *SystemID, data.AddonVersion, data.PlatformVersion)
+	req.Header = getHeaders(apiKey, *SystemID, addonVersion, platformVersion)
 	req.URL.RawQuery = reqData.Encode()
 
 	resp, err := ClientAPI.Do(req)

--- a/client/main.go
+++ b/client/main.go
@@ -2424,7 +2424,7 @@ type GetThisModelData struct {
 }
 
 func bkclientjsGetAsset(appID int, apiKey, assetBaseID, assetID, resolution string, targetSoftware Software) {
-	assetData, err := GetAssetInstance(assetID)
+	assetData, err := GetAssetInstance(assetID) // TODO: use assetBaseID and get the asset via /api/v1/search as advised by Petr
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -2609,6 +2609,7 @@ func bkclientjsGetAsset(appID int, apiKey, assetBaseID, assetID, resolution stri
 
 // Get data for single Asset instance by assetID.
 // https://www.blenderkit.com/api/v1/assets/{assetID}/
+// // TODO: use assetBaseID and get the asset via /api/v1/search as advised by Petr
 func GetAssetInstance(assetID string) (Asset, error) {
 	data := Asset{}
 	url := fmt.Sprintf("%s/api/v1/assets/%s/", *Server, assetID)

--- a/client/main.go
+++ b/client/main.go
@@ -63,6 +63,7 @@ const (
 	EmoDownload      = "⬇️ "
 	EmoIdentity      = "🆔"
 	EmoUpdate        = "🔜"
+	EmoBKClientJS    = "🌐"
 )
 
 var (
@@ -77,8 +78,8 @@ var (
 	lastReportAccess    time.Time
 	lastReportAccessMux sync.Mutex
 
-	ActiveAppsMux sync.Mutex
-	ActiveApps    []int
+	AvailableSoftwares    map[int]Software // Available Softwares which are connected to the Client
+	AvailableSoftwaresMux sync.Mutex
 
 	Tasks                map[int]map[string]*Task
 	TasksMux             sync.Mutex
@@ -99,6 +100,7 @@ func init() {
 	SystemID = getSystemID()
 	OAuth2Sessions = make(map[string]OAuth2VerificationData)
 	Tasks = make(map[int]map[string]*Task)
+	AvailableSoftwares = make(map[int]Software)
 	AddTaskCh = make(chan *Task, 1000)
 	TaskProgressUpdateCh = make(chan *TaskProgressUpdate, 1000)
 	TaskMessageCh = make(chan *TaskMessageUpdate, 1000)
@@ -256,6 +258,10 @@ func main() {
 	mux.HandleFunc("/wrappers/blocking_request", BlockingRequestHandler)
 	mux.HandleFunc("/wrappers/nonblocking_request", NonblockingRequestHandler)
 
+	// WEB BROWSER - bkclient.js
+	mux.HandleFunc("/bkclientjs/status", bkclientjsStatusHandler)
+	mux.HandleFunc("/bkclientjs/get_asset", bkclientjsGetAssetHandler)
+
 	StartClient(mux)
 }
 
@@ -365,11 +371,12 @@ func reportHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // SubscribeNewApp adds new App into Tasks[AppID].
-// This is called when new AppID appears - meeaning new add-on or other app wants to communicate with Client.
+// This is called when new AppID appears - meaning new add-on or other app wants to communicate with Client.
 func SubscribeNewApp(data MinimalTaskData) {
 	BKLog.Printf("%s New add-on connected: %d", EmoNewConnection, data.AppID)
 	Tasks[data.AppID] = make(map[string]*Task)
 
+	go SubscribeAvailableSoftware(data.AppID, "Blender", data.BlenderVersion, data.AddonVersion)
 	go FetchDisclaimer(data)
 	go FetchCategories(data)
 	if data.APIKey != "" {
@@ -412,6 +419,8 @@ func blenderUnsubscribeAddonHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	BKLog.Printf("%s Add-on unsubscribed: %d", EmoDisconnecting, data.AppID)
+
+	go UnsubscribeAvailableSoftware(data.AppID)
 
 	TasksMux.Lock()
 	if Tasks[data.AppID] != nil {
@@ -853,7 +862,7 @@ func GetDownloadURLWrapper(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	canDownload, URL, err := GetDownloadURL(data)
+	canDownload, URL, err := GetDownloadURL(data.SceneID, data.Files, data.PREFS.Resolution, data.APIKey, data.AddonVersion, data.PlatformVersion)
 	if err != nil {
 		http.Error(w, "Error getting download URL: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -2317,4 +2326,196 @@ func DictToParams(inputs map[string]interface{}) []map[string]string {
 		parameters = append(parameters, param)
 	}
 	return parameters
+}
+
+// Browser (via bkclient-js) gets status of the Client and all connected softwares.
+func bkclientjsStatusHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+	data := ClientStatus{
+		ClientVersion: ClientVersion,
+		Softwares:     GetAvailableSoftwares(AvailableSoftwares),
+	}
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonBytes)
+}
+
+// Status report for the bkclientjs library. Contains information about
+// compatible software and its currently running instances.
+type ClientStatus struct {
+	ClientVersion string     `json:"clientVersion"`
+	Softwares     []Software `json:"softwares"`
+}
+
+// Connected and running compatible software.
+// Right now this can be just instance of Blender.
+type Software struct {
+	Name            string `json:"name"`            // Name of the software
+	Version         string `json:"version"`         // Version of the Software
+	AppID           int    `json:"appID"`           // PID of the process
+	AddonVersion    string `json:"addonVersion"`    // Version of the add-on
+	PlatformVersion string `json:"platformVersion"` // Python's platform.platform()
+}
+
+// Data needed from the browser (with bkclientjs lib) to ask for Download of an asset.
+type bkclientjsDownloadData struct {
+	AssetID     string `json:"asset_id"`      // With ID client can directly get asset data on api/v1/assets
+	AssetBaseID string `json:"asset_base_id"` // Unused now. With Base ID add-on can search for the asset on api/v1/search
+	Resolution  string `json:"resolution"`    // Selected resolution - we ideally wants the user to decide on the web
+	APIKey      string `json:"api_key"`       // APIKey to be used (user is logged in on the web, so Client/addon can use this)
+	AppID       int    `json:"app_id"`        // AppID (PID) of the software to which we will download - detailed data in AvailableSoftwares
+}
+
+// User has clicked on Get This Model, or another words browser (via bkclientjs)
+// orders the Client to download the specified asset to specified software.
+func bkclientjsGetAssetHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		// The browser performs what is called a "preflight" request using the OPTIONS method
+		// to check if the actual request is safe to send. This preflight request is part of the CORS protocol
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var data bkclientjsDownloadData
+	err := json.NewDecoder(r.Body).Decode(&data)
+	if err != nil {
+		fmt.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	targetSoftware, exists := AvailableSoftwares[data.AppID]
+	if !exists {
+		BKLog.Printf("%s Could not find software (appID %d) for JS download", EmoWarning, data.AppID)
+		w.WriteHeader(http.StatusExpectationFailed)
+		w.Write([]byte("Software not Found"))
+		return
+	}
+
+	BKLog.Printf("%s Get Asset to %s (%d): %s %s, %s", EmoBKClientJS, targetSoftware.Name, data.AppID, data.AssetID, data.AssetBaseID, data.Resolution)
+	go bkclientjsGetAsset(data.AppID, data.APIKey, data.AssetBaseID, data.AssetID, data.Resolution, targetSoftware)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
+type GetThisModelData struct {
+	ApiKey      string `json:"api_key"`
+	AssetID     string `json:"asset_id"`
+	AssetBaseID string `json:"asset_base_id"`
+	Resolution  string `json:"resolution"`
+	AssetData   Asset  `json:"asset_data"`
+}
+
+func bkclientjsGetAsset(appID int, apiKey, assetBaseID, assetID, resolution string, targetSoftware Software) {
+	assetData, err := GetAssetInstance(assetID)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// BLENDER -> send data to add-on, it will then make a search and ask for download
+	if targetSoftware.Name == "Blender" {
+		AddTaskCh <- &Task{
+			AppID:    appID,
+			TaskID:   uuid.New().String(),
+			TaskType: "bkclientjs/get_asset",
+			Message:  "Download requested from browser.",
+			Status:   "finished",
+			Result: GetThisModelData{
+				ApiKey:      apiKey,
+				AssetID:     assetID,
+				AssetBaseID: assetBaseID,
+				Resolution:  resolution,
+				AssetData:   assetData,
+			},
+		}
+		return
+	}
+
+	// OTHER SOFTWARES
+	file, _ := GetResolutionFile(assetData.Files, resolution)
+	fmt.Print("🌐 File to download:", file)
+
+	fmt.Println("🌐 Downloading:", file.DownloadURL)
+	resp, err := ClientDownloads.Get(file.DownloadURL)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("🌐 Download failed:", resp.Status)
+		return
+	}
+	fmt.Println("🌐 Downloading resp:", resp)
+	//TODO: to be continued with Godot add-on
+}
+
+// Get data for single Asset instance by assetID.
+// https://www.blenderkit.com/api/v1/assets/{assetID}/
+func GetAssetInstance(assetID string) (Asset, error) {
+	data := Asset{}
+	url := fmt.Sprintf("%s/api/v1/assets/%s/", *Server, assetID)
+	resp, err := http.Get(url)
+	if err != nil {
+		return data, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg := "error getting asset"
+		respJSON, respString, err := ParseFailedHTTPResponse(resp)
+		if err != nil || respJSON == nil {
+			return data, fmt.Errorf("%s (%s): failed parsing error response (%v), [URL: %v]", msg, resp.Status, respString, url)
+		}
+		return data, fmt.Errorf("%s (%s)", msg, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Subscribe available software. This can be a Blender add-on, or add-on in any other compatible software, e.g. Godot in future.
+func SubscribeAvailableSoftware(appID int, name, version, addonVersion string) {
+	software := Software{
+		AppID:        appID,
+		Name:         name,
+		Version:      version,
+		AddonVersion: addonVersion,
+	}
+	AvailableSoftwaresMux.Lock()
+	AvailableSoftwares[appID] = software
+	AvailableSoftwaresMux.Unlock()
+}
+
+// Unscubscribe available software. This can be Blender add-on, or any other add-on in compatible software.
+func UnsubscribeAvailableSoftware(appID int) {
+	AvailableSoftwaresMux.Lock()
+	delete(AvailableSoftwares, appID)
+	AvailableSoftwaresMux.Unlock()
+}
+
+// Get AvailableSoftwares as a slice.
+func GetAvailableSoftwares(softwareMap map[int]Software) []Software {
+	var softwares []Software
+	for i := range softwareMap {
+		softwares = append(softwares, softwareMap[i])
+	}
+
+	return softwares
 }

--- a/client/structs.go
+++ b/client/structs.go
@@ -20,12 +20,15 @@ package main
 
 import "context"
 
-// MinimalTaskData is minimal data needed from add-on to schedule a task.
+// MinimalTaskData is minimal data needed from Blender add-on to schedule a task.
+// This is used only for communication with Blender add-on. Other add-on will not schedule a tasks.
+// From this also Software
 type MinimalTaskData struct {
-	AppID           int    `json:"app_id"`  // AppID is PID of Blender in which add-on runs
-	APIKey          string `json:"api_key"` // Can be empty for non-logged users
-	AddonVersion    string `json:"addon_version"`
-	PlatformVersion string `json:"platform_version"`
+	AppID           int    `json:"app_id"`           // AppID is PID of Blender in which add-on runs
+	APIKey          string `json:"api_key"`          // Can be empty for non-logged users
+	AddonVersion    string `json:"addon_version"`    // X.Y.Z version of add-on
+	BlenderVersion  string `json:"blender_version"`  // X.Y.X version of the Blender
+	PlatformVersion string `json:"platform_version"` // Result of platform.platform() in Python
 }
 
 // TaskStatusUpdate is a struct for updating the status of a task through a channel.

--- a/daemon_lib.py
+++ b/daemon_lib.py
@@ -82,6 +82,9 @@ def get_reports(app_id: str):
     If few last calls failed, then try to get reports also from other than default ports.
     """
     data = ensure_minimal_data({"app_id": app_id})
+    data["blender_version"] = (
+        f"{bpy.app.version[0]}.{bpy.app.version[1]}.{bpy.app.version[2]}"
+    )
     if (
         global_vars.CLIENT_FAILED_REPORTS < 10
     ):  # on 10, there is second BlenderKit-Client start

--- a/download.py
+++ b/download.py
@@ -876,6 +876,44 @@ def download(asset_data, **kwargs):
     download_tasks[response["task_id"]] = data
 
 
+def handle_bkclientjs_get_asset(task: daemon_tasks.Task):
+    """Handle incoming bkclientjs/get_asset task. User asked for download in online gallery. How it goes:
+    1. Webpage tries to connect to Client, gets data about connected Softwares
+    2. User choosed Blender with appID of this Blender
+    2. Client gets asset data from API
+    3. Client creates finished task bkclientjs/get_asset containing asset data
+    4. We handle the task in here
+    5. We request the download of the asset as if user has clicked it inside Blender
+
+    TODO: #1262Implement append to universal search results instead.
+    """
+    """ UNUSED CODE for direct download:
+    prefs = utils.get_preferences_as_dict()
+    prefs["resolution"] = task.result["resolution"]
+    prefs["scene_id"] = utils.get_scene_id()
+    download_dirs = paths.get_download_dirs(task.result["asset_data"]["assetType"])
+    data = {
+        "asset_data": task.result["asset_data"],
+        "download_dirs": download_dirs,
+        "PREFS": prefs,
+        "progress": 0,
+        "text": f'Getting asset {task.result["asset_data"]["name"]}',
+        "downloaders": [{'location': (0.0, 0.0, 0.0), 'rotation': (0.0, 0.0, 0.0)}],
+        "cast_parent": "",
+        "target_object": task.result["asset_data"]["name"],
+        "material_target_slot": 0,
+        "model_location": (0.0, 0.0, 0.0),
+        "model_rotation": (0.0, 0.0, 0.0),
+        "replace": False,
+        "replace_resolution": False,
+        "resolution": task.result["resolution"],
+    }
+
+    response = daemon_lib.asset_download(data)
+    download_tasks[response["task_id"]] = data
+    """
+
+
 def check_downloading(asset_data, **kwargs) -> bool:
     """Check if the asset is already being downloaded.
     If not, return False.

--- a/timer.py
+++ b/timer.py
@@ -300,6 +300,10 @@ def handle_task(task: daemon_tasks.Task):
     if task.task_type == "wrappers/nonblocking_request":
         return utils.handle_nonblocking_request_task(task)
 
+    # BKCLIENTJS - Download from web
+    if task.task_type == "bkclientjs/get_asset":
+        return download.handle_bkclientjs_get_asset(task)
+
     # HANDLE MESSAGE FROM DAEMON
     if task.task_type == "message_from_daemon":
         level = task.result.get("level", "INFO").upper()


### PR DESCRIPTION
fixes #1246 

Ready for review, mostly unpacking needs a check, if it works fine. From my finding the Preferences were not used inside the unpack script, so I have removed it in order to lower the complexity of the data needed.

- adds support for multiple versions of connected softwares - these are kept in `AvailableSoftwares map[int]Software // Available Softwares which are connected to the Client`
- connected softwares (aka Blender add-on, Godot plugin) does not need to actively unsubscribe on their unregistration (Godot cannot do that). Instead Client keeps track if they get silent and then unsubscribes them.
- modularizes several functions, so they do not accept huge data structs, instead they accept just needed parameters - to improve reusability
- adds endpoint `mux.HandleFunc("/bkclientjs/status", bkclientjsStatusHandler)` - JS library here can get information about available connected softwares, so downloads can be then directed from the browser directly
- adds endpoint `mux.HandleFunc("/bkclientjs/get_asset", bkclientjsGetAssetHandler)` - here JS library can ask for download of an asset (will be used in Godot, but could be also used for add-on so we skip the clipboard hack - we will ideally need to implement #1262, so the assets get appended to the search and once user gets from browser to blender, they see all the assets they have chosen on the web and then they can drag and drop)
- adds endpoint `mux.HandleFunc("/godot/report", godotReportHandler)` - here Godot asks for reports by which it also tells about its existence, ideally all softwares would have their own routes, e.g. `/software_name/what_to_do`.
