### PR TITLE
Fix #1327 Materials found on disk have missing texture, wrong texture filename parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 out
 pyproject.toml
 client_builds
+.venv

--- a/client/main.go
+++ b/client/main.go
@@ -961,7 +961,7 @@ func GetDownloadURLWrapper(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	canDownload, URL, err := GetDownloadURL(data.SceneID, data.Files, data.PREFS.Resolution, data.APIKey, data.AddonVersion, data.PlatformVersion)
+	canDownload, URL, err := GetDownloadURL(data.Preferences.SceneID, data.DownloadAssetData.Files, data.Preferences.Resolution, data.Preferences.APIKey, data.AddonVersion, data.PlatformVersion)
 	if err != nil {
 		http.Error(w, "Error getting download URL: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/client/structs.go
+++ b/client/structs.go
@@ -229,12 +229,13 @@ type DownloadAssetData struct {
 }
 
 type DownloadData struct {
-	AddonVersion      string   `json:"addon_version"`
-	PlatformVersion   string   `json:"platform_version"`
-	AppID             int      `json:"app_id"`
-	DownloadDirs      []string `json:"download_dirs"`
-	DownloadAssetData `json:"asset_data"`
-	PREFS             `json:"PREFS"`
+	AddonVersion      string            `json:"addon_version"`
+	PlatformVersion   string            `json:"platform_version"`
+	AppID             int               `json:"app_id"`
+	DownloadDirs      []string          `json:"download_dirs"`
+	Resolution        string            `json:"resolution"` // used to populate DownloadAssetData.Resolution
+	DownloadAssetData DownloadAssetData `json:"asset_data"`
+	Preferences       PREFS             `json:"PREFS"`
 }
 
 type Category struct {


### PR DESCRIPTION
- bpy.path.basename(path) does not work for Windows paths with \ when running on Mac, adding backslash conversion
- resolution is sometimes not detected - fixed now