### PR TITLE
#1308 Improve documentation of shortcuts and add few new ones

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -507,7 +507,7 @@ class BlenderKitUIProps(PropertyGroup):
     drag_init_button: BoolProperty(
         name="Drag Initialisation from button",
         default=False,
-        description="Click or drag into scene for download",
+        description="Click or drag into scene for download.\nUse mouse wheel during drag to rotate the asset. Cancel the drag by pressing 'Esc'.",
         update=run_drag_drop_update,
     )
     drag_length: IntProperty(name="Drag length", default=0)

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1517,10 +1517,31 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             search.search(author_id=a)
         return True
 
+    def search_similar(self, asset_index):
+        sr = global_vars.DATA["search results"]
+        asset_data = sr[asset_index]
+        keywords = search.get_search_similar_keywords(asset_data)
+        sprops = utils.get_search_props()
+        sprops.search_keywords = keywords
+        search.search()
+
+    def search_in_category(self, asset_index):
+        sr = global_vars.DATA["search results"]
+        asset_data = sr[asset_index]
+        category = asset_data.get("category")
+        if category is None:
+            return True
+        sprops = utils.get_search_props()
+        sprops.search_category = category
+        search.search()
+
     def handle_key_input(self, event):
+        # Shortcut: Search by author
         if event.type == "A":
             self.search_by_author(self.active_index)
             return True
+
+        # Shortcut: Delete asset from harddrive
         if event.type == "X" and self.active_index > -1:
             # delete downloaded files for this asset
             sr = global_vars.DATA["search results"]
@@ -1529,14 +1550,48 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             paths.delete_asset_debug(asset_data)
             asset_data["downloaded"] = 0
             return True
+
+        # Shortcut: Open Author's personal Webpage
         if event.type == "W" and self.active_index > -1:
             sr = global_vars.DATA["search results"]
             asset_data = sr[self.active_index]
-            a = global_vars.DATA["bkit authors"].get(asset_data["author"]["id"])
-            if a is not None:
-                utils.p("author:", a)
-                if a.get("aboutMeUrl") is not None:
-                    bpy.ops.wm.url_open(url=a["aboutMeUrl"])
+            author = global_vars.DATA["bkit authors"].get(asset_data["author"]["id"])
+            if author is None:
+                print("author is none")
+                return True
+            utils.p("author:", author)
+            url = author.get("aboutMeUrl")
+            if url is None:
+                print("url is none")
+                return True
+            bpy.ops.wm.url_open(url=url)
+            return True
+
+        # Shortcut: Search Similar
+        if event.type == "S" and self.active_index > -1:
+            self.search_similar(self.active_index)
+            return True
+
+        if event.type == "C" and self.active_index > -1:
+            self.search_in_category(self.active_index)
+            return True
+
+        if event.type == "B" and self.active_index > -1:
+            sr = global_vars.DATA["search results"]
+            asset_data = sr[self.active_index]
+            bpy.ops.wm.blenderkit_bookmark_asset(asset_id=asset_data["id"])
+            return True
+
+        # Shortcut: Open Author's profile on BlenderKit
+        if event.type == "P" and self.active_index > -1:
+            sr = global_vars.DATA["search results"]
+            asset_data = sr[self.active_index]
+            author = global_vars.DATA["bkit authors"].get(asset_data["author"]["id"])
+            if author is None:
+                return True
+            utils.p("author:", author)
+            url = paths.get_author_gallery_url(author["id"])
+            bpy.ops.wm.url_open(url=url)
             return True
 
         # FastRateMenu

--- a/global_vars.py
+++ b/global_vars.py
@@ -102,15 +102,31 @@ TIPS = [
     ),
     ("Support the authors by subscribing to Full plan.", f"{SERVER}/plans/pricing/"),
     (
-        "Use the W key over the asset bar to open the Author's webpage.",
+        "Use the 'P' key over the asset bar to open the Author's profile on BlenderKit.",
         "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
     ),
     (
-        "Use the R key over the asset bar for fast rating of assets.",
+        "Use the 'W' key over the asset bar to open Author's personal webpage.",
         "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
     ),
     (
-        "Use the X key over the asset bar to delete the asset from your hard drive.",
+        "Use the 'R' key over the asset bar for fast rating of assets.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Use the 'X' key over the asset bar to delete the asset from your hard drive.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Use the 'S' key over the asset bar to search similar assets.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Use the 'C' key over the asset bar to search assets in same subcategory.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Use the 'B' key over the asset bar to bookmark the asset.",
         "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
     ),
     (

--- a/ratings.py
+++ b/ratings.py
@@ -183,7 +183,7 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
 
 
 class SetBookmark(bpy.types.Operator):
-    """Add or remove bookmarking of the asset"""
+    """Add or remove bookmarking of the asset.\nShortcut: hover over asset in the asset bar and press 'B'."""
 
     bl_idname = "wm.blenderkit_bookmark_asset"
     bl_label = "BlenderKit bookmark assest"

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -329,9 +329,9 @@ class RatingProperties(PropertyGroup):
 
     # the following enum is only to ease interaction - enums support 'drag over' and enable to draw the stars easily.
     rating_quality_ui: EnumProperty(
-        name="rating_quality_ui",
+        name="Quality",
         items=stars_enum_callback,
-        description="Rating stars 0 - 10",
+        description="Rate the quality of the asset from 1 to 10 stars.\nShortcut: Hover over asset in the asset bar and press 'R' to show rating menu",
         default=0,
         update=update_quality_ui,
         options={"SKIP_SAVE"},
@@ -346,7 +346,7 @@ class RatingProperties(PropertyGroup):
     )
     rating_work_hours: FloatProperty(
         name="Work Hours",
-        description="How many hours did this work take?",
+        description="How many hours did this work take?\nShortcut: Hover over asset in the asset bar and press 'R' to show rating menu.",
         default=0.00,
         min=0.0,
         max=300,
@@ -355,7 +355,7 @@ class RatingProperties(PropertyGroup):
     )
     rating_work_hours_ui: EnumProperty(
         name="Work Hours",
-        description="How many hours did this work take?",
+        description="How many hours did this work take?\nShortcut: Hover over asset in the asset bar and press 'R' to show rating menu",
         items=wh_enum_callback,
         default=0,
         update=update_ratings_work_hours_ui,

--- a/search.py
+++ b/search.py
@@ -1353,6 +1353,17 @@ class TooltipLabelOperator(Operator):
         return {"FINISHED"}
 
 
+def get_search_similar_keywords(asset_data: dict) -> str:
+    """Generate search similar keywords from the given asset_data.
+    Could be tuned in the future to provide better search results.
+    """
+    keywords = asset_data["name"]
+    if asset_data.get("description"):
+        keywords += f" {asset_data.get('description')} "
+    keywords += " ".join(asset_data.get("tags"))
+    return keywords
+
+
 classes = [SearchOperator, UrlOperator, TooltipLabelOperator]
 
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -372,10 +372,10 @@ def draw_assetbar_show_hide(layout, props):
 
     if ui_props.assetbar_on:
         icon = "HIDE_OFF"
-        ttip = "Click to Hide Asset Bar"
+        ttip = "Click to Hide Asset Bar.\nShortcut: ;"
     else:
         icon = "HIDE_ON"
-        ttip = "Click to Show Asset Bar"
+        ttip = "Click to Show Asset Bar.\nShortcut: ;"
 
     op = layout.operator("view3d.blenderkit_asset_bar_widget", text="", icon=icon)
     op.keep_running = False
@@ -1945,15 +1945,10 @@ def draw_asset_context_menu(layout, context, asset_data, from_panel=False):
 
     op = layout.operator("view3d.blenderkit_search", text="Search Similar")
     op.esc = True
-    op.tooltip = "Search for similar assets in the library"
-    # build search string from description and tags:
-    op.keywords = asset_data["name"]
-    if asset_data.get("description"):
-        op.keywords += " " + asset_data.get("description") + " "
-    op.keywords += " ".join(asset_data.get("tags"))
+    op.tooltip = "Search for similar assets in the library.\nShortcut: hover over asset in asset bar and press 'S'."
+    op.keywords = search.get_search_similar_keywords(asset_data)
 
     op = layout.operator("wm.url_open", text="See online", icon="URL")
-
     if (
         utils.user_is_owner(asset_data)
         and asset_data["verificationStatus"] != "validated"
@@ -2664,6 +2659,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         op = button_row.operator(
             "view3d.blenderkit_search", text="Find Assets By Author", icon="VIEWZOOM"
         )
+        op.tooltip = "Search all assets by this author.\nShortcut: Hover over the asset in the asset bar and press 'A'."
         op.esc = True
         op.keywords = ""
         op.author_id = self.asset_data["author"]["id"]
@@ -2672,7 +2668,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
 
         # AUTHOR's BLENDERKIT PROFILE
         url = paths.get_author_gallery_url(author["id"])
-        tooltip = "Go to author's profile on BlenderKit webpage"
+        tooltip = "Go to author's profile on BlenderKit web.\nShortcut: Hover over asset in the asset bar and press 'P'."
         icon_value = pcoll["logo"].icon_id
         op = button_row.operator("wm.blenderkit_url", text="", icon_value=icon_value)
         op.url = url
@@ -2685,7 +2681,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             text = utils.shorten_text(text, 45)
             op = button_row.operator("wm.blenderkit_url", text="", icon="URL")
             op.url = url
-            op.tooltip = f"Go to author's personal web page: \n\n{url}\n"
+            op.tooltip = f"Go to author's personal Webpage: {url}\nShortcut: Hover over asset in the asset bar and press 'W'."
 
         # SOCIAL NETWORKS
         social_networks = author.get("socialNetworks", [])
@@ -2864,11 +2860,12 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
 
         for i, c in enumerate(cat_path):
             cat_name = cat_path_names[i]
-
             ui_props = bpy.context.window_manager.blenderkitUI
-            op = name_row.operator(
-                "view3d.blenderkit_set_category", text=cat_name + "     >", emboss=True
-            )
+            if i < len(cat_path) - 1:
+                bl_id = "view3d.blenderkit_set_category_in_popup_card"
+            else:
+                bl_id = "view3d.blenderkit_set_category_in_popup_card_last"
+            op = name_row.operator(bl_id, text=cat_name + "     >", emboss=True)
             op.asset_type = ui_props.asset_type
             # this gets filled not to change anything in browsing categories
             op.category_browse = global_vars.DATA["active_category_browse"][
@@ -3153,10 +3150,8 @@ class SetCommentReplyId(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class SetCategoryOperator(bpy.types.Operator):
-    """Visit subcategory"""
-
-    bl_idname = "view3d.blenderkit_set_category"
+class SetCategoryOperatorOrigin(bpy.types.Operator):
+    bl_idname = "view3d.blenderkit_set_category_origin"
     bl_label = "BlenderKit Set Active Category"
     bl_options = {"REGISTER", "UNDO", "INTERNAL"}
 
@@ -3193,6 +3188,26 @@ class SetCategoryOperator(bpy.types.Operator):
         # we have to write back to wm. Thought this should happen with original list.
         global_vars.DATA["active_category_browse"][self.asset_type] = acat
         return {"FINISHED"}
+
+
+# TODO: Handle here SelectSubcategory/SelectCategory
+# and VisitSubcategory/VisitCategory and VisitUpperCategory/VisitUpperSubcategory
+class SetCategoryOperator(SetCategoryOperatorOrigin):
+    """Visit subcategory"""
+
+    bl_idname = "view3d.blenderkit_set_category"
+
+
+class SetCategoryOperatorInPopupCard(SetCategoryOperatorOrigin):
+    """Subcategory of the asset. Click to search this subcategory."""
+
+    bl_idname = "view3d.blenderkit_set_category_in_popup_card"
+
+
+class SetCategoryOperatorLastInPopupCard(SetCategoryOperatorOrigin):
+    """Subcategory of the asset. Click to search this subcategory. Shortcut: Hover over asset in the asset bar and press 'C'."""
+
+    bl_idname = "view3d.blenderkit_set_category_in_popup_card_last"
 
 
 class ClosePopupButton(bpy.types.Operator):
@@ -3640,7 +3655,10 @@ def ui_message(title, message):
 preview_collections = {}
 
 classes = (
+    SetCategoryOperatorOrigin,
     SetCategoryOperator,
+    SetCategoryOperatorInPopupCard,
+    SetCategoryOperatorLastInPopupCard,
     SetCommentReplyId,
     VIEW3D_PT_blenderkit_profile,
     # VIEW3D_PT_blenderkit_login,


### PR DESCRIPTION
fixes #1308

- adding B for bookmarking hoovered asset
- adding P for opening profile on BlenderKit web
- adding C for searching assets in same subcategory
- adding S for searching similar assets
- adding info to tooltips about semicolon, R, A, W