### PR TITLE
Fix #1044 BlenderKit add-on does not report it does not support running in parallel with another version of the add-on

### DIFF
--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -116,11 +116,12 @@ def login(signup: bool) -> None:
     Using the access_code Client then requests api_token and handles the results as a task with status finished/error.
     This is handled by function handle_login_task which saves tokens, or shows error message.
     """
-    local_landing_URL = f"http://localhost:{client_lib.get_port()}/consumer/exchange/"
+    # We use redirect_URI without /vX.Y/ API path prefix to not complicate stuff on the server side.
+    redirect_URI = f"http://localhost:{client_lib.get_port()}/consumer/exchange/"
     code_verifier, code_challenge = generate_pkce_pair()
     state = secrets.token_urlsafe()
     client_lib.send_oauth_verification_data(code_verifier, state)
-    authorize_url = f"/o/authorize?client_id={CLIENT_ID}&response_type=code&state={state}&redirect_uri={local_landing_URL}&code_challenge={code_challenge}&code_challenge_method=S256"
+    authorize_url = f"/o/authorize?client_id={CLIENT_ID}&response_type=code&state={state}&redirect_uri={redirect_URI}&code_challenge={code_challenge}&code_challenge_method=S256"
     if signup:
         authorize_url = urlquote(authorize_url)
         authorize_url = f"{global_vars.SERVER}/accounts/register/?next={authorize_url}"

--- a/client/login.go
+++ b/client/login.go
@@ -141,7 +141,7 @@ func GetTokens(authCode string, refreshToken string, verificationData OAuth2Veri
 
 	data.Set("client_id", OAUTH_CLIENT_ID)
 	data.Set("scopes", "read write")
-	data.Set("redirect_uri", fmt.Sprintf("http://localhost:%s/consumer/exchange/", *Port))
+	data.Set("redirect_uri", fmt.Sprintf("http://localhost:%s/consumer/exchange/", *Port)) // /vX.Y/ prefix not used as server does not support regex for redirect paths
 
 	url := fmt.Sprintf("%s/o/token/", *Server)
 	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))

--- a/client/networking.go
+++ b/client/networking.go
@@ -35,6 +35,11 @@ import (
 // Handler for the index of the Client.
 // In future we can add here links to /debug or other useful endpoints.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" { // Go handles "/" path as catchall, so refusing non-index stuff here
+		BKLog.Printf("%v Access to unknown path: %v", EmoWarning, r.URL.Path)
+		http.Error(w, "Not found: "+r.URL.Path, http.StatusNotFound)
+		return
+	}
 	pid := os.Getpid()
 	w.Header().Set("Content-Type", "text/html")
 	fmt.Fprintf(w, `

--- a/timer.py
+++ b/timer.py
@@ -19,6 +19,7 @@
 import logging
 import os
 import queue
+import requests
 
 import bpy
 
@@ -58,29 +59,42 @@ def handle_failed_reports(exception: Exception) -> float:
     """
     global_vars.CLIENT_ACCESSIBLE = False
     global_vars.CLIENT_FAILED_REPORTS += 1  # De facto means we count from 1, not from 0
-    if (
-        global_vars.CLIENT_FAILED_REPORTS == 1
-    ):  # First failed reports -> lets start the Client
-        bk_logger.info(
-            f"First request for BlenderKit-Client reports failed: {type(exception)} {exception}"
-        )
+
+    # First failed report -> lets start the Client
+    if global_vars.CLIENT_FAILED_REPORTS == 1:
+        ### Expected - port probably free as connection was refused
+        if isinstance(exception, requests.ConnectionError):
+            bk_logger.info(
+                f"Expectedly, first request for BKClient reports failed: {str(exception).strip()} {type(exception)}"
+            )
+        ### Something unsupported runs on the port (other program, or Client refusing for version reasons)
+        elif isinstance(exception, requests.HTTPError):
+            bk_logger.info(
+                f"First request for BKClient reports was rejected: {str(exception).strip()} {type(exception)}. Port is occupied and has to be changed"
+            )
+            client_lib.reorder_ports()
+        # Not so expected
+        else:
+            bk_logger.warning(
+                f"First request for BKClient reports failed unexpectedly: {str(exception).strip()} {type(exception)}"
+            )
         client_lib.start_blenderkit_client()
     else:
         bk_logger.warning(
-            f"Request for BlenderKit-Client reports failed: {type(exception)} {exception}"
+            f"Request for BKClient reports failed: {str(exception).strip()} {type(exception)}"
         )
 
     if global_vars.CLIENT_FAILED_REPORTS <= 10:  # try 10 times
         return 0.1 * global_vars.CLIENT_FAILED_REPORTS
 
-    # MORE THAN 10 FAILURES
-    bk_logger.warning(
-        f"Could not get reports: {exception} ({global_vars.CLIENT_FAILED_REPORTS}. failure)"
-    )
+    # MORE THAN 10 FAILURES - enough time for the Client to get up and running
+    # so we need to investigate why it failed to start and respond correctly
+    log_msg = f"Could not get reports ({global_vars.CLIENT_FAILED_REPORTS}. failure): {str(exception).strip()} {type(exception)}"
     return_code, meaning = client_lib.check_blenderkit_client_return_code()
 
     # On FAILED_REPORTS == 11, 21, 31...
     if global_vars.CLIENT_FAILED_REPORTS % 10 == 1:
+        reports.add_report(log_msg, 5, "ERROR")  # Let's show the message to user
         if return_code == -1:
             msg = "Client is not responding, add-on will not work."
             reports.add_report(msg, timeout=10, type="ERROR")
@@ -92,6 +106,8 @@ def handle_failed_reports(exception: Exception) -> float:
         # But there is not a better solution.
         client_lib.reorder_ports()
         client_lib.start_blenderkit_client()
+    else:  # On FAILED_REPORTS == 12..20,22..30,32..40 we just log into terminal
+        bk_logger.warning(log_msg)
 
     wm = bpy.context.window_manager
     wm.blenderkitUI.logo_status = "logo_offline"  # type: ignore[attr-defined]


### PR DESCRIPTION
fixes #1044 

- add-on is now expected to send "expected_client_version" in requests to /reports
- if client finds it does not fullfil this expectation, it refuses the request (but if there is not expected_client_version = older add-ons, it will serve them - otherwise it would require users to change the ports etc... just serve it and we will hard reject once the new versions are adopted)
- add-on then handles the refusal as other HTTP errors - it assumes that this port is occupied
- add-on then also checks if BlenderKit-Client-Version headers are set in the /reports response. If they are not, it means we communicate with older Client - the add-on will raise an error = refuse to accept to communicate with this Client - assumes the port is occupied
- if port is occupied add-on moves on different port to start pre-packed client (with expected version) in there
- add-on can also specify (mostly as hack) that it expects "any" Client version, Client will ignore the comparison then
- in future we might add more modular control, like ignoring the patch version number and comparing just major and minor
- or even comparing just major version - but that's for the future when the API changes on Client are defined more robustly