### PR TITLE
Fix #1342 ModuleNotFoundError: No Module Named 'pwd' error

### DIFF
--- a/paths.py
+++ b/paths.py
@@ -107,7 +107,10 @@ def get_temp_dir(subdir=None):
         d = dirs_exist_dict.get("top")
         if d is not None:
             return d
-    username = getpass.getuser()
+    try:  # if USERNAME envvar is unset on Win, getuser() fallbacks to pwd module which is not available on Windows
+        username = getpass.getuser()
+    except ModuleNotFoundError as e:
+        username = "bkuser"
     safe_username = "".join(c for c in username if c.isalnum())
     tempdir = os.path.join(tempfile.gettempdir(), f"bktemp_{safe_username}")
     if tempdir.startswith("//"):


### PR DESCRIPTION
- env variable USERNAME can be unset on some Windows systems, it is unusual but it can happen
- python function getpass.getuser() of built-in module getpass then fallback to module `pwd`
- module `pwd` is however available only on Linux and MacOS distroc, not on Windows, which leads to import error
- catch the import error and set default username `bkuser`