### PR TITLE
Implement #1222 Add-on should try different port when Client start fails

### DIFF
--- a/client_lib.py
+++ b/client_lib.py
@@ -91,9 +91,14 @@ def ensure_minimal_data_class(data_class):
     return data_class
 
 
-def reorder_ports(port: str):
-    """Reorder CLIENT_PORTS so the specified port is first."""
-    i = global_vars.CLIENT_PORTS.index(port)
+def reorder_ports(port: str = ""):
+    """Reorder CLIENT_PORTS so the specified port is first.
+    If no port is specified, the current first port is moved to back so second becomes the first.
+    """
+    if port == "":
+        i = 1
+    else:
+        i = global_vars.CLIENT_PORTS.index(port)
     global_vars.CLIENT_PORTS = (
         global_vars.CLIENT_PORTS[i:] + global_vars.CLIENT_PORTS[:i]
     )
@@ -644,15 +649,13 @@ def start_blenderkit_client():
             )
     except Exception as e:
         reports.add_report(
-            f"Error: BlenderKit-Client {client_version} failed to start - {e}",
+            f"Error: BlenderKit-Client {client_version} failed to start on {get_address()}:{e}",
             10,
             "ERROR",
         )
         raise (e)
 
-    bk_logger.info(
-        f"BlenderKit-Client {client_version} starting on {get_address()}, log file at: {log_path}"
-    )
+    bk_logger.info(f"BlenderKit-Client {client_version} starting on {get_address()}")
 
 
 def decide_client_binary_name() -> str:

--- a/global_vars.py
+++ b/global_vars.py
@@ -27,13 +27,14 @@ from . import datas
 
 CLIENT_VERSION = "v1.2.1"
 CLIENT_ACCESSIBLE = False
+"""Is Client accessible? Can add-on access it and call stuff which uses it?"""
+CLIENT_RUNNING = False
+"""Just  for on_startup_client_online_timer()."""
 CLIENT_FAILED_REPORTS = 0
 """Number of failed requests to get reports from the BlenderKit-Client. If too many, something is wrong."""
-
 CLIENT_PORTS = ["62485", "65425", "55428", "49452", "35452", "25152", "5152", "1234"]
 """Ports are ordered during the start, and later after malfunction."""
 
-CLIENT_RUNNING = False
 DATA: dict = {  # TODO: move these
     "images available": {},
     "search history": deque(maxlen=20),


### PR DESCRIPTION
fixes #1220

- on start add-on tries request to Client on default port
- if that fails, it starts Client on default port
- it tries to contact the Client 9 times, if it does not respond in 5.4s totally, it will print error message and start on different port
- after start on next port, it will try 10 times (cca 10.5s)
- on 21st, 31st, 41st etc. fails, it will move to starting on other ports, cycling through all available