### PR TITLE
Geo nodes drop dialog

### DIFF
--- a/download.py
+++ b/download.py
@@ -585,6 +585,8 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
                 node_y=kwargs.get("node_y", 0),
                 target_object=kwargs.get("target_object"),
                 nodegroup_mode=kwargs.get("nodegroup_mode", ""),
+                model_location=kwargs.get("model_location", (0, 0, 0)),
+                model_rotation=kwargs.get("model_rotation", (0, 0, 0)),
             )
             # Show a message to the user if the node was not added to an editor or modifier
             if not added_to_editor:
@@ -609,6 +611,8 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
                 node_y=kwargs.get("node_y", 0),
                 target_object=kwargs.get("target_object"),
                 nodegroup_mode=kwargs.get("nodegroup_mode", ""),
+                model_location=kwargs.get("model_location", (0, 0, 0)),
+                model_rotation=kwargs.get("model_rotation", (0, 0, 0)),
             )
         bk_logger.info(f"appended nodegroup: {nodegroup}")
         asset_main = nodegroup

--- a/override_extension_draw.py
+++ b/override_extension_draw.py
@@ -432,7 +432,6 @@ def extension_draw_item_override(
     extensions_warnings,  # `dict[str, list[str]]`
     show_developer_ui=False,  # `bool`
 ):
-    print("BlenderKit Debug: ENTERING extension_draw_item_override")
     # filter by verification state, only for blenderkit repository
     if repo_item.remote_url == EXTENSIONS_API_URL:
         extension_draw_item_blenderkit(


### PR DESCRIPTION
Fix geometry nodegroup interactions in asset bar
Consistent behavior: Clicking geometry nodegroups now shows import options popup (like drag-drop)
Proper positioning: Geometry nodes use raycast/floor positioning like models when dropped in empty space
Modifier overwrite: Added option to replace existing geometry nodes modifiers to avoid recursion issues
Dual workflows: Fixed both "As Modifier" and "As Node" modes with proper node tree creation
Editor integration: Drag-drop into existing node editors adds to tree instead of creating new modifiers