### PR TITLE
Improvement #1197 Clearer text for locked full plan asset

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1927,7 +1927,11 @@ class BlenderKitAddonPreferences(AddonPreferences):
 
     api_key: StringProperty(
         name="BlenderKit API Key",
-        description="Your blenderkit API Key. Get it from your page on the website",
+        description=(
+            "Your unique API key authenticates downloads and requests inside the add-on. "
+            "No manual setup is required, the API Key is auto-filled at login and cleared at logout. "
+            "However, you can also paste the key from your profile settings on the BlenderKit website."
+        ),
         default="",
         subtype="PASSWORD",
         update=utils.api_key_property_updated,

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -1735,8 +1735,8 @@ class AssetDragOperator(bpy.types.Operator):
         ui_props = bpy.context.window_manager.blenderkitUI
         self.asset_data = dict(sr[ui_props.active_index])
         if not self.asset_data.get("canDownload"):
-            message = "Let's support asset creators and Open source."
-            link_text = "Unlock the asset."
+            message = "This asset is included in Full Plan.\nSupport asset creators & open-source by subscribing."
+            link_text = "Unlock All Assets"
             url = f'{global_vars.SERVER}/get-blenderkit/{self.asset_data["id"]}/?from_addon=True'
             bpy.ops.wm.blenderkit_url_dialog(
                 "INVOKE_REGION_WIN", url=url, message=message, link_text=link_text

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3429,7 +3429,7 @@ class PopupDialog(bpy.types.Operator):
 
 
 class UrlPopupDialog(bpy.types.Operator):
-    """Generate Cycles thumbnail for model assets"""
+    """Show a popup asking the user to subscribe or log in to access the locked asset"""
 
     bl_idname = "wm.blenderkit_url_dialog"
     bl_label = "BlenderKit message:"
@@ -3443,14 +3443,12 @@ class UrlPopupDialog(bpy.types.Operator):
 
     message: bpy.props.StringProperty(name="Text", description="text", default="")  # type: ignore[valid-type]
 
-    # @classmethod
-    # def poll(cls, context):
-    #     return bpy.context.view_layer.objects.active is not None
+    width: bpy.props.IntProperty(name="width", description="width", default=300)  # type: ignore[valid-type]
 
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        row.label(text=self.message)
+        utils.label_multiline(layout, text=self.message, width=300)
         row.operator("view3d.close_popup_button", text="", icon="CANCEL")
 
         layout.active_default = True
@@ -3458,19 +3456,19 @@ class UrlPopupDialog(bpy.types.Operator):
         if not utils.user_logged_in():
             utils.label_multiline(
                 layout,
-                text="Already subscribed? You need to login to access your Full Plan.",
+                text="Already subscribed? Log in to access your account.",
                 width=300,
             )
 
             layout.operator_context = "EXEC_DEFAULT"
-            layout.operator("wm.blenderkit_login", text="Login", icon="URL").signup = (
-                False
-            )
+            layout.operator(
+                "wm.blenderkit_login", text="Welcome Home", icon="URL"
+            ).signup = False
         op.url = self.url
 
     def execute(self, context):
         wm = bpy.context.window_manager
-        return wm.invoke_popup(self, width=300)
+        return wm.invoke_popup(self, width=self.width)
 
 
 class LoginPopupDialog(bpy.types.Operator):


### PR DESCRIPTION
fixes #1197 

- also reformulate the API key description in the preferences, so it is clear that user do not need to fill it manually or tweak or whatever

<img width="477" height="448" alt="Screenshot 2025-08-20 at 11 27 23" src="https://github.com/user-attachments/assets/e418f581-512c-4f39-9413-0f73c78d91f2" />

