### PR TITLE
Implement #1589 Preview photo thumbnails on the printables

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -767,20 +767,19 @@ func parseThumbnails(searchResults SearchResults, data SearchTaskData) {
 			continue
 		}
 
+		// Full Photo Thumbnail - we need to get it from files list
 		for _, file := range result.Files {
 			if file.FileType != "photo_thumbnail" {
 				continue
 			}
 
-			// For photo thumbnails, we need both small and full versions
 			if file.ThumbnailMiddleURL == "" {
 				BKLog.Printf("Missing photo_thumbnail.ThumbnailMiddleURL for asset: %s", result.DisplayName)
 				continue
 			}
 			fullPhotoThumbURL := file.ThumbnailMiddleURL
 
-			// Full Photo Thumbnail
-			fullPhotoThumbnailName, fullPhotoThumbnailNameErr := ExtractFilenameFromURL(fullThumbURL)
+			fullPhotoThumbnailName, fullPhotoThumbnailNameErr := ExtractFilenameFromURL(fullPhotoThumbURL)
 			fullPhotoThumbnailPath := filepath.Join(data.TempDir, fullPhotoThumbnailName)
 			fullPhotoThumbnailTaskData := DownloadThumbnailData{
 				AddonVersion:  data.AddonVersion,

--- a/client/structs.go
+++ b/client/structs.go
@@ -146,6 +146,7 @@ type Asset struct {
 	IsPrivate                        bool                   `json:"isPrivate"`
 	LastBlendUpload                  string                 `json:"lastBlendUpload"`
 	LastGltfUpload                   string                 `json:"lastGltfUpload"`
+	LastPhotoThumbnailUpload         string                 `json:"lastPhotoThumbnailUpload"`
 	LastResolutionUpload             string                 `json:"lastResolutionUpload"`
 	LastThumbnailUpload              string                 `json:"lastThumbnailUpload"`
 	LastUserInteraction              string                 `json:"lastUserInteraction"`
@@ -224,6 +225,10 @@ type AssetFile struct {
 
 	URL      string `json:"url"`      // retrieved URL to the actual file
 	Filename string `json:"filename"` // filename of the file to be saved.
+
+	// FileType = "photo_thumbnail" or "thumbnail"
+	ThumbnailSmallURL  string `json:"thumbnailSmallUrl"`
+	ThumbnailMiddleURL string `json:"thumbnailMiddleUrl"`
 }
 
 type DownloadAssetData struct {

--- a/global_vars.py
+++ b/global_vars.py
@@ -175,6 +175,14 @@ TIPS = [
         "Jump directly to a specific tab using Ctrl+1 through Ctrl+9 in the asset bar.",
         "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
     ),
+    {
+        "Use keys 1 and 2 to toggle photo thumbnail over printable assets in the asset bar.",
+        "",
+    },
+    {
+        "Use keys [ and ] to toggle between normal and photo thumbnail over printable assets.",
+        "",
+    },
 ]
 VERSION = [0, 0, 0, 0]  # filled in register()
 

--- a/global_vars.py
+++ b/global_vars.py
@@ -175,14 +175,14 @@ TIPS = [
         "Jump directly to a specific tab using Ctrl+1 through Ctrl+9 in the asset bar.",
         "https://github.com/BlenderKit/blenderkit/wiki/BlenderKit-add-on-documentation#assetbar",
     ),
-    {
+    (
         "Use keys 1 and 2 to toggle photo thumbnail over printable assets in the asset bar.",
         "",
-    },
-    {
+    ),
+    (
         "Use keys [ and ] to toggle between normal and photo thumbnail over printable assets.",
         "",
-    },
+    ),
 ]
 VERSION = [0, 0, 0, 0]  # filled in register()
 

--- a/ui.py
+++ b/ui.py
@@ -113,21 +113,14 @@ def get_full_photo_thumbnail(asset_data):
         if file.get("fileType") == "photo_thumbnail":
             photo_file = file
             break
-    if not photo_file:
-        bk_logger.info("No photo thumbnail file found in asset data")
+
+    if photo_file is None:
+        bk_logger.warning("No photo thumbnail file found in asset data")
         return None
 
-    bk_logger.info(f"Photo thumbnail file found: {photo_file}")
-    # Try to get the best quality thumbnail URL in order of preference
-    photo_url = None
     photo_url = photo_file.get("thumbnailMiddleUrl")
-    if photo_url:
-        bk_logger.info(f"Found photo thumbnail URL: {photo_url}")
-    else:
-        bk_logger.info("No thumbnail URL found in photo file")
-
-    if not photo_url:
-        bk_logger.info("No thumbnail URL found in photo file")
+    if photo_url is None:
+        bk_logger.warning("No thumbnail URL found in photo file")
         return None
 
     # Get the directory and construct the path

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2803,6 +2803,19 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         )
         self.img.gl_touch()
 
+        # Display photo thumbnail for printable objects
+        if (
+            self.asset_data.get("assetType") == "printable"
+            and hasattr(self, "full_photo_thumbnail")
+            and self.full_photo_thumbnail
+        ):
+            box_thumbnail.scale_y = 0.4
+            box_thumbnail.template_icon(
+                icon_value=self.full_photo_thumbnail.preview.icon_id,
+                scale=width * 0.12,
+            )
+            self.full_photo_thumbnail.gl_touch()
+
         # op = row.operator('view3d.asset_drag_drop', text='Drag & Drop from here', depress=True)
         # From here on, only ratings are drawn, which won't be displayed for private assets from now on.
 
@@ -3127,22 +3140,6 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         split_left = row.split(factor=split_ratio)
         left_column = split_left.column()
         self.draw_thumbnail_box(left_column, width=int(self.width * split_ratio))
-
-        # Display photo thumbnail for printable objects
-        if (
-            self.asset_data.get("assetType") == "printable"
-            and hasattr(self, "full_photo_thumbnail")
-            and self.full_photo_thumbnail
-        ):
-            left_column.separator()
-            left_column.label(text="Photo")
-            photo_box = left_column.box()
-            photo_box.scale_y = 0.4
-            photo_box.template_icon(
-                icon_value=self.full_photo_thumbnail.preview.icon_id,
-                scale=int(self.width * split_ratio * 0.12),
-            )
-            self.full_photo_thumbnail.gl_touch()
 
         if not utils.user_is_owner(asset_data=self.asset_data):
             # Draw ratings, but not for owners of assets - doesn't make sense.

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3188,9 +3188,6 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             self.full_photo_thumbnail = ui.get_full_photo_thumbnail(asset_data)
             if self.full_photo_thumbnail:
                 utils.img_to_preview(self.full_photo_thumbnail, copy_original=True)
-                bk_logger.info(f"Full photo thumbnail: {self.full_photo_thumbnail}")
-            else:
-                bk_logger.info("No photo thumbnail found for this printable asset")
 
         self.asset_type = asset_data["assetType"]
         self.asset_id = asset_data["id"]

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3127,6 +3127,23 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         split_left = row.split(factor=split_ratio)
         left_column = split_left.column()
         self.draw_thumbnail_box(left_column, width=int(self.width * split_ratio))
+
+        # Display photo thumbnail for printable objects
+        if (
+            self.asset_data.get("assetType") == "printable"
+            and hasattr(self, "full_photo_thumbnail")
+            and self.full_photo_thumbnail
+        ):
+            left_column.separator()
+            left_column.label(text="Photo")
+            photo_box = left_column.box()
+            photo_box.scale_y = 0.4
+            photo_box.template_icon(
+                icon_value=self.full_photo_thumbnail.preview.icon_id,
+                scale=int(self.width * split_ratio * 0.12),
+            )
+            self.full_photo_thumbnail.gl_touch()
+
         if not utils.user_is_owner(asset_data=self.asset_data):
             # Draw ratings, but not for owners of assets - doesn't make sense.
             ratings_box = left_column.box()
@@ -3169,6 +3186,14 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
 
         self.img = ui.get_large_thumbnail_image(asset_data)
         utils.img_to_preview(self.img, copy_original=True)
+
+        if asset_data["assetType"] == "printable":
+            self.full_photo_thumbnail = ui.get_full_photo_thumbnail(asset_data)
+            if self.full_photo_thumbnail:
+                utils.img_to_preview(self.full_photo_thumbnail, copy_original=True)
+                bk_logger.info(f"Full photo thumbnail: {self.full_photo_thumbnail}")
+            else:
+                bk_logger.info("No photo thumbnail found for this printable asset")
 
         self.asset_type = asset_data["assetType"]
         self.asset_id = asset_data["id"]


### PR DESCRIPTION
fixes #1589 

- Client now also download photo_thumbnail ThumbnailMiddleURL aka full thumbnail size
- full photo thumbnail is used in asset popup card, it is shown below the normal thumbnail
- for asset tooltip it is possible to switch between normal thumbnail and photo thumbnail
- either cycle by pressing `[` or `]` over the asset small thumbnail
- or toggle the photo thumbnail by pressing `2`, toggle normal thumbnail by pressing `1`
- both shortcuts are chosen so we could theoretically implement more thumbnails in the future and allow users to cycle/switch between type 1, 2, 3... 


![Screenshot 2025-05-15 at 17 25 32](https://github.com/user-attachments/assets/a9a81416-1772-4984-bab5-c2a028051e4f)
![Screenshot 2025-05-15 at 17 25 18](https://github.com/user-attachments/assets/9aed571b-f9d2-430a-9d09-f91542f41711)

