### PR TITLE
#1292 Make addon_dir, global_dir, client_log and temp_dir easily accessible

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2342,20 +2342,36 @@ In this case you should also set path to your system CA bundle containing proxy'
         addon_updater_ops.update_settings_ui(self, context)
 
         # RUNTIME INFO
-        addondir_row = layout.row()
-        addondir_row.label(text=f"Installed at: {path.dirname(__file__)}")
-        addondir_row.enabled = False
-        globdir_row = layout.row()
-        globdir_row.label(text=f"Global directory: {self.global_dir}")
-        globdir_row.enabled = False
-        dlog_row = layout.row()
-        dlog_row.label(
-            text=f"BlenderKit-client log: {daemon_lib.get_client_log_path()}"
+        globdir_op = layout.operator(
+            "wm.blenderkit_open_global_directory",
+            text=f"Global directory: {self.global_dir}",
+            icon="FILE_FOLDER",
         )
-        dlog_row.enabled = False
-        tmpdir_row = layout.row()
-        tmpdir_row.label(text=f"Temp directory: {paths.get_temp_dir()}")
-        tmpdir_row.enabled = False
+        globdir_op.directory = self.global_dir
+
+        clientlog_path = daemon_lib.get_client_log_path()
+        clientlog_op = layout.operator(
+            "wm.blenderkit_open_client_log",
+            text=f"Client log: {clientlog_path}",
+            icon="FILE_FOLDER",
+        )
+        clientlog_op.directory = clientlog_path
+
+        addondir = path.dirname(__file__)
+        addondir_op = layout.operator(
+            "wm.blenderkit_open_addon_directory",
+            text=f"Installed at: {addondir}",
+            icon="FILE_FOLDER",
+        )
+        addondir_op.directory = addondir
+
+        tempdir = paths.get_temp_dir()
+        tempdir_op = layout.operator(
+            "wm.blenderkit_open_temp_directory",
+            text=f"Temp directory: {tempdir}",
+            icon="FILE_FOLDER",
+        )
+        tempdir_op.directory = tempdir
 
 
 # registration

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1827,12 +1827,11 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
 
 
 class OpenSystemDirectory(bpy.types.Operator):
-    """Open system directory"""
+    """Open directory in default system file explorer"""
 
     bl_idname = "wm.blenderkit_open_system_directory"
     bl_label = "Open system directory"
     bl_options = {"REGISTER", "UNDO"}
-
     directory: StringProperty(name="directory", default="")
 
     @classmethod
@@ -1841,10 +1840,52 @@ class OpenSystemDirectory(bpy.types.Operator):
 
     def execute(self, context):
         if not os.path.exists(self.directory):
+            self.report({"ERROR"}, "Directory not found.")
+            return {"CANCELLED"}
+        paths.open_path_in_file_browser(self.directory)
+        return {"FINISHED"}
+
+
+class OpenAssetDirectory(OpenSystemDirectory):
+    """Open directory containing the asset data"""
+
+    bl_idname = "wm.blenderkit_open_asset_directory"
+    bl_label = "Open asset directory"
+
+    def execute(self, context):
+        if not os.path.exists(self.directory):
             self.report({"ERROR"}, "Directory not found. Asset not downloaded yet.")
             return {"CANCELLED"}
         paths.open_path_in_file_browser(self.directory)
         return {"FINISHED"}
+
+
+class OpenAddonDirectory(OpenSystemDirectory):
+    """Open the directory in which the BlenderKit add-on is installed. Move one level up and delete it to hard-uninstall the add-on"""
+
+    bl_idname = "wm.blenderkit_open_addon_directory"
+    bl_label = "Open global directory"
+
+
+class OpenGlobalDirectory(OpenSystemDirectory):
+    """Open the BlenderKit's Global directory. This is the directory where BlenderKit stores downloaded assets. It also contains Client binary and log files"""
+
+    bl_idname = "wm.blenderkit_open_global_directory"
+    bl_label = "Open global directory"
+
+
+class OpenClientLog(OpenSystemDirectory):
+    """Open Log file of currently running Client. Client logs errors and other message in here. Inspect to see what is wrong with Client. Copy the contents when you make a bug report"""
+
+    bl_idname = "wm.blenderkit_open_client_log"
+    bl_label = "Open Client log"
+
+
+class OpenTempDirectory(OpenSystemDirectory):
+    """Open BlenderKit's temporary directory. This is the directory where thumbnails and other temporary files are stored"""
+
+    bl_idname = "wm.blenderkit_open_temp_directory"
+    bl_label = "Open temp directory"
 
 
 def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
@@ -1922,7 +1963,7 @@ def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
     dir_paths = paths.get_asset_directories(asset_data)
     if len(dir_paths) > 0 and os.path.exists(dir_paths[-1]):
         op = layout.operator(
-            "wm.blenderkit_open_system_directory",
+            "wm.blenderkit_open_asset_directory",
             text="Open Directory",
             icon="FILE_FOLDER",
         )
@@ -3609,6 +3650,11 @@ classes = (
     NODE_PT_blenderkit_material_properties,
     OpenBlenderKitDiscord,
     OpenSystemDirectory,
+    OpenAssetDirectory,
+    OpenAddonDirectory,
+    OpenGlobalDirectory,
+    OpenClientLog,
+    OpenTempDirectory,
     # VIEW3D_PT_blenderkit_ratings,
     VIEW3D_PT_blenderkit_downloads,
     # OBJECT_MT_blenderkit_resolution_menu,


### PR DESCRIPTION
fixes #1292 

- all buttons have also more information about what those locations are, before it was not possible with the label
- replaces Global Dir informative text with open directory button for Global Directory (we often tell users to open and search for something there or delete it)
- replaces Temp dir informative text with open directory button for Temp Directory
- replaces Addon Dir informative text with open directory for Addon Directory
- replaces Client Log informative text with direct open of the Log File - needs to be tested on Windows, please check! <3