### PR TITLE
Skip saving to user preferences on factory startup

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -530,8 +530,8 @@ def save_prefs_without_save_userpref(user_preferences, context):
 
 
 def save_prefs(user_preferences, context, **kwargs):
-    # first check context, so we don't do this on registration or blender startup
-    if bpy.app.background is True:
+    # first check context, so we don't do this on registration, blender startup, or blender factory startup
+    if bpy.app.background is True or bpy.app.factory_startup is True:
         return
 
     global_vars.PREFS = get_preferences_as_dict()


### PR DESCRIPTION
When running Blender with factory default settings, via `--factory-startup`, factory default preferences are used and user preferences are skipped and not saved (autosave is disabled). However, trying to enable this add-on (which fails, but can be a separate fix) triggers an unexpected save to user preferences, causing the factory startup settings to override the user's. This prevents that.

While doing some testing, I noticed that user preferences are saved even on factory default startup (enabling the add-on seems to fail, but that's a separate issue), which is supposed to ignore and not save user preferences unless the user presses the button. This prevents that from happening, regardless of if the add-on starts up correctly or not.