### PR TITLE
Fix #1390 Use new /ratings API endpoint for pre-fetching of ratings when user is validator

### DIFF
--- a/client/structs.go
+++ b/client/structs.go
@@ -461,16 +461,6 @@ type GetCommentsData struct {
 	AssetID         string `json:"asset_id"`
 }
 
-type SendRatingData struct {
-	AddonVersion    string  `json:"addon_version"`
-	PlatformVersion string  `json:"platform_version"`
-	AppID           int     `json:"app_id"`
-	APIKey          string  `json:"api_key"`
-	AssetID         string  `json:"asset_id"`
-	RatingType      string  `json:"rating_type"`
-	RatingValue     float32 `json:"rating_value"`
-}
-
 type FetchGravatarData struct {
 	AddonVersion    string `json:"addon_version"`
 	PlatformVersion string `json:"platform_version"`
@@ -485,12 +475,43 @@ type CancelDownloadData struct {
 	AppID  int    `json:"app_id"`
 }
 
+// MARK: RATINGS
+
 type GetRatingData struct {
 	AddonVersion    string `json:"addon_version"`
 	PlatformVersion string `json:"platform_version"`
 	AppID           int    `json:"app_id"`
 	APIKey          string `json:"api_key"`
 	AssetID         string `json:"asset_id"`
+}
+
+type GetRatingsResponse struct {
+	Count    int      `json:"count"`
+	Next     string   `json:"next"`
+	Previous string   `json:"previous"`
+	Results  []Rating `json:"results"`
+}
+
+// Rating data obtained from the server.
+type Rating struct {
+	Score      float32     `json:"score"`
+	RatingType string      `json:"ratingType"`
+	Asset      RatingAsset `json:"asset"`
+}
+
+type RatingAsset struct {
+	AssetUUID   string `json:"assetUuid"`   // aka assetBaseID
+	VersionUUID string `json:"versionUuid"` // aka ID
+}
+
+type SendRatingData struct {
+	AddonVersion    string  `json:"addon_version"`
+	PlatformVersion string  `json:"platform_version"`
+	AppID           int     `json:"app_id"`
+	APIKey          string  `json:"api_key"`
+	AssetID         string  `json:"asset_id"`
+	RatingType      string  `json:"rating_type"`
+	RatingValue     float32 `json:"rating_value"`
 }
 
 type Notification struct {
@@ -591,6 +612,7 @@ type SearchTaskData struct {
 	SceneUUID       string `json:"scene_uuid"`
 	TempDir         string `json:"tempdir"`
 	URLQuery        string `json:"urlquery"`
+	IsValidator     bool   `json:"is_validator"` // is true for validators, so we can do immediate hacks in the Client right after the search results come
 }
 
 type ReportData struct {

--- a/datas.py
+++ b/datas.py
@@ -61,6 +61,9 @@ class SearchData:
     platform_version: str = ""
     api_key: str = ""
     app_id: int = 0
+    is_validator: bool = (
+        False  # Client makes some extra stuff for validators - like fetching all the ratings right away
+    )
 
 
 @dataclasses.dataclass

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -63,6 +63,15 @@ def handle_get_rating_task(task: client_tasks.Task):
         store_rating_local(asset_id, rating["ratingType"], rating["score"])
 
 
+def handle_get_ratings_task(task: client_tasks.Task):
+    """Handle incomming get_ratings task. This is a special task used only by validators which fetches the ratings
+    in big batch right after the search results come into the Client. This is used only to signal problems in the
+    Goroutine which fetches the ratings. The individual ratings are then sent as normal 'get_rating' tasks.
+    """
+    if task.status == "error":  # only reason this task type exists right now
+        return bk_logger.warning(f"{task.task_type} task failed: {task.message}")
+
+
 def handle_get_bookmarks_task(task: client_tasks.Task):
     """Handle incomming get_bookmarks task by saving the results into global_vars.
     This is different from standard ratings - the results come from elastic search API

--- a/search.py
+++ b/search.py
@@ -399,8 +399,6 @@ def handle_search_task(task: client_tasks.Task) -> bool:
         comments = comments_utils.get_comments_local(asset_data["assetBaseId"])
         if comments is None:
             client_lib.get_comments(asset_data["assetBaseId"])
-        # fetch ratings
-        ratings_utils.ensure_rating(asset_data["id"])
 
     global_vars.DATA[search_name] = result_field
     global_vars.DATA[f"{search_name} orig"] = task.result
@@ -954,6 +952,7 @@ def add_search_process(query, get_next: bool, page_size: int, next_url: str):
         get_next=get_next,
         page_size=page_size,
         blender_version=blender_version,
+        is_validator=utils.profile_is_validator(),
     )
     response = client_lib.asset_search(search_data)
     search_tasks[response["task_id"]] = search_data

--- a/timer.py
+++ b/timer.py
@@ -296,6 +296,8 @@ def handle_task(task: client_tasks.Task):
     # HANDLE RATINGS
     if task.task_type == "ratings/get_rating":
         return ratings_utils.handle_get_rating_task(task)
+    if task.task_type == "ratings/get_ratings":
+        return ratings_utils.handle_get_ratings_task(task)
     if task.task_type == "ratings/send_rating":
         return ratings_utils.handle_send_rating_task(task)
 


### PR DESCRIPTION
fixes #1390 

- add is_validator field to search task so Client knows whether normal user or validator does the search
- when search results come and user is validator, Client triggers batch fetch or Ratings for all assets in the result in single request
- batch Ratings are parsed and comes to add-on as normal finished ratings/get_rating tasks
- this is quite fast as the fetching goes from Client directly after search results are known, in most cases ratings are loaded before mouse goes to asset detail - I wanted to implement this architecture for a while, so it is good to see that it works
- pagination resolved in [7459b41](https://github.com/BlenderKit/BlenderKit/pull/1398/commits/7459b41f650881b68f903172d00dbd066a8e3c37)

Suggestions for future improvements:
- it could be used to fetch bookmarks (it actually does for validators) - this would make the bookmarks to be synced every time the search results are presented to the user - the only question is whether the API can handle it. But I guess it is not that hardcore request @PetrDlouhy 
- we could use the similar technique for comments (with new API endpoint for comments, or without them - no reason to trigger the comments from the add-on for validators, Client can do it) - for users if the API could handle it in one request for multiple assets, we could do the same hack for all users

