### PR TITLE
Brushes from before 3.5 didn't work properly,

### DIFF
--- a/download.py
+++ b/download.py
@@ -463,9 +463,15 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
             asset_thumb_path = os.path.join(asset_thumbs_dir, thumbnail_name)
             shutil.copy(thumbpath, asset_thumb_path)
 
+            asset_blender_version = utils.asset_version_as_tuple(asset_data)
+            # brushes from blender version < 3.5 have inverted texture bias
+            # so we need to invert it here
+            if asset_blender_version < (3, 5, 0):
+                brush.texture_sample_bias = -brush.texture_sample_bias
+
             # re-mark as asset in blender version >= 4.3
             # but only if asset comes from a version older than that
-            asset_blender_version = utils.asset_version_as_tuple(asset_data)
+
             if asset_blender_version < (4, 3, 0) and bpy.app.version >= (4, 3, 0):
                 brush.asset_clear()
                 brush.asset_mark()

--- a/utils.py
+++ b/utils.py
@@ -1140,7 +1140,7 @@ def asset_from_newer_blender_version(asset_data, blender_version=None):
 def asset_version_as_tuple(asset_data) -> tuple[int, int, int]:
     """Convert a version string to a tuple of integers. This way it can be compared to the blender version tuple."""
     version = asset_data["sourceAppVersion"]
-    return tuple(map(int, version=asset_data["sourceAppVersion"].split(".")))
+    return tuple(map(int, asset_data["sourceAppVersion"].split(".")))
 
 
 def guard_from_crash():


### PR DESCRIPTION
the texture sampling bias was inverted. 
A beatiful undocumented change from Blender devs, introduced with VDM brushes. 
also fixes a stupid bug introduced in previous PR (too much AI coding!) where I didn't test properly. The map function was used with a non existing keyword.