### PR TITLE
Validators comments preview

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -471,7 +471,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         if (
             user_preferences.asset_popup_counter
             < user_preferences.asset_popup_counter_max
-        ):
+        ) or utils.profile_is_validator():
             # this is shown only to users who don't know yet about the popup card.
             label = self.new_text(
                 "Right click for menu.",
@@ -481,7 +481,11 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 text_size=self.author_text_size,
             )
             self.tooltip_widgets.append(label)
+            self.comments = label
             offset += 1
+            if utils.profile_is_validator():
+                label.multiline = True
+                label.text = "No comments yet."
         # version warning
         version_warning = self.new_text(
             "",
@@ -850,6 +854,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             red_alert.active = False
             new_button.red_alert = red_alert
             self.red_alerts.append(red_alert)
+
         # if result['downloaded'] > 0:
         #     ui_bgl.draw_rect(x, y, int(ui_props.thumb_size * result['downloaded'] / 100.0), 2, green)
 
@@ -1215,6 +1220,20 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             if utils.profile_is_validator():
                 quality_text += f" / {int(asset_data['score'])}"
             self.quality_label.text = quality_text
+
+            # preview comments for validators
+            if utils.profile_is_validator():
+                comments = global_vars.DATA.get("asset comments", {})
+                comments = comments.get(asset_data["assetBaseId"], [])
+                comment_text = "No comments yet."
+                comment_text = "It's updating"
+                if comments is not None:
+                    comment_text = ""
+                    for comment in comments:
+                        comment_text += (
+                            f"{comment['userName']}:\n{comment['comment']}\n\n"
+                        )
+                self.comments.text = comment_text
 
             from_newer, difference = utils.asset_from_newer_blender_version(asset_data)
             if from_newer:

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1197,8 +1197,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             if comments is not None:
                 comment_text = ""
                 # iterate comments from last to first
-                comments = comments[::-1]
-                for comment in comments:
+                for comment in reversed(comments):
                     comment_text += f"{comment['userName']}:\n"
                     # strip urls and stuff
                     comment_lines = comment["comment"].split("\n")

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1226,13 +1226,22 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 comments = global_vars.DATA.get("asset comments", {})
                 comments = comments.get(asset_data["assetBaseId"], [])
                 comment_text = "No comments yet."
-                comment_text = "It's updating"
                 if comments is not None:
                     comment_text = ""
+                    # iterate comments from last to first
+                    comments = comments[::-1]
                     for comment in comments:
-                        comment_text += (
-                            f"{comment['userName']}:\n{comment['comment']}\n\n"
-                        )
+                        comment_text += f"{comment['userName']}:\n"
+                        # strip urls and stuff
+                        comment_lines = comment["comment"].split("\n")
+                        for line in comment_lines:
+                            urls, text = utils.has_url(line)
+                            if urls:
+                                comment_text += f"{text}{urls[0][0]}\n"
+                            else:
+                                comment_text += f"{text}\n"
+                        comment_text += "\n"
+
                 self.comments.text = comment_text
 
             from_newer, difference = utils.asset_from_newer_blender_version(asset_data)

--- a/bl_ui_widgets/bl_ui_label.py
+++ b/bl_ui_widgets/bl_ui_label.py
@@ -13,6 +13,9 @@ class BL_UI_Label(BL_UI_Widget):
         self._text_size = 16
         self._halign = "LEFT"
         self._valign = "TOP"
+        # multiline
+        self.multiline = False
+        self.row_height = 20
 
     @property
     def text_color(self):
@@ -73,8 +76,16 @@ class BL_UI_Label(BL_UI_Widget):
             if self._valign == "CENTER":
                 y -= height // 2
             # bottom could be here but there's no reason for it
-        blf.position(font_id, x, y, 0)
+        if not self.multiline:
+            blf.position(font_id, x, y, 0)
 
-        blf.color(font_id, r, g, b, a)
+            blf.color(font_id, r, g, b, a)
 
-        blf.draw(font_id, self._text)
+            blf.draw(font_id, self._text)
+        else:
+            lines = self._text.split("\n")
+            for line in lines:
+                blf.position(font_id, x, y, 0)
+                blf.color(font_id, r, g, b, a)
+                blf.draw(font_id, line)
+                y -= self.row_height

--- a/search.py
+++ b/search.py
@@ -33,6 +33,7 @@ from bpy.types import Operator
 
 from . import (
     asset_bar_op,
+    comments_utils,
     daemon_lib,
     daemon_tasks,
     global_vars,
@@ -380,6 +381,16 @@ def handle_search_task(task: daemon_tasks.Task) -> bool:
         asset_data = parse_result(r)
         if asset_data is not None:
             result_field.append(asset_data)
+        # fetch all comments if user is validator to preview them faster
+        # these comments are also shown as part of the tooltip oh mouse hover in asset bar.
+        if utils.profile_is_validator():
+            comments = comments_utils.get_comments_local(asset_data["assetBaseId"])
+            if comments is None:
+                user_preferences = bpy.context.preferences.addons[
+                    __package__
+                ].preferences
+                api_key = user_preferences.api_key
+                daemon_lib.get_comments(asset_data["assetBaseId"])
 
     # Get ratings from BlenderKit server TODO: do this in daemon
     if utils.profile_is_validator():


### PR DESCRIPTION
Shows comments for validators direclty in 3d view:
This helps validators to see the history of asset faster and make better judgement. 
By now, the formatting is just what it is... nothing fancy, but should help.
<img width="827" alt="image" src="https://github.com/user-attachments/assets/2411dc8d-10cd-4c55-a331-49213ab1fcb3">
