### PR TITLE
Fix #1518 Custom proxy settings are not used for the http transpot layer

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2133,7 +2133,7 @@ class BlenderKitAddonPreferences(AddonPreferences):
         name="Custom proxy address",
         description="""Set custom HTTP proxy for HTTPS requests of add-on. This setting preceeds any system wide proxy settings. If left empty custom proxy will not be set.
         
-If you use simple HTTP proxy, set in format http://ip:port, or http://username:password@ip:port if your HTTP proxy requires authentication. You have to specify the address with http:// prefix.
+If you use simple HTTP proxy, set in format http://ip:port, or http://username:password@ip:port if your HTTP proxy requires authentication (make sure to escape special characters like #$%:^&*() etc. in username and password). You have to specify the address with http:// prefix.
 
 HTTPS proxies are not supported! We wait for support in Python 3.11 and in aiohttp module. You can specify the HTTPS proxy with https:// prefix for hacking around and development purposes, but functionality cannot be guaranteed.
 In this case you should also set path to your system CA bundle containing proxy's certificates in the field "Custom CA certificates path" below""",

--- a/client/networking.go
+++ b/client/networking.go
@@ -83,7 +83,7 @@ func GetHTTPClient(transport *http.Transport, tlsConfig *tls.Config, proxy func(
 	transport.Proxy = proxy
 
 	return &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: transport,
 		Timeout:   timeout,
 	}
 }


### PR DESCRIPTION
fixes #1518 