### PR TITLE
Add tab navigation keyboard shortcuts in modal function

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -180,6 +180,25 @@ def modal_inside(self, context, event):
                     )
                 return {"RUNNING_MODAL"}
 
+        # Handle Alt+Left/Right for history navigation
+        elif (
+            event.alt
+            and event.value == "PRESS"
+            and self.panel.is_in_rect(self.mouse_x, self.mouse_y)
+        ):
+            if event.type == "LEFT_ARROW":
+                bk_logger.info("Alt+Left pressed - history back")
+                active_tab = global_vars.TABS["tabs"][global_vars.TABS["active_tab"]]
+                if active_tab["history_index"] > 0:
+                    self.history_back(None)  # None instead of widget
+                return {"RUNNING_MODAL"}
+            elif event.type == "RIGHT_ARROW":
+                bk_logger.info("Alt+Right pressed - history forward")
+                active_tab = global_vars.TABS["tabs"][global_vars.TABS["active_tab"]]
+                if active_tab["history_index"] < len(active_tab["history"]) - 1:
+                    self.history_forward(None)  # None instead of widget
+                return {"RUNNING_MODAL"}
+
         # ANY EVENT ACTIVATED = DON'T LET EVENTS THROUGH
         if self.handle_widget_events(event):
             return {"RUNNING_MODAL"}

--- a/global_vars.py
+++ b/global_vars.py
@@ -163,6 +163,18 @@ TIPS = [
         "Right-click on the downloaded asset to rate, bookmark and more in the 'Selected Model' submenu.",
         "",
     ),
+    (
+        "Use Ctrl+T to open a new tab, Ctrl+W to close the current tab in the asset bar.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Navigate between tabs with Ctrl+Tab (next) and Ctrl+Shift+Tab (previous).",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
+    (
+        "Jump directly to a specific tab using Ctrl+1 through Ctrl+9 in the asset bar.",
+        "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
+    ),
 ]
 VERSION = [0, 0, 0, 0]  # filled in register()
 


### PR DESCRIPTION
- Implement Ctrl+T to add new tab
- Implement Ctrl+W to close tab
- Add Ctrl+Tab and Ctrl+Shift+Tab to cycle through tabs
- Add Ctrl+1-9 to directly switch to specific tabs
- Move tab management shortcuts from handle_key_input to modal_inside
- Remove redundant logging statements