### PR TITLE
Improve asset drag drop operator:

### DIFF
--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -804,10 +804,6 @@ class AssetDragOperator(bpy.types.Operator):
         # Store original active collection
         orig_active_collection = context.view_layer.active_layer_collection
 
-        # We need to do a selection to see what's under the mouse
-        # First, clear current selection
-        bpy.ops.outliner.item_activate(extend=False, deselect_all=True)
-
         # Use outliner's built-in selection to find what's under the mouse
         region = context.region
         with bpy.context.temp_override(


### PR DESCRIPTION
Works in all areas now, but actively in 3d view and Outliner handles detection of Outliner selections quite nicely, but still throws some error that doesn't influence functionality Cancels in all other views by now
works quite well for materials, objects, printables

This is important also for implementing drag drop from browser as planned. The client should be able simply to run this operator and it should be active when the mouse enters blender window.
TODO: nodes in node editors.