### PR TITLE
Fix autothumbnailer and printables upload/download

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2530,8 +2530,8 @@ def register():
                     (bpy.ops.wm.save_userpref, ()),
                     fake_context=False,
                 )
-    # extension draw overrides,
-    if bpy.app.version >= (4, 2, 0):
+    # extension draw overrides, only in new versions and not in background mode
+    if bpy.app.version >= (4, 2, 0) and bpy.app.background is False:
         override_extension_draw.register()
         override_extension_draw.ensure_repository(api_key=user_preferences.api_key)
 
@@ -2586,6 +2586,6 @@ def unregister():
 
     bpy.app.handlers.load_post.remove(scene_load)
 
-    # extension draw overrides,
-    if bpy.app.version >= (4, 2, 0):
+    # extension draw overrides, only in new versions and not in background mode
+    if bpy.app.version >= (4, 2, 0) and bpy.app.background is False:
         override_extension_draw.unregister()

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -99,7 +99,7 @@ def draw_callback_3d_dragging(self, context):
         return
     ui_props = context.window_manager.blenderkitUI
     # print(self.asset_data["assetType"], self.has_hit, self.snapped_location)
-    if self.asset_data["assetType"] == "model":
+    if self.asset_data["assetType"] in ["model", "printable"]:
         if self.has_hit:
             draw_bbox(
                 self.snapped_location,
@@ -251,7 +251,7 @@ def draw_callback_3d_progress(self, context):
         asset_data = task["asset_data"]
         if task.get("downloaders"):
             for d in task["downloaders"]:
-                if asset_data["assetType"] == "model":
+                if asset_data["assetType"] in ["model", "printable"]:
                     draw_bbox(
                         d["location"],
                         d["rotation"],
@@ -487,7 +487,7 @@ class AssetDragOperator(bpy.types.Operator):
         scene = bpy.context.scene
         ui_props = bpy.context.window_manager.blenderkitUI
 
-        if self.asset_data["assetType"] == "model":
+        if self.asset_data["assetType"] in ["model", "printable"]:
             if not self.drag:
                 self.snapped_location = scene.cursor.location
                 self.snapped_rotation = (0, 0, 0)
@@ -705,7 +705,10 @@ class AssetDragOperator(bpy.types.Operator):
                 self.object_name = object.name
 
             # MODELS can be dragged on scene floor
-            if not self.has_hit and self.asset_data["assetType"] == "model":
+            if not self.has_hit and self.asset_data["assetType"] in [
+                "model",
+                "printable",
+            ]:
                 (
                     self.has_hit,
                     self.snapped_location,
@@ -718,7 +721,7 @@ class AssetDragOperator(bpy.types.Operator):
                 if object is not None:
                     self.object_name = object.name
 
-            if self.asset_data["assetType"] == "model":
+            if self.asset_data["assetType"] in ["model", "printable"]:
                 self.snapped_bbox_min = Vector(self.asset_data["bbox_min"])
                 self.snapped_bbox_max = Vector(self.asset_data["bbox_max"])
             # return {'RUNNING_MODAL'}

--- a/asset_inspector.py
+++ b/asset_inspector.py
@@ -373,7 +373,7 @@ def check_modifiers(props, obs):
 def get_autotags():
     """call all analysis functions"""
     ui = bpy.context.window_manager.blenderkitUI
-    if ui.asset_type == "MODEL":
+    if ui.asset_type == "MODEL" or ui.asset_type == "PRINTABLE":
         ob = utils.get_active_model()
         obs = utils.get_hierarchy(ob)
         props = ob.blenderkit

--- a/search.py
+++ b/search.py
@@ -166,6 +166,10 @@ def check_clipboard():
         target_asset_type = "SCENE"
     elif asset_type_string.find("hdr") > -1:
         target_asset_type = "HDR"
+    elif asset_type_string.find("printable") > -1:
+        target_asset_type = "PRINTABLE"
+    elif asset_type_string.find("nodegroup") > -1:
+        target_asset_type = "NODEGROUP"
     ui_props = bpy.context.window_manager.blenderkitUI
     if ui_props.asset_type != target_asset_type:
         ui_props.asset_type = target_asset_type  # switch asset type before placing keywords, so it does not search under wrong asset type
@@ -265,7 +269,7 @@ def parse_result(r) -> dict:
     # parse extra params needed for blender here
     params = r["dictParameters"]  # utils.params_to_dict(r['parameters'])
 
-    if asset_type == "model":
+    if asset_type in ["model", "printable"]:
         if params.get("boundBoxMinX") != None:
             bbox = {
                 "bbox_min": (
@@ -729,6 +733,7 @@ def query_to_url(
         "brush",
         "hdr",
         "nodegroup",
+        "printable",
     ):
         query["category_subtree"] = None
 
@@ -1259,6 +1264,7 @@ def detect_asset_type_from_keywords(keywords: str) -> tuple[str, str]:
         "hdri": "HDR",
         "nodegroup": "NODEGROUP",
         "node": "NODEGROUP",
+        "printable": "PRINTABLE",
     }
 
     # Convert to lowercase for matching
@@ -1333,6 +1339,8 @@ def search_update(self, context):
                 target_asset_type = "HDR"
             elif asset_type_string.find("nodegroup") > -1:
                 target_asset_type = "NODEGROUP"
+            elif asset_type_string.find("printable") > -1:
+                target_asset_type = "PRINTABLE"
 
             if ui_props.asset_type != target_asset_type:
                 ui_props.search_keywords = ""


### PR DESCRIPTION
fixes #1509
fixes #1504 

Enhance asset handling by supporting "printable" asset type alongside "model" in various components. Update extension draw overrides to only apply in non-background mode for Blender versions 4.2.0 and above.