### PR TITLE
Fix #1481 As staff/validator switch to validated only scenes can give an error

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1496,6 +1496,8 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         if self.active_index != search_index:
             self.active_index = search_index
             sr = search.get_search_results()
+            if search_index >= len(sr):
+                return  # issue #1481 - index can be sometimes over the length of search results
             asset_data = sr[search_index]
 
             self.draw_tooltip = True


### PR DESCRIPTION
fixes #1481

- error is kind of evil as it breaks whole search bar and one needs to restart Blender or disable/enable add-on
- in BlenderKitAssetBarOperator def enter_button check if search_index is not higher then search_results length