### PR TITLE
Fix shortcut interference when typing in text input fields

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1664,7 +1664,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
         now = time.time()
         # avoid double click to download assets under panels, mainly category panel
-        if now - ui_panels.last_time_dropdown_active < 0.5:
+        if now - ui_panels.last_time_overlay_panel_active < 0.5:
             return
         # start drag drop
         bpy.ops.view3d.asset_drag_drop(
@@ -1902,6 +1902,12 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         search.search()
 
     def handle_key_input(self, event):
+        # Check if enough time has passed since last popup/text input activity
+        # to prevent shortcuts from triggering while typing in text fields
+        now = time.time()
+        if now - ui_panels.last_time_overlay_panel_active < 0.5:
+            return False
+
         # Shortcut: Toggle between normal and photo thumbnail
         if event.type in {"ONE"}:
             if self.show_photo_thumbnail == True:

--- a/download.py
+++ b/download.py
@@ -1572,7 +1572,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
 
     def draw(self, context):
         # this timer is there to not let double clicks thorugh the popups down to the asset bar.
-        ui_panels.last_time_dropdown_active = time.time()
+        ui_panels.last_time_overlay_panel_active = time.time()
         layout = self.layout
         if self.invoke_resolution:
             layout.prop(self, "resolution", expand=True, icon_only=False)

--- a/ratings.py
+++ b/ratings.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import logging
+import time
 
 import bpy
 from bpy.props import StringProperty
@@ -185,6 +186,11 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
 
         ratings_utils.ensure_rating(self.asset_id)
         self.prefill_ratings()
+
+        # Update last popup activity time to prevent shortcut interference
+        from . import ui_panels
+
+        ui_panels.last_time_dropdown_active = time.time()
 
         if self.asset_type in ("model", "scene"):
             # spawn a wider one for validators for the enum buttons

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -53,7 +53,7 @@ ACCEPTABLE_ENGINES = ("CYCLES", "BLENDER_EEVEE", "BLENDER_EEVEE_NEXT")
 
 bk_logger = logging.getLogger(__name__)
 
-last_time_dropdown_active = 0.0
+last_time_overlay_panel_active = 0.0
 
 
 def draw_not_logged_in(source, message="Please Login/Signup to use this feature"):
@@ -1563,8 +1563,8 @@ class VIEW3D_PT_blenderkit_categories(Panel):
     def draw(self, context):
         # measure time since last dropdown activation/ mouse hover e.t.c.
         # this is then used in asset_bar_op.py to cancel asset drag drop if the time is too small and thus means double clicking.
-        global last_time_dropdown_active
-        last_time_dropdown_active = time.time()
+        global last_time_overlay_panel_active
+        last_time_overlay_panel_active = time.time()
         draw_panel_categories(self.layout, context)
 
 
@@ -3134,6 +3134,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         # box.label(text=str(comment['flags']))
 
     def draw(self, context):
+        global last_time_overlay_panel_active
+        last_time_overlay_panel_active = time.time()
+
         layout = self.layout
         # top draggable bar with name of the asset
         top_row = layout.row()


### PR DESCRIPTION
Prevents asset bar shortcuts (S, R, etc.) from triggering while typing in comment fields and other text inputs. Double letters like "issue" or "RR" were incorrectly triggering Search Similar and Rating dialogs.
Changes:
Renamed last_time_dropdown_active to last_time_overlay_panel_active for better clarity
Added 0.5-second blocking period after popup/text input activity in asset bar shortcut handler
Extended timing mechanism to cover AssetPopupCard, rating dialogs, and comment input fields
Reuses existing timing infrastructure originally designed for category dropdown protection
Result: Users can now type freely in text fields without accidentally triggering shortcuts.