### PR TITLE
Fix complexity rating ranges for printable and nodegroup asset tyes

### DIFF
--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -243,7 +243,7 @@ def stars_enum_callback(self, context):
 
 def wh_enum_callback(self, context):
     """Regenerates working hours enum."""
-    if self.asset_type in ("model", "scene"):
+    if self.asset_type in ("model", "scene", "printable", "nodegroup"):
         possible_wh_values = [
             0,
             0.5,


### PR DESCRIPTION
This fixes the complexity rating for these asset types, 
it used the default 0-5 range, but in this case much more is needed.