### PR TITLE
Fix #1501 upload of printable asset type is broken

### DIFF
--- a/bg_blender.py
+++ b/bg_blender.py
@@ -200,6 +200,7 @@ process_sources = (
     ("TEXTURE", "Texture", "a texture, or texture set"),
     ("BRUSH", "Brush", "brush, can be any type of blender brush"),
     ("NODEGROUP", "Node Group", "node group, can be any type of blender node group"),
+    ("PRINTABLE", "Printable", "3D printable model"),
 )
 
 
@@ -263,6 +264,12 @@ class KillBgProcess(bpy.types.Operator):
                 if source.bl_rna.name == "Brush" and self.process_source == "BRUSH":
                     brush = utils.get_active_brush()
                     if brush is not None and source.name == brush.name:
+                        kill = True
+                if (
+                    source.bl_rna.name == "Object"
+                    and self.process_source == "PRINTABLE"
+                ):
+                    if source.name == bpy.context.active_object.name:
                         kill = True
                 if kill:
                     estring = tcom.eval_path_computing + " = False"

--- a/upload.py
+++ b/upload.py
@@ -1408,18 +1408,27 @@ def handle_asset_upload(task: client_tasks.Task):
 
         # crazy shit to parse stupid Django incosistent error messages
         if "detail" in task.result:
-            for key in task.result["detail"]:
-                bk_logger.info("detai key " + str(key))
-                if type(task.result["detail"][key]) == list:
-                    for item in task.result["detail"][key]:
-                        asset.upload_state += f"\n- {key}: {item}"
-                else:
-                    asset.upload_state += f"\n- {key}: {task.result['detail'][key]}"
-            return reports.add_report(
-                f"{task.message}: {task.result['detail']}",
-                type="ERROR",
-                details=task.message_detailed,
-            )
+            if type(task.result["detail"]) == dict:
+                for key in task.result["detail"]:
+                    bk_logger.info("detail key " + str(key))
+                    if type(task.result["detail"][key]) == list:
+                        for item in task.result["detail"][key]:
+                            asset.upload_state += f"\n- {key}: {item}"
+                    else:
+                        asset.upload_state += f"\n- {key}: {task.result['detail'][key]}"
+                return reports.add_report(
+                    f"{task.message}: {task.result['detail']}",
+                    type="ERROR",
+                    details=task.message_detailed,
+                )
+            if type(task.result["detail"]) == list:
+                for item in task.result["detail"]:
+                    asset.upload_state += f"\n- {item}"
+                return reports.add_report(
+                    f"{task.message}: {task.result['detail']}",
+                    type="ERROR",
+                    details=task.message_detailed,
+                )
         else:
             asset.upload_state += f"\n {task.result}"
             return reports.add_report(

--- a/upload_bg.py
+++ b/upload_bg.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
             if s.name != "upload":
                 bpy.data.scenes.remove(s)  # type: ignore
 
-        if upload_data["assetType"] == "model":
+        if upload_data["assetType"] in ["model", "printable"]:
             obnames = export_data["models"]
             main_source, allobs = append_link.append_objects(
                 file_name=export_data["source_filepath"],


### PR DESCRIPTION
fixes #1501 

- also improves handling of errors from the server when upload data are not correct - Django returns not only {"details": {....} } but sometimes the details can be also just a list. So the error handling function now checks for the type of the error details.