### PR TITLE
Fix #1375 Assetbar, drag and drop and disclaimer does not work in Blender 4.4.0-alpha

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1040,8 +1040,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             (0, int((self.bar_height - self.button_size) / 2))
         )
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def on_init(self, context):
         self.tooltip_base_size_pixels = 512

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -850,8 +850,8 @@ class DownloadGizmoOperator(BL_UI_OT_draw_operator):
         if cancel_download:
             bpy.ops.scene.blenderkit_download_kill(task_id=self.task_key)
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # get downloader
         self.task = None

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -8,7 +8,8 @@ class BL_UI_OT_draw_operator(Operator):
     bl_description = "Operator for bl ui widgets"
     bl_options = {"REGISTER"}
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.draw_handle = None
         self.draw_event = None
         self._finished = False

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -84,8 +84,8 @@ class BlenderKitDisclaimerOperator(BL_UI_OT_draw_operator):
 
         bpy.ops.wm.url_open(url=self.url)
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         ui_scale = bpy.context.preferences.view.ui_scale
 
         text_size = int(14 * ui_scale)


### PR DESCRIPTION
fixes #1375

- classes inheriting from Operator class which overrides __init__() function, need to accept *args, **kwargs
- they also need to call parent __init__ with *args, **kwargs info at: https://developer.blender.org/docs/release_notes/4.4/python_api/#blender-based-python-classes-construction