### PR TITLE
Fix #1532 API request error have first long URL and then interesting part which is often out of window

### DIFF
--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -46,7 +46,7 @@ from .bl_ui_widgets.bl_ui_draw_op import BL_UI_OT_draw_operator
 from .bl_ui_widgets.bl_ui_image import BL_UI_Image
 
 
-bk_logger = logging.getLogger("blenderkit")
+bk_logger = logging.getLogger(__name__)
 
 handler_2d = None
 handler_3d = None

--- a/categories.py
+++ b/categories.py
@@ -134,7 +134,7 @@ def handle_categories_task(task: client_tasks.Task):
             )  # TODO: do this in Client, just saving the file so next time it is updated even without internet
         return
 
-    bk_logger.warning(task.message)
+    bk_logger.warning(f"Could not load categories: {task.message}")
     if not os.path.exists(categories_filepath):
         source_path = paths.get_addon_file(subpath="data" + os.sep + "categories.json")
         try:

--- a/comments_utils.py
+++ b/comments_utils.py
@@ -74,7 +74,7 @@ def handle_notifications_task(task: client_tasks.Task):
         global_vars.DATA["bkit notifications"] = task.result
         return
     if task.status == "error":
-        return bk_logger.warning(f"Notifications fetching failed: {task.message}")
+        return bk_logger.warning(f"Could not load notifications: {task.message}")
 
 
 def check_notifications_read():

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -31,7 +31,7 @@ from .bl_ui_widgets.bl_ui_image import BL_UI_Image
 from .ui_bgl import get_text_size
 
 
-bk_logger = logging.getLogger("blenderkit")
+bk_logger = logging.getLogger(__name__)
 
 disclaimer_counter = 0
 

--- a/disclaimer_op.py
+++ b/disclaimer_op.py
@@ -287,8 +287,7 @@ def handle_disclaimer_task(task: client_tasks.Task):
         return
 
     if task.status == "error":
-        msg = f"Error downloading disclaimer info: {task.message}"
-        reports.add_report(msg, timeout=5, type="ERROR")
+        bk_logger.warning(f"Could not load disclaimer: {task.message}")
         return show_random_tip()
 
 

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -80,10 +80,12 @@ def handle_get_bookmarks_task(task: client_tasks.Task):
     if task.status == "created":
         return
     if task.status == "error":
-        return bk_logger.warning(f"{task.task_type} task failed: {task.message}")
+        bk_logger.warning(f"Could not load bookmarks: {task.message}")
+        return
 
     for asset in task.result["results"]:
         store_rating_local(asset["id"], "bookmarks", 1)
+    bk_logger.info("Bookmarks loaded")
 
 
 def handle_send_rating_task(task: client_tasks.Task):

--- a/timer.py
+++ b/timer.py
@@ -151,6 +151,7 @@ def client_communication_timer():
             app_id=task["app_id"],
             task_type=task["task_type"],
             message=task["message"],
+            message_detailed=task["message_detailed"],
             progress=task["progress"],
             status=task["status"],
             result=task["result"],


### PR DESCRIPTION
fixes #1532

not the most needed fix, but will improve the visibility of the error on the screenshots which the users prefer to send. search error now has the URL removed and just the ending - server not responded/dns not found etc is shown. the juicy interesting part. will improve our debugging and customer service experience.