### PR TITLE
Fix #1395 Finalize func bkclientjsGetAssetHandler() in Client

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -642,8 +642,9 @@ func GetResolutionFile(files []AssetFile, targetRes string) (AssetFile, string) 
 				return f, "blend"
 			}
 		}
-		if targetRes == "gltf" && f.FileType == "gltf" {
-			return f, "gltf"
+		// Special handling for file type "gltf" or "gltf_godot"
+		if strings.Contains(targetRes, "gltf") && f.FileType == targetRes {
+			return f, f.FileType
 		}
 
 		r := strconv.Itoa(resolutionsMap[f.FileType])

--- a/client/download.go
+++ b/client/download.go
@@ -642,6 +642,9 @@ func GetResolutionFile(files []AssetFile, targetRes string) (AssetFile, string) 
 				return f, "blend"
 			}
 		}
+		if targetRes == "gltf" && f.FileType == "gltf" {
+			return f, "gltf"
+		}
 
 		r := strconv.Itoa(resolutionsMap[f.FileType])
 		if r == targetRes {

--- a/client/main.go
+++ b/client/main.go
@@ -2587,7 +2587,6 @@ func bkclientjsGetAsset(appID int, apiKey, assetBaseID, assetID, resolution stri
 
 	// OTHER SOFTWARES - JUST GODOT NOW
 	sceneID := uuid.New().String()
-	resolution = "gltf" // TODO: change to new assetfile type introduced for Godot specifically
 	canDownload, downloadURL, err := GetDownloadURL(sceneID, assetData.Files, resolution, apiKey, targetSoftware.AddonVersion, "")
 	if err != nil {
 		BKLog.Printf("%s GetDownloadURL error %v", EmoBKClientJS, err)


### PR DESCRIPTION
- handler now fetches data by AssetBaseID using the /search endpoint as requested by Petr
- it now downloads GLTF file to Godot
- file downloads to Godot are expected to have "resolution" `gltf_godot`, this is expected to be properly selected on UI or bkclientjs side

external blocks (solved):
- wait for https://github.com/BlenderKit/BlenderKit-server/pull/1169
