### PR TITLE
Fix #1618 AssetBar's title need to set font size in int in Blender 3.0

### DIFF
--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -159,8 +159,11 @@ class BL_UI_Button(BL_UI_Widget):
 
     def draw_text(self, area_height):
         font_id = 1
-
-        if bpy.app.version < (4, 0, 0):
+        if bpy.app.version < (3, 1, 0):
+            # Blender 3.0 requires size:int https://docs.blender.org/api/3.0/blf.html#blf.size
+            # but assetBar's search tab text is float - needs conversion in here
+            blf.size(font_id, int(self._text_size), 72)
+        elif bpy.app.version < (4, 0, 0):
             blf.size(font_id, self._text_size, 72)
         else:
             blf.size(font_id, self._text_size)
@@ -204,7 +207,9 @@ class BL_UI_Button(BL_UI_Widget):
             try:
                 self.mouse_down_func(self)
             except Exception as e:
-                print(e)
+                import traceback
+
+                traceback.print_exc()
 
             return True
 

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -1,3 +1,4 @@
+import traceback
 import bpy
 from bpy.types import Operator
 
@@ -113,4 +114,4 @@ def draw_callback_px_separated(self, op, context):
             for widget in self.widgets:
                 widget.draw()
     except Exception as e:
-        print(e)
+        traceback.print_exc()

--- a/overrides.py
+++ b/overrides.py
@@ -224,7 +224,9 @@ class BringToScene(Operator):
                     parent = ob
                     bpy.context.view_layer.objects.active = parent
             except Exception as e:
-                print(e)
+                bk_logger.exception(
+                    f"BringToScene.execute: failed to link an object to the collection"
+                )
 
         bpy.ops.object.make_local(type="ALL")
 
@@ -234,10 +236,9 @@ class BringToScene(Operator):
                 try:
                     ob.select_set(True)
                 except Exception as e:
-                    print(
-                        "failed to select an object from the collection, getting a replacement."
+                    bk_logger.exception(
+                        f"BringToScene.execute: failed to select an object from the collection, getting a replacement."
                     )
-                    print(e)
 
         related = []
 

--- a/unpack_asset_bg.py
+++ b/unpack_asset_bg.py
@@ -20,6 +20,7 @@
 import json
 import os
 import sys
+import traceback
 
 import bpy
 
@@ -83,7 +84,8 @@ def unpack_asset(data):
         try:
             os.mkdir(tex_dir_abs)
         except Exception as e:
-            print(e)
+            traceback.print_exc()
+
     bpy.data.use_autopack = False
     for image in bpy.data.images:
         if image.name == "Render Result":
@@ -145,7 +147,8 @@ def unpack_asset(data):
     try:
         os.remove(bpy.data.filepath + "1")
     except Exception as e:
-        print(e)
+        traceback.print_exc()
+
     bpy.ops.wm.quit_blender()
     sys.exit()
 

--- a/utils.py
+++ b/utils.py
@@ -124,8 +124,7 @@ def selection_set(sel):
         for ob in sel[1]:
             ob.select_set(True)
     except Exception as e:
-        print("Selectible objects not found")
-        print(e)
+        bk_logger.exception(f"failed to select objects: {str(e)}")
 
 
 def get_active_model() -> Optional[bpy.types.Object]:


### PR DESCRIPTION
fixes #1618

- AssetBar search tab's font is defined dynamically as half of its height, but blf.size() does not accept floats in Blender 3.0, so it needs to be converted to int()
- Remove bare prints of exceptions - use traceback or logger.exception() instead because `except Exception as e: print(e)` makes it a nightmare to find the LOC, spent 60+minutes just searching for the place from where the error `integer argument expected, got float` come