### PR TITLE
#1305 Special character breaks the search

### DIFF
--- a/search.py
+++ b/search.py
@@ -20,7 +20,7 @@ import json
 import logging
 import math
 import os
-import platform
+import urllib.parse
 import unicodedata
 
 import bpy
@@ -647,19 +647,21 @@ def handle_get_user_profile(task: daemon_tasks.Task):
 
 
 def query_to_url(query={}, params={}):
-    # build a new request
+    """Build a new search request by parsing query dictionaty into appropriate URL.
+    Also modifies query and params and adds some stuff in there which is very misleading anti-patter.
+    TODO: just convert to URL here and move the sorting and adding of params to separate function.
+    https://www.blenderkit.com/api/v1/search/
+    """
     url = f"{paths.BLENDERKIT_API}/search/"
 
-    # build request manually
-    # TODO use real queries
     requeststring = "?query="
-    #
     if query.get("query") not in ("", None):
-        requeststring += query["query"]  # .lower()
-    for i, q in enumerate(query):
+        requeststring += urllib.parse.quote_plus(query["query"])  # .lower()
+    for q in query:
         if q != "query" and q != "free_first":
-            requeststring += "+"
-            requeststring += q + ":" + str(query[q])  # .lower()
+            requeststring += (
+                f"+{q}:{urllib.parse.quote_plus(str(query[q]))}"  # .lower()
+            )
 
     # add dict_parameters to make results smaller
     # result ordering: _score - relevance, score - BlenderKit score
@@ -700,11 +702,12 @@ def query_to_url(query={}, params={}):
     requeststring += "&dict_parameters=1"
 
     requeststring += "&page_size=" + str(params["page_size"])
-    requeststring += "&addon_version=%s" % params["addon_version"]
+    requeststring += f"&addon_version={params['addon_version']}"
     if not (query.get("query") and query.get("query").find("asset_base_id") > -1):
-        requeststring += "&blender_version=%s" % params["blender_version"]
+        requeststring += f"&blender_version={params['blender_version']}"
     if params.get("scene_uuid") is not None:
-        requeststring += "&scene_uuid=%s" % params["scene_uuid"]
+        requeststring += f"&scene_uuid={params['scene_uuid']}"
+
     urlquery = url + requeststring
     return urlquery
 
@@ -1090,10 +1093,12 @@ def clean_filters():
 
 
 def update_filters():
-    # update filters for 2 reasons
-    # - first to show if filters are active
-    # - second to show login popup if user needs to log in
-    # returns True if search should proceed, False to bounce search(like in the case of bookmarks)
+    """Update filters for 2 reasons
+    - first to show if filters are active
+    - second to show login popup if user needs to log in
+
+    returns True if search should proceed, False to bounce search(like in the case of bookmarks)
+    """
 
     sprops = utils.get_search_props()
     ui_props = bpy.context.window_manager.blenderkitUI


### PR DESCRIPTION
fixes #1305

Whole search really needs a huge refactor, it is crazy.


We should not manipulate params/queries inside function which is named query_to_url. It is completely misleading.

```python
    order = []
    if query.get("free_first", False):
        order = [
            "-is_free",
        ]

    # query with category_subtree:model etc gives irrelevant results
    if query.get("category_subtree") in (
        "model",
        "material",
        "scene",
        "brush",
        "hdr",
        "nodegroup",
    ):
        query["category_subtree"] = None

    if query.get("query") is None and query.get("category_subtree") == None:
        # assumes no keywords and no category, thus an empty search that is triggered on start.
        # orders by last core file upload
        if query.get("verification_status") == "uploaded":
            # for validators, sort uploaded from oldest
            order.append("last_blend_upload")
        else:
            order.append("-last_blend_upload")
    elif query.get("author_id") is not None and utils.profile_is_validator():
        order.append("-created")
    else:
        if query.get("category_subtree") is not None:
            order.append("-score,_score")
        else:
            order.append("_score")
    if requeststring.find("+order:") == -1:
        requeststring += "+order:" + ",".join(order)
    requeststring += "&dict_parameters=1"

    requeststring += "&page_size=" + str(params["page_size"])
    requeststring += f"&addon_version={params['addon_version']}"
    if not (query.get("query") and query.get("query").find("asset_base_id") > -1):
        requeststring += f"&blender_version={params['blender_version']}"
    if params.get("scene_uuid") is not None:
        requeststring += f"&scene_uuid={params['scene_uuid']}"
```