### PR TITLE
Fix #1625 AssetBar calls to bpy.context.temp_override() breaks in B3.0, B3.1

### DIFF
--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -1193,14 +1193,29 @@ class AssetDragOperator(bpy.types.Operator):
                         "scene": context.scene,
                         "view_layer": context.view_layer,
                     }
-                    bpy.ops.outliner.item_activate(
-                        override, extend=False, deselect_all=True
-                    )
+                    # Only try to deselect if we have valid area and region
+                    if self.outliner_area and self.outliner_region:
+                        bpy.ops.outliner.select_box(
+                            override,
+                            xmin=0,
+                            xmax=1,
+                            ymin=0,
+                            ymax=1,
+                            wait_for_input=False,
+                            mode="SET",
+                        )  # Use a very small selection box in the corner to deselect everything
                 else:  # B3.2+ can use context.temp_override()
                     with bpy.context.temp_override(
                         area=self.outliner_area, region=self.outliner_region
                     ):
-                        bpy.ops.outliner.item_activate(extend=False, deselect_all=True)
+                        bpy.ops.outliner.select_box(
+                            xmin=0,
+                            xmax=1,
+                            ymin=0,
+                            ymax=1,
+                            wait_for_input=False,
+                            mode="SET",
+                        )  # Use a very small selection box in the corner to deselect everything
 
     def modal(self, context, event):
         ui_props = bpy.context.window_manager.blenderkitUI

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -1403,7 +1403,9 @@ class AssetDragOperator(bpy.types.Operator):
                         self.face_index,
                         object,
                         self.matrix,
-                    ) = mouse_raycast(override, region_mouse_x, region_mouse_y)
+                    ) = mouse_raycast(
+                        active_region, region_data, region_mouse_x, region_mouse_y
+                    )
                     if object is not None:
                         self.object_name = object.name
                 else:  # B3.2+ can use context.temp_override()
@@ -1418,7 +1420,9 @@ class AssetDragOperator(bpy.types.Operator):
                             self.face_index,
                             object,
                             self.matrix,
-                        ) = mouse_raycast(bpy.context, region_mouse_x, region_mouse_y)
+                        ) = mouse_raycast(
+                            active_region, region_data, region_mouse_x, region_mouse_y
+                        )
                         if object is not None:
                             self.object_name = object.name
 
@@ -1452,7 +1456,9 @@ class AssetDragOperator(bpy.types.Operator):
                         self.face_index,
                         object,
                         self.matrix,
-                    ) = floor_raycast(override, region_mouse_x, region_mouse_y)
+                    ) = floor_raycast(
+                        active_region, region_data, region_mouse_x, region_mouse_y
+                    )
                     if object is not None:
                         self.object_name = object.name
                 else:  # B3.2+ can use context.temp_override()
@@ -1467,7 +1473,9 @@ class AssetDragOperator(bpy.types.Operator):
                             self.face_index,
                             object,
                             self.matrix,
-                        ) = floor_raycast(bpy.context, region_mouse_x, region_mouse_y)
+                        ) = floor_raycast(
+                            active_region, region_data, region_mouse_x, region_mouse_y
+                        )
                         if object is not None:
                             self.object_name = object.name
 


### PR DESCRIPTION
fixes #1625 

- oldschool context overrides need to be applied for Blender 3.0 and 3.1