### PR TITLE
Addon Support in asset bar

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -297,6 +297,12 @@ def asset_type_callback(self, context):
                 6,
             ),
         ]
+
+        # Only add addon option for Blender 4.2+
+        import bpy
+
+        if bpy.app.version >= (4, 2, 0):
+            items.append(("ADDON", "Addons", "Find addons", "PLUGIN", 7))
     else:
         items = [
             ("MODEL", "Model", "Upload a model", "OBJECT_DATAMODE", 0),
@@ -313,6 +319,12 @@ def asset_type_callback(self, context):
                 6,
             ),
         ]
+
+        # Only add addon option for Blender 4.2+
+        import bpy
+
+        if bpy.app.version >= (4, 2, 0):
+            items.append(("ADDON", "Addon", "Upload an addon", "PLUGIN", 7))
 
     return items
 
@@ -1107,6 +1119,19 @@ class BlenderKitBrushSearchProps(PropertyGroup, BlenderKitCommonSearchProps):
 
 class BlenderKitGeoToolSearchProps(PropertyGroup, BlenderKitCommonSearchProps):
     pass
+
+
+class BlenderKitAddonSearchProps(PropertyGroup, BlenderKitCommonSearchProps):
+    search_installed: BoolProperty(
+        name="Installed Only",
+        description="Show only addons that are already installed in Blender",
+        default=False,
+        update=lambda self, context: (
+            search.refresh_search()
+            if context.window_manager.blenderkitUI.asset_type == "ADDON"
+            else None
+        ),
+    )
 
 
 class BlenderKitHDRUploadProps(PropertyGroup, BlenderKitCommonUploadProps):
@@ -2329,6 +2354,12 @@ In this case you should also set path to your system CA bundle containing proxy'
         update=search.search_update,
     )  # In future we can subsets like sexualized, pornography or violence subset. And allow users choose what is part of NSFW.
 
+    temp_enabled_addons: StringProperty(
+        name="Temporarily Enabled Addons",
+        description="JSON string of temporarily enabled addon package IDs that should be disabled on next session",
+        default="[]",
+    )
+
     def draw(self, context):
         layout = self.layout
         if self.api_key.strip() == "":
@@ -2434,6 +2465,7 @@ classes = (
     BlenderKitBrushUploadProps,
     BlenderKitGeoToolSearchProps,
     BlenderKitNodeGroulUploadProps,
+    BlenderKitAddonSearchProps,
 )
 
 
@@ -2499,6 +2531,9 @@ def register():
     )
     bpy.types.NodeTree.blenderkit = PointerProperty(  # for uploads, not now...
         type=BlenderKitNodeGroulUploadProps
+    )
+    bpy.types.WindowManager.blenderkit_addon = PointerProperty(
+        type=BlenderKitAddonSearchProps
     )
     if bpy.app.factory_startup is False:
         user_preferences = bpy.context.preferences.addons[__package__].preferences

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -364,6 +364,34 @@ asset_bar_operator = None
 # BL_UI_Button.handle_event = handle_event
 
 
+def get_addon_pricing_data(asset_data):
+    """Helper function to get addon pricing information from extensions cache"""
+    is_for_sale = False
+    base_price = None
+
+    try:
+        # Import here to avoid circular imports
+        from . import override_extension_draw
+
+        override_extension_draw.ensure_repo_cache()
+        bk_ext_cache = bpy.context.window_manager.get(
+            "blenderkit_extensions_repo_cache", {}
+        )
+
+        # Try to match by extensionId first, then by assetBaseId
+        extension_id = asset_data.get("dictParameters", {}).get("extensionId")
+
+        matching_pkg = bk_ext_cache.get(extension_id)
+
+        if matching_pkg:
+            is_for_sale = matching_pkg.get("is_for_sale", False)
+            base_price = matching_pkg.get("base_price")
+    except Exception as e:
+        print(f"BlenderKit: Error fetching extension pricing data: {e}")
+
+    return is_for_sale, base_price
+
+
 def get_tooltip_data(asset_data):
     tooltip_data = asset_data.get("tooltip_data")
     if tooltip_data is not None:
@@ -380,7 +408,11 @@ def get_tooltip_data(asset_data):
             print("\n\n\nget_tooltip_data() AUTHOR NOT FOUND", author_id)
 
     aname = asset_data["displayName"]
-    aname = aname[0].upper() + aname[1:]
+    if len(aname) == 0:
+        # this shouldn't happen, but obviously did on server in addons section.
+        aname = ""
+    else:
+        aname = aname[0].upper() + aname[1:]
     if len(aname) > 36:
         aname = f"{aname[:33]}..."
 
@@ -392,10 +424,49 @@ def get_tooltip_data(asset_data):
         rcount = min(rc.get("quality", 0), rc.get("workingHours", 0))
     if rcount > show_rating_threshold:
         quality = str(round(asset_data["ratingsAverage"].get("quality")))
+
+    # Add pricing information
+    price_text = ""
+    price_color = (1.0, 0.8, 0.2, 1.0)  # Default golden color
+
+    # Check if asset is free or paid (works for all asset types)
+    is_free = asset_data.get("isFree", True)
+    can_download = asset_data.get("canDownload", True)
+
+    if asset_data.get("assetType") == "addon":
+        # Get pricing info from extensions cache
+        is_for_sale, base_price = get_addon_pricing_data(asset_data)
+
+        if is_for_sale and not can_download and base_price:
+            price_text = f"${base_price}"
+            price_color = (0.8, 0.4, 1.0, 1.0)  # Purple for paid addons
+        elif not is_free and not is_for_sale:
+            price_text = "Full Plan"
+            price_color = (0.8, 0.4, 1.0, 1.0)  # Purple for paid addons
+        elif (
+            is_for_sale and can_download
+        ):  # purchased, but not yet downloaded, so we can't show price
+            price_text = f"Purchased (${base_price})"
+            price_color = (0.8, 0.4, 1.0, 1.0)  # Purple for paid addons
+        else:
+            price_text = "Free"
+            price_color = (0.4, 0.8, 0.4, 1.0)  # Green for free addons
+    else:
+        # For other asset types, show basic pricing info
+        if not can_download:
+            price_text = "Full Plan"
+            price_color = (0.8, 0.4, 1.0, 1.0)  # Purple for paid assets
+        elif is_free:
+            price_text = "Free"
+            price_color = (0.4, 0.8, 0.4, 1.0)  # Green for free assets
+        # Don't show price text for regular paid assets that can be downloaded
+
     tooltip_data = {
         "aname": aname,
         "author_text": author_text,
         "quality": quality,
+        "price_text": price_text,
+        "price_color": price_color,
     }
     asset_data["tooltip_data"] = tooltip_data
 
@@ -571,6 +642,19 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         )
         self.tooltip_widgets.append(quality_label)
         self.quality_label = quality_label
+
+        # Add price label for addons
+        price_label = self.new_text(
+            "",
+            self.tooltip_margin,
+            self.tooltip_height
+            - int(self.asset_name_text_size + 2 * self.tooltip_margin),
+            height=self.asset_name_text_size,
+            text_size=self.asset_name_text_size,
+        )
+        price_label.text_color = (1.0, 0.8, 0.2, 1.0)  # Golden color for price
+        self.tooltip_widgets.append(price_label)
+        self.price_label = price_label
 
         user_preferences = bpy.context.preferences.addons[__package__].preferences
         offset = 0
@@ -1566,10 +1650,28 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
             self.asset_name.text = an
             self.authors_name.text = asset_data["tooltip_data"]["author_text"]
-            quality_text = asset_data["tooltip_data"]["quality"]
-            if utils.profile_is_validator():
-                quality_text += f" / {int(asset_data['score'])}"
-            self.quality_label.text = quality_text
+
+            # Hide ratings for addons
+            is_addon = asset_data.get("assetType") == "addon"
+            if not is_addon:
+                quality_text = asset_data["tooltip_data"]["quality"]
+                if utils.profile_is_validator():
+                    quality_text += f" / {int(asset_data['score'])}"
+                self.quality_label.text = quality_text
+                self.quality_label.visible = True
+                self.quality_star.visible = True
+            else:
+                self.quality_label.visible = False
+                self.quality_star.visible = False
+
+            # Update price label for addons
+            price_text = asset_data["tooltip_data"].get("price_text", "")
+            price_color = asset_data["tooltip_data"].get(
+                "price_color", (1.0, 0.8, 0.2, 1.0)
+            )
+            self.price_label.text = price_text
+            self.price_label.text_color = price_color
+            self.price_label.visible = bool(price_text)
 
             # preview comments for validators
             self.update_comments_for_validators(asset_data)
@@ -1744,12 +1846,37 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             else:
                 asset_button.validation_icon.visible = False
         else:
-            if asset_data.get("canDownload", True) == 0:
-                img_fp = paths.get_addon_thumbnail_path("locked.png")
-                asset_button.validation_icon.set_image(img_fp)
-                asset_button.validation_icon.visible = True
+            # Check for addon-specific purchasing information
+            if asset_data.get("assetType") == "addon":
+                # For addons, check purchasing status like in extension override
+                can_download = asset_data.get(
+                    "canDownload"
+                )  # Note: corrected field name
+                is_free = asset_data.get("isFree")  # Note: corrected field name
+
+                # Get pricing info from extensions cache
+                is_for_sale, base_price = get_addon_pricing_data(asset_data)
+
+                # Locked addons: for sale but not downloadable (not purchased)
+                if is_for_sale and not can_download:
+                    img_fp = paths.get_addon_thumbnail_path("locked.png")
+                    asset_button.validation_icon.set_image(img_fp)
+                    asset_button.validation_icon.visible = True
+                # Full plan addons: not free and not for sale (subscription required)
+                elif not is_free and not is_for_sale:
+                    img_fp = paths.get_addon_thumbnail_path("locked.png")
+                    asset_button.validation_icon.set_image(img_fp)
+                    asset_button.validation_icon.visible = True
+                else:
+                    asset_button.validation_icon.visible = False
             else:
-                asset_button.validation_icon.visible = False
+                # Regular asset lock logic
+                if asset_data.get("canDownload", True) == 0:
+                    img_fp = paths.get_addon_thumbnail_path("locked.png")
+                    asset_button.validation_icon.set_image(img_fp)
+                    asset_button.validation_icon.visible = True
+                else:
+                    asset_button.validation_icon.visible = False
 
     def update_image(self, asset_id):
         """should be run after thumbs are retrieved so they can be updated"""

--- a/categories.py
+++ b/categories.py
@@ -124,6 +124,7 @@ def handle_categories_task(task: client_tasks.Task):
         "BRUSH": ["brush"],
         "NODEGROUP": ["nodegroup"],
         "PRINTABLE": ["printable"],
+        "ADDON": ["addon"],
     }
 
     if task.status == "finished":

--- a/download.py
+++ b/download.py
@@ -38,6 +38,398 @@ from . import (
 
 bk_logger = logging.getLogger(__name__)
 
+
+def get_addon_installation_status(asset_data):
+    """Get the installation and enablement status of an addon.
+
+    Returns:
+        dict: {
+            "installed": bool,
+            "enabled": bool,
+            "pkg_id": str,
+            "cached_pkg": dict or None
+        }
+    """
+    import bpy
+    from . import override_extension_draw
+
+    # Get the correct package ID
+    extension_id = asset_data.get("dictParameters", {}).get("extensionId")
+    if not extension_id:
+        return {
+            "installed": False,
+            "enabled": False,
+            "pkg_id": None,
+            "cached_pkg": None,
+        }
+
+        # Check if addon is installed and enabled using Blender's addon system
+    import addon_utils
+
+    # Method 1: Check if it's in the enabled addons list
+    # For new extension system, addons have format: bl_ext.repository_name.package_name
+    enabled_addons = [addon.module for addon in bpy.context.preferences.addons]
+
+    # Check direct match first
+    is_enabled = extension_id in enabled_addons
+
+    # If not found, check for extension format: bl_ext.www_blenderkit_com.package_name
+    if not is_enabled:
+        extension_module_name = f"bl_ext.www_blenderkit_com.{extension_id}"
+        is_enabled = extension_module_name in enabled_addons
+        bk_logger.info(
+            f"Checking extension format: {extension_module_name} -> enabled: {is_enabled}"
+        )
+
+        # Also try other possible repository name formats
+        if not is_enabled:
+            for addon_module in enabled_addons:
+                if addon_module.endswith(
+                    f".{extension_id}"
+                ) and addon_module.startswith("bl_ext."):
+                    is_enabled = True
+                    bk_logger.info(
+                        f"Found enabled addon with extension format: {addon_module}"
+                    )
+                    break
+
+    # Method 2: Check if it's installed (may be disabled) using addon_utils
+    is_installed = False
+    try:
+        for addon_module in addon_utils.modules():
+            # Check direct match
+            if addon_module.__name__ == extension_id:
+                is_installed = True
+                break
+            # Check extension format match
+            elif addon_module.__name__.endswith(
+                f".{extension_id}"
+            ) and addon_module.__name__.startswith("bl_ext."):
+                is_installed = True
+                bk_logger.info(
+                    f"Found installed addon with extension format: {addon_module.__name__}"
+                )
+                break
+    except Exception as e:
+        bk_logger.warning(f"Error checking addon_utils.modules(): {e}")
+
+    # If found through addon_utils, we know it's installed
+    # But we need to double-check enabled status using the correct module name
+    if is_installed and not is_enabled:
+        # Try to find the correct module name format for this addon
+        try:
+            for addon_module in addon_utils.modules():
+                if addon_module.__name__ == extension_id or (
+                    addon_module.__name__.endswith(f".{extension_id}")
+                    and addon_module.__name__.startswith("bl_ext.")
+                ):
+                    # Check if this specific module name is enabled
+                    is_enabled = addon_module.__name__ in enabled_addons
+                    if is_enabled:
+                        bk_logger.info(f"Found enabled addon: {addon_module.__name__}")
+                    break
+        except Exception as e:
+            bk_logger.warning(f"Error double-checking enabled status: {e}")
+
+    # Method 3: If not found through traditional addon system, check extensions system
+    if not is_installed:
+        try:
+            override_extension_draw.ensure_repo_cache()
+            bk_ext_cache = bpy.context.window_manager.get(
+                "blenderkit_extensions_repo_cache", {}
+            )
+
+            for cache_key, pkg_data in bk_ext_cache.items():
+                if isinstance(pkg_data, dict) and pkg_data.get("id") == extension_id:
+                    # Check if it's actually installed in the extension system
+                    is_installed = pkg_data.get("installed", False)
+                    # For extensions, enabled status might be in the cache
+                    if is_installed and not is_enabled:
+                        is_enabled = pkg_data.get("enabled", False)
+                    break
+        except Exception as e:
+            bk_logger.warning(f"Error checking extension cache: {e}")
+
+    # Method 4: Check through Blender's extension repositories directly
+    if not is_installed:
+        try:
+            from . import global_vars
+
+            # Look for BlenderKit repository and check its packages
+            for repo in bpy.context.preferences.extensions.repos:
+                if not repo.enabled:
+                    continue
+                if not (
+                    (repo.remote_url and global_vars.SERVER in repo.remote_url)
+                    or "blenderkit" in repo.name.lower()
+                ):
+                    continue
+
+                # This is a BlenderKit repository, try to find our package
+                # Note: The actual package checking would require deeper access to the repository data
+                # For now, we'll rely on the previous methods
+                break
+        except Exception as e:
+            bk_logger.warning(f"Error checking extension repositories: {e}")
+
+    # Debug: Show some enabled addons for reference
+    blenderkit_addons = [
+        addon
+        for addon in enabled_addons
+        if "blenderkit" in addon.lower() or addon.endswith(extension_id)
+    ]
+    if blenderkit_addons:
+        bk_logger.info(f"Found BlenderKit-related enabled addons: {blenderkit_addons}")
+
+    bk_logger.info(
+        f"Addon status check for '{extension_id}': installed={is_installed}, enabled={is_enabled}"
+    )
+
+    return {
+        "installed": is_installed,
+        "enabled": is_enabled,
+        "pkg_id": extension_id,
+        "cached_pkg": None,  # Not using cached_pkg anymore
+    }
+
+
+def call_extension_operator_with_ui_context(context, operator_func, *args, **kwargs):
+    """
+    Call a Blender extension operator with proper UI context to ensure
+    error messages are displayed in the status bar.
+    """
+    try:
+        # Create a context override with UI area if available
+        override_context = {"window": context.window}
+
+        # Try to find a preferences area or any UI area for proper error display
+        for area in context.window.screen.areas:
+            if area.type == "PREFERENCES":
+                override_context["area"] = area
+                override_context["region"] = area.regions[
+                    -1
+                ]  # Use last region (usually main)
+                break
+
+        # If no preferences area found, use any available area
+        if "area" not in override_context and context.window.screen.areas:
+            override_context["area"] = context.window.screen.areas[0]
+            override_context["region"] = context.window.screen.areas[0].regions[-1]
+
+        # Call with override context so operator can display its native error messages
+        with bpy.context.temp_override(**override_context):
+            return operator_func("INVOKE_DEFAULT", *args, **kwargs)
+    except Exception as e:
+        # If context override fails, fall back to regular call
+        bk_logger.warning(f"Context override failed, using regular operator call: {e}")
+        return operator_func(*args, **kwargs)
+
+
+def install_addon_from_url(asset_data):
+    """Install an addon using Blender's extensions API with proper parameters."""
+    import bpy
+    from . import global_vars
+    from . import override_extension_draw
+
+    addon_name = asset_data.get("name", "Unknown Addon")
+    asset_id = asset_data.get("id", "")
+
+    # Check if Blender version supports extensions (4.2+)
+    if bpy.app.version < (4, 2, 0):
+        error_msg = f"Addon installation requires Blender 4.2 or newer. Current version: {'.'.join(map(str, bpy.app.version[:2]))}"
+        reports.add_report(error_msg, type="ERROR")
+        raise Exception(error_msg)
+
+    if not asset_id:
+        error_msg = f"No asset ID found for addon '{addon_name}'"
+        reports.add_report(error_msg, type="ERROR")
+        raise Exception(error_msg)
+
+    try:
+        # Check if the addon is already installed and find the correct package ID
+        # First look in the BlenderKit extension repository cache
+        override_extension_draw.ensure_repo_cache()
+        bk_ext_cache = bpy.context.window_manager.get(
+            "blenderkit_extensions_repo_cache", {}
+        )
+
+        # Find the correct package ID from BlenderKit asset data
+        actual_pkg_id = None
+        cached_pkg = None
+
+        # First, try to get the extension ID from BlenderKit asset data
+        extension_id = asset_data.get("dictParameters", {}).get("extensionId")
+        if extension_id:
+            actual_pkg_id = extension_id
+            bk_logger.info(f"Using extensionId from asset data: '{extension_id}'")
+
+            # Try to find this package in the cache
+            for cache_key, pkg_data in bk_ext_cache.items():
+                if isinstance(pkg_data, dict) and pkg_data.get("id") == extension_id:
+                    cached_pkg = pkg_data
+                    break
+        else:
+            # Fallback: Search through cache to find package with matching BlenderKit asset ID
+            for cache_key, pkg_data in bk_ext_cache.items():
+                if isinstance(pkg_data, dict):
+                    # Check if this package corresponds to our BlenderKit asset
+                    pkg_blenderkit_id = pkg_data.get("blenderkit_id") or pkg_data.get(
+                        "id", ""
+                    )
+                    if (
+                        pkg_blenderkit_id == asset_id
+                        or pkg_blenderkit_id.startswith(asset_id)
+                        or asset_id in pkg_blenderkit_id
+                    ):
+                        actual_pkg_id = pkg_data.get("id", cache_key)
+                        cached_pkg = pkg_data
+                        bk_logger.info(
+                            f"Found package mapping: BlenderKit ID '{asset_id}' -> Package ID '{actual_pkg_id}'"
+                        )
+                        break
+
+            # If we still didn't find a mapping, try using the asset_id as-is (final fallback)
+            if not actual_pkg_id:
+                actual_pkg_id = asset_id
+                cache_key = asset_id[:32]
+                cached_pkg = bk_ext_cache.get(cache_key)
+                bk_logger.warning(
+                    f"No package mapping found, using asset_id as package_id: '{actual_pkg_id}'"
+                )
+
+        if cached_pkg and cached_pkg.get("installed", False):
+            reports.add_report(
+                f"Addon '{addon_name}' is already installed", type="INFO"
+            )
+            return
+
+        # Find BlenderKit extension repository
+        repo_index = -1
+        blenderkit_repo = None
+
+        # Look for BlenderKit repository in extensions (only enabled repos)
+        enabled_repos = [
+            repo for repo in bpy.context.preferences.extensions.repos if repo.enabled
+        ]
+        bk_logger.info(
+            f"Searching through {len(enabled_repos)} enabled repositories (total: {len(bpy.context.preferences.extensions.repos)})..."
+        )
+
+        for i, repo in enumerate(enabled_repos):
+            bk_logger.info(
+                f"  Enabled Repo {i}: '{repo.name}' - URL: '{repo.remote_url}'"
+            )
+            # Check if this is a BlenderKit repository (by URL or name)
+            if (
+                repo.remote_url and global_vars.SERVER in repo.remote_url
+            ) or "blenderkit" in repo.name.lower():
+                repo_index = i
+                blenderkit_repo = repo
+                bk_logger.info(
+                    f"Found BlenderKit repository at enabled index {i}: {repo.name}"
+                )
+                break
+
+        if repo_index == -1:
+            bk_logger.warning(
+                "No BlenderKit repository found in extension repositories"
+            )
+
+        # Try repository-based installation first (your working method)
+        if repo_index >= 0:
+            try:
+                # Use the simple approach that works (like your example)
+                bk_logger.info(
+                    f"Installing package: repo_index={repo_index}, pkg_id='{actual_pkg_id}'"
+                )
+                bk_logger.info(
+                    f"Repository name: '{blenderkit_repo.name}', URL: '{blenderkit_repo.remote_url}'"
+                )
+                # Try to call with UI context first, but since we don't have context here,
+                # fall back to regular call with verification
+                result = bpy.ops.extensions.package_install(
+                    repo_index=repo_index,
+                    pkg_id=actual_pkg_id,
+                )
+                if "FINISHED" not in result and "RUNNING_MODAL" not in result:
+                    raise Exception(
+                        f"Installation failed - operation returned: {result}"
+                    )
+
+                # Verify installation was successful
+                post_install_status = get_addon_installation_status(asset_data)
+                if not post_install_status["installed"]:
+                    raise Exception(
+                        f"Installation verification failed: '{addon_name}' was not installed. "
+                        f"This may be due to version compatibility issues or other requirements not being met."
+                    )
+
+                reports.add_report(
+                    f"Successfully installed addon '{addon_name}' from BlenderKit repository",
+                    type="INFO",
+                )
+                return
+            except Exception as repo_ex:
+                bk_logger.warning(f"Repository installation failed: {repo_ex}")
+                # Fall through to file-based installation
+        else:
+            bk_logger.warning("No BlenderKit repository found")
+
+        # Fallback: File-based installation
+        # Get the download URL and use package_install_files instead
+        bk_logger.info("Trying file-based installation as fallback")
+        download_url = None
+        for f in asset_data.get("files", []):
+            if f["fileType"] == "zip_file":
+                download_url = f["downloadUrl"]
+                break
+
+        if download_url:
+            # Download the file temporarily and install from file
+            import tempfile
+            import urllib.request
+
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp_file:
+                try:
+                    urllib.request.urlretrieve(download_url, tmp_file.name)
+
+                    result = bpy.ops.extensions.package_install_files(
+                        filepath=tmp_file.name,
+                        enable_on_install=True,
+                    )
+                    if "FINISHED" not in result:
+                        raise Exception(
+                            f"File-based installation failed - operation returned: {result}"
+                        )
+
+                    # Verify installation was successful
+                    post_install_status = get_addon_installation_status(asset_data)
+                    if not post_install_status["installed"]:
+                        raise Exception(
+                            f"Installation verification failed: '{addon_name}' was not installed. "
+                            f"This may be due to version compatibility issues or other requirements not being met."
+                        )
+                finally:
+                    # Clean up temporary file
+                    import os
+
+                    try:
+                        os.unlink(tmp_file.name)
+                    except:
+                        pass  # Ignore cleanup errors
+
+            reports.add_report(
+                f"Successfully installed addon '{addon_name}' as extension", type="INFO"
+            )
+        else:
+            raise Exception(
+                "No BlenderKit repository found and no download URL available"
+            )
+    except Exception as e:
+        bk_logger.error(f"Failed to install addon '{addon_name}': {e}")
+        raise Exception(f"Failed to install addon '{addon_name}': {e}")
+
+
 import bpy
 from bpy.app.handlers import persistent
 from bpy.props import (
@@ -115,6 +507,71 @@ def check_unused():
             l.user_clear()
 
 
+def get_temp_enabled_addons():
+    """Get list of temporarily enabled addons from preferences."""
+    import json
+
+    try:
+        prefs = bpy.context.preferences.addons[__package__].preferences
+        temp_addons_json = prefs.temp_enabled_addons
+        return json.loads(temp_addons_json)
+    except Exception as e:
+        bk_logger.warning(f"Error reading temporary addons from preferences: {e}")
+        return []
+
+
+def set_temp_enabled_addons(addon_list):
+    """Save list of temporarily enabled addons to preferences."""
+    import json
+
+    try:
+        prefs = bpy.context.preferences.addons[__package__].preferences
+        prefs.temp_enabled_addons = json.dumps(addon_list)
+        bk_logger.info(f"Saved {len(addon_list)} temporary addons to preferences")
+    except Exception as e:
+        bk_logger.error(f"Error saving temporary addons to preferences: {e}")
+
+
+def add_temp_enabled_addon(pkg_id):
+    """Add an addon to the temporary enabled list."""
+    temp_enabled = get_temp_enabled_addons()
+    if pkg_id not in temp_enabled:
+        temp_enabled.append(pkg_id)
+        set_temp_enabled_addons(temp_enabled)
+        bk_logger.info(f"Added {pkg_id} to temporary addons list")
+
+
+def cleanup_temp_enabled_addons():
+    """Disable temporarily enabled addons."""
+    import bpy
+
+    try:
+        temp_enabled = get_temp_enabled_addons()
+
+        if not temp_enabled:
+            bk_logger.info("No temporarily enabled addons to clean up")
+            return
+
+        bk_logger.info(f"Cleaning up {len(temp_enabled)} temporarily enabled addons")
+
+        # Disable all temporarily enabled addons using preferences API
+        for pkg_id in temp_enabled:
+            try:
+                full_module_name = f"bl_ext.www_blenderkit_com.{pkg_id}"
+                bpy.ops.preferences.addon_disable(module=full_module_name)
+                bk_logger.info(f"Disabled temporarily enabled addon: {pkg_id}")
+            except Exception as e:
+                bk_logger.warning(
+                    f"Failed to disable temporarily enabled addon {pkg_id}: {e}"
+                )
+
+        # Clear the list in preferences
+        set_temp_enabled_addons([])
+        bk_logger.info("Temporary addon cleanup completed")
+    except Exception as e:
+        bk_logger.error(f"Error during temporary addon cleanup: {e}")
+
+
 @persistent
 def scene_save(context):
     """Do cleanup of blenderkit props and send a message to the server about assets used."""
@@ -127,6 +584,12 @@ def scene_save(context):
     )  # TODO: FIX OR REMOVE THIS (now returns empty dict all the time) https://github.com/BlenderKit/blenderkit/issues/1013
     if report_data != {}:
         client_lib.report_usages(report_data)
+
+
+@persistent
+def scene_load_pre(context):
+    """Clean up temporarily enabled addons before loading new file."""
+    cleanup_temp_enabled_addons()
 
 
 @persistent
@@ -617,9 +1080,20 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
         bk_logger.info(f"appended nodegroup: {nodegroup}")
         asset_main = nodegroup
 
+    elif asset_data["assetType"] == "addon":
+        # Handle addon installation using extensions API
+        try:
+            install_addon_from_url(asset_data)
+            asset_main = None  # Addons don't have a main asset object
+        except Exception as e:
+            bk_logger.error(f"Failed to install addon: {e}")
+            reports.add_report(f"Failed to install addon: {e}", type="ERROR")
+            return
+
     asset_data["resolution"] = kwargs["resolution"]
     udpate_asset_data_in_dicts(asset_data)
-    update_asset_metadata(asset_main, asset_data)
+    if asset_main is not None:
+        update_asset_metadata(asset_main, asset_data)
 
     bpy.ops.ed.undo_push(
         "INVOKE_REGION_WIN", message="add %s to scene" % asset_data["name"]
@@ -1294,8 +1768,525 @@ asset_types = (
     ("MATERIAL", "Material", "any .blend Material"),
     ("TEXTURE", "Texture", "a texture, or texture set"),
     ("BRUSH", "Brush", "brush, can be any type of blender brush"),
-    ("ADDON", "Addon", "addnon"),
+    ("ADDON", "Addon", "addon"),
 )
+
+
+class BlenderkitAddonManagerOperator(bpy.types.Operator):
+    """Manage BlenderKit addon installation, enabling, and disabling"""
+
+    bl_idname = "scene.blenderkit_addon_manager"
+    bl_label = "Addon Manager"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    asset_data: bpy.props.StringProperty()  # JSON encoded asset data
+    action: bpy.props.EnumProperty(
+        items=[
+            ("INSTALL", "Install", "Install the addon"),
+            ("UNINSTALL", "Uninstall", "Uninstall the addon"),
+            ("ENABLE", "Enable", "Enable the addon"),
+            ("DISABLE", "Disable", "Disable the addon"),
+            ("TEMP_ENABLE", "Enable Temporarily", "Enable until end of session"),
+        ]
+    )
+
+    def execute(self, context):
+        import json
+        from . import global_vars
+
+        try:
+            asset_data = json.loads(self.asset_data)
+        except:
+            reports.add_report("Invalid asset data", type="ERROR")
+            return {"CANCELLED"}
+
+        addon_name = asset_data.get("name", "Unknown Addon")
+        status = get_addon_installation_status(asset_data)
+        pkg_id = status["pkg_id"]
+
+        if not pkg_id:
+            reports.add_report("No extension ID found for this addon", type="ERROR")
+            return {"CANCELLED"}
+
+        # Find the BlenderKit repository
+        enabled_repos = [
+            repo for repo in bpy.context.preferences.extensions.repos if repo.enabled
+        ]
+        repo_index = -1
+        for i, repo in enumerate(enabled_repos):
+            if (
+                repo.remote_url and global_vars.SERVER in repo.remote_url
+            ) or "blenderkit" in repo.name.lower():
+                repo_index = i
+                break
+
+        if repo_index == -1:
+            reports.add_report("BlenderKit repository not found", type="ERROR")
+            return {"CANCELLED"}
+
+        try:
+            if self.action == "INSTALL":
+                # Check if already installed before attempting installation
+                pre_install_status = get_addon_installation_status(
+                    json.loads(self.asset_data)
+                )
+
+                # Call the operator with proper UI context so it can show its own error messages
+                result = call_extension_operator_with_ui_context(
+                    context,
+                    bpy.ops.extensions.package_install,
+                    repo_index=repo_index,
+                    pkg_id=pkg_id,
+                )
+
+                # Handle modal operations properly
+                if "RUNNING_MODAL" in result:
+                    # Modal operation started - this is normal for UI-invoked operations
+                    # DON'T report success yet - let the modal operation complete and report its own result
+                    bk_logger.info(
+                        f"Modal installation started for '{addon_name}' - waiting for completion"
+                    )
+                    # Return early without reporting success - Blender will handle the reporting
+                    return {"FINISHED"}
+                elif "FINISHED" in result:
+                    # Non-modal operation completed, verify it succeeded
+                    post_install_status = get_addon_installation_status(
+                        json.loads(self.asset_data)
+                    )
+                    if not post_install_status["installed"]:
+                        raise Exception(
+                            f"Installation verification failed: '{addon_name}' was not installed. "
+                            f"Check the status bar for specific error details."
+                        )
+                    # Only report success for verified non-modal operations
+                    reports.add_report(
+                        f"Successfully installed '{addon_name}'", type="INFO"
+                    )
+                    self.report({"INFO"}, f"Successfully installed '{addon_name}'")
+                else:
+                    # Operation failed immediately
+                    raise Exception(
+                        f"Installation failed - operation returned: {result}"
+                    )
+
+            elif self.action == "UNINSTALL":
+                result = bpy.ops.extensions.package_uninstall(
+                    repo_index=repo_index, pkg_id=pkg_id
+                )
+                if "FINISHED" not in result:
+                    raise Exception(
+                        f"Uninstallation failed - operation returned: {result}"
+                    )
+                reports.add_report(
+                    f"Successfully uninstalled '{addon_name}'", type="INFO"
+                )
+                self.report({"INFO"}, f"Successfully uninstalled '{addon_name}'")
+
+            elif self.action == "ENABLE":
+                result = bpy.ops.extensions.package_enable(
+                    repo_index=repo_index, pkg_id=pkg_id
+                )
+                if "FINISHED" not in result:
+                    raise Exception(f"Enable failed - operation returned: {result}")
+                reports.add_report(f"Successfully enabled '{addon_name}'", type="INFO")
+                self.report({"INFO"}, f"Successfully enabled '{addon_name}'")
+
+            elif self.action == "DISABLE":
+                result = bpy.ops.extensions.package_disable(
+                    repo_index=repo_index, pkg_id=pkg_id
+                )
+                if "FINISHED" not in result:
+                    raise Exception(f"Disable failed - operation returned: {result}")
+                reports.add_report(f"Successfully disabled '{addon_name}'", type="INFO")
+                self.report({"INFO"}, f"Successfully disabled '{addon_name}'")
+
+            elif self.action == "TEMP_ENABLE":
+                result = bpy.ops.extensions.package_enable(
+                    repo_index=repo_index, pkg_id=pkg_id
+                )
+                if "FINISHED" not in result:
+                    raise Exception(
+                        f"Temporary enable failed - operation returned: {result}"
+                    )
+                # Store the package for later disabling
+                wm = context.window_manager
+                temp_enabled = wm.get("blenderkit_temp_enabled_addons", [])
+                if pkg_id not in temp_enabled:
+                    temp_enabled.append(pkg_id)
+                    wm["blenderkit_temp_enabled_addons"] = temp_enabled
+                reports.add_report(
+                    f"Temporarily enabled '{addon_name}' (will disable on session end)",
+                    type="INFO",
+                )
+                self.report({"INFO"}, f"Temporarily enabled '{addon_name}'")
+
+        except Exception as e:
+            error_msg = f"Failed to {self.action.lower()} '{addon_name}': {e}"
+            reports.add_report(error_msg, type="ERROR")
+            self.report({"ERROR"}, error_msg)
+            return {"CANCELLED"}
+
+        return {"FINISHED"}
+
+
+class BlenderkitAddonChoiceOperator(bpy.types.Operator):
+    """Show addon management options popup"""
+
+    bl_idname = "scene.blenderkit_addon_choice"
+    bl_label = "Addon Options"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    asset_data: bpy.props.StringProperty()  # JSON encoded asset data
+
+    # Actions for not installed addons
+    action_not_installed: bpy.props.EnumProperty(
+        name="Action",
+        description="Choose what to do with this addon",
+        items=[
+            (
+                "INSTALL_AND_ENABLE",
+                "Install and Enable",
+                "Install the addon and enable it immediately",
+                "CHECKBOX_HLT",
+                0,
+            ),
+            (
+                "INSTALL_AND_TEMP_ENABLE",
+                "Install and Enable Temporarily",
+                "Install and enable until end of session",
+                "TIME",
+                1,
+            ),
+            (
+                "INSTALL_ONLY",
+                "Install Only",
+                "Install the addon but keep it disabled",
+                "IMPORT",
+                2,
+            ),
+        ],
+    )
+
+    # Actions for installed and enabled addons
+    action_installed_enabled: bpy.props.EnumProperty(
+        name="Action",
+        description="Choose what to do with this addon",
+        items=[
+            ("DISABLE", "Disable", "Disable the addon", "CHECKBOX_DEHLT", 0),
+            ("UNINSTALL", "Uninstall", "Completely remove the addon", "CANCEL", 1),
+        ],
+    )
+
+    # Actions for installed but disabled addons
+    action_installed_disabled: bpy.props.EnumProperty(
+        name="Action",
+        description="Choose what to do with this addon",
+        items=[
+            ("ENABLE", "Enable", "Enable the addon permanently", "CHECKBOX_HLT", 0),
+            (
+                "TEMP_ENABLE",
+                "Enable Temporarily",
+                "Enable until end of session",
+                "TIME",
+                1,
+            ),
+            ("UNINSTALL", "Uninstall", "Completely remove the addon", "CANCEL", 2),
+        ],
+    )
+
+    def draw(self, context):
+        import json
+
+        layout = self.layout
+
+        try:
+            asset_data = json.loads(self.asset_data)
+        except:
+            layout.label(text="Invalid asset data")
+            return
+
+        addon_name = asset_data.get("name", "Unknown Addon")
+        status = get_addon_installation_status(asset_data)
+
+        layout.label(text=f"Addon: {addon_name}")
+        layout.separator()
+
+        layout = layout.column()
+        # Show current status and appropriate action enum
+        if not status["installed"]:
+            layout.label(text="Status: Not Installed", icon="QUESTION")
+            layout.separator()
+            layout.prop(self, "action_not_installed", expand=True)
+        elif status["enabled"]:
+            layout.label(text="Status: Installed and Enabled", icon="CHECKMARK")
+            layout.separator()
+            layout.prop(self, "action_installed_enabled", expand=True)
+        else:
+            layout.label(text="Status: Installed but Disabled", icon="X")
+            layout.separator()
+            layout.prop(self, "action_installed_disabled", expand=True)
+
+    def invoke(self, context, event):
+        # Set default values for each enum
+        self.action_not_installed = "INSTALL_AND_ENABLE"
+        self.action_installed_enabled = "DISABLE"
+        self.action_installed_disabled = "ENABLE"
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self, width=350)
+
+    def execute(self, context):
+        import json
+        from . import global_vars
+
+        try:
+            asset_data = json.loads(self.asset_data)
+        except:
+            reports.add_report("Invalid asset data", type="ERROR")
+            return {"CANCELLED"}
+
+        addon_name = asset_data.get("name", "Unknown Addon")
+        status = get_addon_installation_status(asset_data)
+        pkg_id = status["pkg_id"]
+
+        # Get the selected action based on addon status
+        if not status["installed"]:
+            selected_action = self.action_not_installed
+        elif status["enabled"]:
+            selected_action = self.action_installed_enabled
+        else:
+            selected_action = self.action_installed_disabled
+
+        if not pkg_id:
+            reports.add_report("No extension ID found for this addon", type="ERROR")
+            return {"CANCELLED"}
+
+        # Find the BlenderKit repository
+        enabled_repos = [
+            repo for repo in bpy.context.preferences.extensions.repos if repo.enabled
+        ]
+        repo_index = -1
+        for i, repo in enumerate(enabled_repos):
+            if (
+                repo.remote_url and global_vars.SERVER in repo.remote_url
+            ) or "blenderkit" in repo.name.lower():
+                repo_index = i
+                break
+
+        if repo_index == -1:
+            reports.add_report("BlenderKit repository not found", type="ERROR")
+            return {"CANCELLED"}
+
+        try:
+            if selected_action == "INSTALL_AND_ENABLE":
+                # Call the operator with proper UI context so it can show its own error messages
+                result = call_extension_operator_with_ui_context(
+                    context,
+                    bpy.ops.extensions.package_install,
+                    repo_index=repo_index,
+                    pkg_id=pkg_id,
+                )
+
+                # Handle modal operations properly
+                if "RUNNING_MODAL" in result:
+                    # Modal operation started - this is normal for UI-invoked operations
+                    # DON'T report success yet - let the modal operation complete and report its own result
+                    bk_logger.info(
+                        f"Modal installation started for '{addon_name}' - waiting for completion"
+                    )
+                    # Return early without reporting success - Blender will handle the reporting
+                    return {"FINISHED"}
+                elif "FINISHED" in result:
+                    # Non-modal operation completed, verify it succeeded
+                    post_install_status = get_addon_installation_status(asset_data)
+                    if not post_install_status["installed"]:
+                        raise Exception(
+                            f"Installation verification failed: '{addon_name}' was not installed. "
+                            f"Check the status bar for specific error details."
+                        )
+                    # Only report success for verified non-modal operations
+                    # No need to enable separately, install usually enables by default
+                    reports.add_report(
+                        f"Successfully installed and enabled '{addon_name}'",
+                        type="INFO",
+                    )
+                    self.report(
+                        {"INFO"}, f"Successfully installed and enabled '{addon_name}'"
+                    )
+                else:
+                    # Operation failed immediately
+                    raise Exception(
+                        f"Installation failed - operation returned: {result}"
+                    )
+
+            elif selected_action == "INSTALL_AND_TEMP_ENABLE":
+                # Call the operator with proper UI context so it can show its own error messages
+                result = call_extension_operator_with_ui_context(
+                    context,
+                    bpy.ops.extensions.package_install,
+                    repo_index=repo_index,
+                    pkg_id=pkg_id,
+                )
+
+                # Handle modal operations properly
+                if "RUNNING_MODAL" in result:
+                    # Modal operation started - this is normal for UI-invoked operations
+                    # DON'T report success yet - let the modal operation complete and report its own result
+                    bk_logger.info(
+                        f"Modal installation started for '{addon_name}' - waiting for completion"
+                    )
+                    # Return early without reporting success - Blender will handle the reporting
+                    return {"FINISHED"}
+                elif "FINISHED" in result:
+                    # Non-modal operation completed, verify it succeeded
+                    post_install_status = get_addon_installation_status(asset_data)
+                    if not post_install_status["installed"]:
+                        raise Exception(
+                            f"Installation verification failed: '{addon_name}' was not installed. "
+                            f"Check the status bar for specific error details."
+                        )
+                    # Only report success for verified non-modal operations
+                    # Store the package for temporary disabling later
+                    add_temp_enabled_addon(pkg_id)
+                    reports.add_report(
+                        f"Successfully installed and temporarily enabled '{addon_name}' (will disable on session end)",
+                        type="INFO",
+                    )
+                    self.report(
+                        {"INFO"},
+                        f"Successfully installed and temporarily enabled '{addon_name}'",
+                    )
+                else:
+                    # Operation failed immediately
+                    raise Exception(
+                        f"Installation failed - operation returned: {result}"
+                    )
+
+            elif selected_action == "INSTALL_ONLY":
+                # Call the operator with proper UI context so it can show its own error messages
+                result = call_extension_operator_with_ui_context(
+                    context,
+                    bpy.ops.extensions.package_install,
+                    repo_index=repo_index,
+                    pkg_id=pkg_id,
+                )
+
+                # Handle modal operations properly
+                if "RUNNING_MODAL" in result:
+                    # Modal operation started - this is normal for UI-invoked operations
+                    # DON'T report success yet - let the modal operation complete and report its own result
+                    bk_logger.info(
+                        f"Modal installation started for '{addon_name}' - waiting for completion"
+                    )
+                    # Return early without reporting success - Blender will handle the reporting
+                    return {"FINISHED"}
+                elif "FINISHED" in result:
+                    # Non-modal operation completed, verify it succeeded
+                    post_install_status = get_addon_installation_status(asset_data)
+                    if not post_install_status["installed"]:
+                        raise Exception(
+                            f"Installation verification failed: '{addon_name}' was not installed. "
+                            f"Check the status bar for specific error details."
+                        )
+                    # Only report success for verified non-modal operations
+                    # Disable after install using preferences API
+                    full_module_name = f"bl_ext.www_blenderkit_com.{pkg_id}"
+                    try:
+                        bpy.ops.preferences.addon_disable(module=full_module_name)
+                    except Exception as e:
+                        bk_logger.error(f"Failed to disable after install: {e}")
+                    reports.add_report(
+                        f"Successfully installed '{addon_name}' (disabled)", type="INFO"
+                    )
+                    self.report(
+                        {"INFO"}, f"Successfully installed '{addon_name}' (disabled)"
+                    )
+                else:
+                    # Operation failed immediately
+                    raise Exception(
+                        f"Installation failed - operation returned: {result}"
+                    )
+
+            elif selected_action == "UNINSTALL":
+                result = bpy.ops.extensions.package_uninstall(
+                    repo_index=repo_index, pkg_id=pkg_id
+                )
+                if "FINISHED" not in result:
+                    raise Exception(
+                        f"Uninstallation failed - operation returned: {result}"
+                    )
+                reports.add_report(
+                    f"Successfully uninstalled '{addon_name}'", type="INFO"
+                )
+                self.report({"INFO"}, f"Successfully uninstalled '{addon_name}'")
+
+            elif selected_action == "ENABLE":
+                # Enable using preferences API
+                full_module_name = f"bl_ext.www_blenderkit_com.{pkg_id}"
+                try:
+                    result = bpy.ops.preferences.addon_enable(module=full_module_name)
+                    if "FINISHED" not in result:
+                        raise Exception(f"Enable operation failed - returned: {result}")
+                    reports.add_report(
+                        f"Successfully enabled '{addon_name}'", type="INFO"
+                    )
+                    self.report({"INFO"}, f"Successfully enabled '{addon_name}'")
+                except Exception as e:
+                    bk_logger.error(f"Failed to enable addon: {e}")
+                    reports.add_report(
+                        f"Failed to enable '{addon_name}': {e}", type="ERROR"
+                    )
+
+            elif selected_action == "DISABLE":
+                # Disable using preferences API
+                full_module_name = f"bl_ext.www_blenderkit_com.{pkg_id}"
+                try:
+                    result = bpy.ops.preferences.addon_disable(module=full_module_name)
+                    if "FINISHED" not in result:
+                        raise Exception(
+                            f"Disable operation failed - returned: {result}"
+                        )
+                    reports.add_report(
+                        f"Successfully disabled '{addon_name}'", type="INFO"
+                    )
+                    self.report({"INFO"}, f"Successfully disabled '{addon_name}'")
+                except Exception as e:
+                    bk_logger.error(f"Failed to disable addon: {e}")
+                    reports.add_report(
+                        f"Failed to disable '{addon_name}': {e}", type="ERROR"
+                    )
+
+            elif selected_action == "TEMP_ENABLE":
+                # Temporarily enable using preferences API
+                full_module_name = f"bl_ext.www_blenderkit_com.{pkg_id}"
+                try:
+                    result = bpy.ops.preferences.addon_enable(module=full_module_name)
+                    if "FINISHED" not in result:
+                        raise Exception(
+                            f"Temporary enable operation failed - returned: {result}"
+                        )
+                except Exception as e:
+                    bk_logger.error(f"Failed to temp enable addon: {e}")
+                    reports.add_report(
+                        f"Failed to enable '{addon_name}': {e}", type="ERROR"
+                    )
+                    return {"CANCELLED"}
+
+                # Store the package for later disabling
+                add_temp_enabled_addon(pkg_id)
+                reports.add_report(
+                    f"Temporarily enabled '{addon_name}' (will disable on session end)",
+                    type="INFO",
+                )
+                self.report({"INFO"}, f"Temporarily enabled '{addon_name}'")
+
+        except Exception as e:
+            bk_logger.error(f"Addon operation failed for '{addon_name}': {e}")
+            error_msg = f"Failed to {selected_action.lower().replace('_', ' ')} '{addon_name}': {e}"
+            reports.add_report(error_msg, type="ERROR")
+            self.report({"ERROR"}, error_msg)
+            return {"CANCELLED"}
+
+        return {"FINISHED"}
 
 
 class BlenderkitKillDownloadOperator(bpy.types.Operator):
@@ -1338,6 +2329,10 @@ def available_resolutions_callback(self, context):
 
 def has_asset_files(asset_data):
     """Check if asset has files."""
+    # Addons are handled separately by the extension system
+    if asset_data["assetType"] == "addon":
+        return True
+
     for f in asset_data["files"]:
         if f["fileType"] == "blend":
             return True
@@ -1514,6 +2509,15 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         asset_type = self.asset_data["assetType"]
+
+        # Handle addon assets with popup
+        if asset_type == "addon":
+            import json
+
+            bpy.ops.scene.blenderkit_addon_choice(
+                "INVOKE_DEFAULT", asset_data=json.dumps(self.asset_data)
+            )
+            return {"FINISHED"}
         if (
             (asset_type == "model" or asset_type == "material")
             and (bpy.context.mode != "OBJECT")
@@ -1659,12 +2663,20 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
 def register_download():
     bpy.utils.register_class(BlenderkitDownloadOperator)
     bpy.utils.register_class(BlenderkitKillDownloadOperator)
+    # bpy.utils.register_class(BlenderkitAddonManagerOperator)  # Replaced by BlenderkitAddonChoiceOperator
+    bpy.utils.register_class(BlenderkitAddonChoiceOperator)
     bpy.app.handlers.load_post.append(scene_load)
     bpy.app.handlers.save_pre.append(scene_save)
+    bpy.app.handlers.load_pre.append(scene_load_pre)
 
 
 def unregister_download():
     bpy.utils.unregister_class(BlenderkitDownloadOperator)
     bpy.utils.unregister_class(BlenderkitKillDownloadOperator)
+    # bpy.utils.unregister_class(BlenderkitAddonManagerOperator)  # Replaced by BlenderkitAddonChoiceOperator
+    bpy.utils.unregister_class(BlenderkitAddonChoiceOperator)
     bpy.app.handlers.load_post.remove(scene_load)
     bpy.app.handlers.save_pre.remove(scene_save)
+    bpy.app.handlers.load_pre.remove(scene_load_pre)
+    # Clean up any remaining temporarily enabled addons
+    cleanup_temp_enabled_addons()

--- a/paths.py
+++ b/paths.py
@@ -45,6 +45,7 @@ BLENDERKIT_MATERIAL_UPLOAD_INSTRUCTIONS_URL = (
 BLENDERKIT_BRUSH_UPLOAD_INSTRUCTIONS_URL = f"{global_vars.SERVER}/docs/uploading-brush/"
 BLENDERKIT_HDR_UPLOAD_INSTRUCTIONS_URL = f"{global_vars.SERVER}/docs/uploading-hdr/"
 BLENDERKIT_SCENE_UPLOAD_INSTRUCTIONS_URL = f"{global_vars.SERVER}/docs/uploading-scene/"
+BLENDERKIT_ADDON_UPLOAD_INSTRUCTIONS_URL = f"{global_vars.SERVER}/docs/uploading-addon/"
 BLENDERKIT_LOGIN_URL = f"{global_vars.SERVER}/accounts/login"
 BLENDERKIT_SIGNUP_URL = f"{global_vars.SERVER}/accounts/register"
 
@@ -152,6 +153,7 @@ def get_download_dirs(asset_type):
         "hdr": "hdrs",
         "nodegroup": "nodegroups",
         "printable": "printables",
+        "addon": "addons",
     }
 
     dirs = []

--- a/search.py
+++ b/search.py
@@ -170,6 +170,8 @@ def check_clipboard():
         target_asset_type = "PRINTABLE"
     elif asset_type_string.find("nodegroup") > -1:
         target_asset_type = "NODEGROUP"
+    elif asset_type_string.find("addon") > -1 or asset_type_string.find("add-on") > -1:
+        target_asset_type = "ADDON"
     ui_props = bpy.context.window_manager.blenderkitUI
     if ui_props.asset_type != target_asset_type:
         ui_props.asset_type = target_asset_type  # switch asset type before placing keywords, so it does not search under wrong asset type
@@ -392,6 +394,14 @@ def handle_search_task(task: client_tasks.Task) -> bool:
         comments = comments_utils.get_comments_local(asset_data["assetBaseId"])
         if comments is None:
             client_lib.get_comments(asset_data["assetBaseId"])
+
+    # Apply addon-specific filtering if needed
+    if ui_props.asset_type == "ADDON":
+        addon_props = bpy.context.window_manager.blenderkit_addon
+        if addon_props.search_installed:
+            result_field = filter_addon_search_results(
+                result_field, filter_installed_only=True
+            )
 
     # Store results in history step
     history_step["search_results"] = result_field
@@ -748,7 +758,10 @@ def query_to_url(
             # for validators, sort uploaded from oldest
             order.append("last_blend_upload")
         else:
-            order.append("-last_blend_upload")
+            if query.get("asset_type") == "addon":
+                order.append("-created")
+            else:
+                order.append("-last_blend_upload")
     elif (
         query.get("author_id") is not None
         or query.get("query", "").find("+author_id:") > -1
@@ -917,6 +930,51 @@ def build_query_nodegroup(
     """Pure function to construct search query dict for nodegroups."""
     query = {"asset_type": "nodegroup"}
     return build_query_common(query, props, ui_props)
+
+
+def build_query_addon(props, ui_props) -> dict:
+    """Pure function to construct search query dict for addons."""
+    query = {"asset_type": "addon"}
+    return build_query_common(query, props, ui_props)
+
+
+def filter_addon_search_results(search_results, filter_installed_only=False):
+    """
+    Filter addon search results based on local installation status.
+    This is called after search results arrive since installation info isn't stored on server.
+
+    Args:
+        search_results: List of addon asset data from search
+        filter_installed_only: If True, only return installed addons
+
+    Returns:
+        Filtered list of addon assets
+    """
+    if not filter_installed_only:
+        return search_results
+
+    from . import download
+
+    filtered_results = []
+
+    for asset in search_results:
+        if asset.get("assetType") != "addon":
+            # Skip non-addon assets (shouldn't happen in addon search but safety check)
+            continue
+
+        # Check if this addon is installed
+        try:
+            status = download.get_addon_installation_status(asset)
+            if status.get("installed", False):
+                filtered_results.append(asset)
+        except Exception as e:
+            # If we can't determine status, skip this addon to be safe
+            bk_logger.warning(
+                f"Could not determine installation status for addon {asset.get('name', 'Unknown')}: {e}"
+            )
+            continue
+
+    return filtered_results
 
 
 def add_search_process(
@@ -1096,6 +1154,12 @@ def search(get_next=False, query=None, author_id=""):
                 ui_props=bpy.context.window_manager.blenderkitUI,
             )
 
+        if ui_props.asset_type == "ADDON":
+            query = build_query_addon(
+                props=bpy.context.window_manager.blenderkit_addon,
+                ui_props=bpy.context.window_manager.blenderkitUI,
+            )
+
         # crop long searches
         if query.get("query"):
             if len(query["query"]) > 50:
@@ -1221,6 +1285,8 @@ def update_filters():
         sprops.use_filters = sprops.true_hdr
     elif ui_props.asset_type == "NODEGROUP":
         sprops.use_filters = fcommon
+    elif ui_props.asset_type == "ADDON":
+        sprops.use_filters = fcommon
     return True
 
 
@@ -1269,6 +1335,8 @@ def detect_asset_type_from_keywords(keywords: str) -> tuple[str, str]:
         "nodegroup": "NODEGROUP",
         "node": "NODEGROUP",
         "printable": "PRINTABLE",
+        "addon": "ADDON",
+        "extension": "ADDON",
     }
 
     # Convert to lowercase for matching
@@ -1345,6 +1413,8 @@ def search_update(self, context):
                 target_asset_type = "NODEGROUP"
             elif asset_type_string.find("printable") > -1:
                 target_asset_type = "PRINTABLE"
+            elif asset_type_string.find("addon") > -1:
+                target_asset_type = "ADDON"
 
             if ui_props.asset_type != target_asset_type:
                 ui_props.search_keywords = ""
@@ -1643,6 +1713,8 @@ def get_ui_state():
         store_props = store_scene_props
     elif asset_type == "PRINTABLE":
         store_props = store_model_props
+    elif asset_type == "ADDON":
+        store_props = []  # Addons don't need to store specific props
 
     search_props = utils.get_search_props()
 
@@ -1651,6 +1723,13 @@ def get_ui_state():
     for prop_name in store_props:
         if prop_name != "rna_type":
             ui_state["search_props"][prop_name] = getattr(search_props, prop_name)
+
+    # Store addon-specific search properties
+    if ui_props.asset_type == "ADDON":
+        addon_props = bpy.context.window_manager.blenderkit_addon
+        ui_state["addon_props"] = {
+            "search_installed": addon_props.search_installed,
+        }
 
     return ui_state
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -87,6 +87,9 @@ def draw_upload_common(layout, props, asset_type, context):
         url = (
             paths.BLENDERKIT_MODEL_UPLOAD_INSTRUCTIONS_URL
         )  # Reuse model instructions since prints are similar
+    if asset_type == "ADDON":
+        asset_type_text = asset_type
+        url = paths.BLENDERKIT_ADDON_UPLOAD_INSTRUCTIONS_URL
     op = layout.operator(
         "wm.url_open", text=f"Read {asset_type} upload instructions", icon="QUESTION"
     )
@@ -223,6 +226,21 @@ def draw_panel_hdr_search(self, context):
     draw_assetbar_show_hide(row, props)
 
     utils.label_multiline(layout, text=props.report)
+
+
+def draw_panel_addon_search(self, context):
+    import bpy
+
+    wm = context.window_manager
+    ui_props = wm.blenderkitUI
+    addon_props = wm.blenderkit_addon
+
+    layout = self.layout
+    row = layout.row()
+    row.prop(ui_props, "search_keywords", text="", icon="VIEWZOOM")
+    draw_assetbar_show_hide(row, addon_props)
+
+    utils.label_multiline(layout, text=addon_props.report)
 
 
 def draw_panel_nodegroup_upload(self, context):
@@ -1556,6 +1574,32 @@ class VIEW3D_PT_blenderkit_advanced_nodegroup_search(Panel):
         draw_common_filters(self.layout, ui_props)
 
 
+class VIEW3D_PT_blenderkit_advanced_addon_search(Panel):
+    bl_category = "BlenderKit"
+    bl_idname = "VIEW3D_PT_blenderkit_advanced_addon_search"
+    bl_parent_id = "VIEW3D_PT_blenderkit_unified"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_label = "Search filters"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    @classmethod
+    def poll(cls, context):
+        ui_props = bpy.context.window_manager.blenderkitUI
+        if not global_vars.CLIENT_RUNNING:
+            return False
+        return ui_props.down_up == "SEARCH" and ui_props.asset_type == "ADDON"
+
+    def draw(self, context):
+        ui_props = bpy.context.window_manager.blenderkitUI
+        draw_common_filters(self.layout, ui_props)
+        layout = self.layout
+        addon_props = bpy.context.window_manager.blenderkit_addon
+        # Add installed filter for addons
+        row = layout.row()
+        row.prop(addon_props, "search_installed", text="Installed Only")
+
+
 class VIEW3D_PT_blenderkit_advanced_printable_search(Panel):
     bl_category = "BlenderKit"
     bl_idname = "VIEW3D_PT_blenderkit_advanced_printable_search"
@@ -1788,6 +1832,9 @@ class VIEW3D_PT_blenderkit_unified(Panel):
         if ui_props.asset_type == "NODEGROUP":
             return draw_panel_nodegroup_search(self, context)
 
+        if ui_props.asset_type == "ADDON":
+            return draw_panel_addon_search(self, context)
+
     def draw_upload(self, context, layout, ui_props):
         if ui_props.asset_type == "MODEL" or ui_props.asset_type == "PRINTABLE":
             if bpy.context.view_layer.objects.active is not None:
@@ -1822,6 +1869,15 @@ class VIEW3D_PT_blenderkit_unified(Panel):
 
         if ui_props.asset_type == "NODEGROUP":
             return draw_panel_nodegroup_upload(self, context)
+
+        if ui_props.asset_type == "ADDON":
+            layout.label(text="Addon uploads are managed through")
+            layout.label(text="the BlenderKit website.")
+            op = layout.operator(
+                "wm.url_open", text="Go to BlenderKit Website", icon="URL"
+            )
+            op.url = paths.BLENDERKIT_ADDON_UPLOAD_INSTRUCTIONS_URL
+            return
 
 
 class BlenderKitWelcomeOperator(bpy.types.Operator):
@@ -2617,38 +2673,155 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
 
         # self.draw_property(box, 'Tags', self.asset_data['tags']) #TODO make them clickable!
 
-        # Free/Full plan or private Access
+        # Free/Full plan or private Access - with special handling for addons
         plans_tooltip = (
             "BlenderKit has 2 plans:\n"
             "  *  Free plan - more than 50% of all assets\n"
             "  *  Full plan - unlimited access to everything\n"
             "Click to go to subscriptions page"
         )
-        if self.asset_data["isPrivate"]:
-            t = "Private"
-            self.draw_property(box, "Access", t, icon="LOCKED")
-        elif self.asset_data["isFree"]:
-            t = "Free plan"
-            icon = pcoll["free"]
-            self.draw_property(
-                box,
-                "Access",
-                t,
-                icon_value=icon.icon_id,
-                tooltip=plans_tooltip,
-                url=paths.BLENDERKIT_PLANS_URL,
+
+        # Special pricing display for addons
+        if self.asset_data.get("assetType") == "addon":
+            from . import asset_bar_op
+
+            can_download = self.asset_data.get("canDownload")
+            is_free = self.asset_data.get("isFree")
+
+            # Get pricing info from extensions cache
+            is_for_sale, base_price = asset_bar_op.get_addon_pricing_data(
+                self.asset_data
             )
+
+            if self.asset_data["isPrivate"]:
+                t = "Private"
+                self.draw_property(box, "Access", t, icon="LOCKED")
+            elif is_for_sale and not can_download and base_price:
+                t = f"${base_price} (Not purchased)"
+                icon = pcoll["full"]
+                self.draw_property(
+                    box,
+                    "Price",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip="This addon is for sale but you haven't purchased it yet",
+                )
+            elif is_for_sale and can_download and base_price:
+                t = f"${base_price} (Purchased)"
+                icon = pcoll["full"]
+                self.draw_property(
+                    box,
+                    "Price",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip="You have purchased this addon",
+                )
+            elif not is_free and not is_for_sale:
+                t = "Full plan required"
+                icon = pcoll["full"]
+                self.draw_property(
+                    box,
+                    "Access",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip=plans_tooltip,
+                    url=paths.BLENDERKIT_PLANS_URL,
+                )
+            else:
+                t = "Free"
+                icon = pcoll["free"]
+                self.draw_property(
+                    box,
+                    "Access",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip="This addon is free to use",
+                )
+
+            # Display Blender version requirements for addons
+            dict_params = self.asset_data.get("dictParameters", {})
+            min_version = dict_params.get("blenderVersionMin")
+            max_version = dict_params.get("blenderVersionMax")
+
+            if min_version or max_version:
+                version_text = ""
+                if min_version and max_version:
+                    version_text = f"{min_version} - {max_version}"
+                elif min_version:
+                    version_text = f"{min_version}+"
+                elif max_version:
+                    version_text = f"≤ {max_version}"
+
+                # Check if current Blender version is compatible
+                current_version = (
+                    f"{bpy.app.version[0]}.{bpy.app.version[1]}.{bpy.app.version[2]}"
+                )
+                is_compatible = True
+
+                if min_version:
+                    try:
+                        current_tuple = tuple(map(int, current_version.split(".")))
+                        min_tuple = tuple(map(int, min_version.split(".")))
+                        if current_tuple < min_tuple:
+                            is_compatible = False
+                    except (ValueError, AttributeError):
+                        pass  # If version parsing fails, assume compatible
+
+                if max_version and is_compatible:
+                    try:
+                        current_tuple = tuple(map(int, current_version.split(".")))
+                        max_tuple = tuple(map(int, max_version.split(".")))
+                        if current_tuple > max_tuple:
+                            is_compatible = False
+                    except (ValueError, AttributeError):
+                        pass  # If version parsing fails, assume compatible
+
+                # Display version requirement with appropriate warning
+                if not is_compatible:
+                    box.alert = True
+                    self.draw_property(
+                        box,
+                        "Blender versions",
+                        f"{version_text} (Incompatible!)",
+                        icon="ERROR",
+                        tooltip=f"This addon requires Blender {version_text}, but you're using {current_version}",
+                    )
+                    box.alert = False
+                else:
+                    self.draw_property(
+                        box,
+                        "Blender versions",
+                        version_text,
+                        icon="CHECKMARK",
+                        tooltip=f"This addon is compatible with your Blender version ({current_version})",
+                    )
         else:
-            t = "Full plan"
-            icon = pcoll["full"]
-            self.draw_property(
-                box,
-                "Access",
-                t,
-                icon_value=icon.icon_id,
-                tooltip=plans_tooltip,
-                url=paths.BLENDERKIT_PLANS_URL,
-            )
+            # Regular asset access display
+            if self.asset_data["isPrivate"]:
+                t = "Private"
+                self.draw_property(box, "Access", t, icon="LOCKED")
+            elif self.asset_data["isFree"]:
+                t = "Free plan"
+                icon = pcoll["free"]
+                self.draw_property(
+                    box,
+                    "Access",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip=plans_tooltip,
+                    url=paths.BLENDERKIT_PLANS_URL,
+                )
+            else:
+                t = "Full plan"
+                icon = pcoll["full"]
+                self.draw_property(
+                    box,
+                    "Access",
+                    t,
+                    icon_value=icon.icon_id,
+                    tooltip=plans_tooltip,
+                    url=paths.BLENDERKIT_PLANS_URL,
+                )
 
         if utils.profile_is_validator():
             date = self.asset_data["created"][:10]
@@ -3184,8 +3357,12 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
         left_column = split_left.column()
         self.draw_thumbnail_box(left_column, width=int(self.width * split_ratio))
 
-        if not utils.user_is_owner(asset_data=self.asset_data):
+        if (
+            not utils.user_is_owner(asset_data=self.asset_data)
+            and self.asset_data.get("assetType") != "addon"
+        ):
             # Draw ratings, but not for owners of assets - doesn't make sense.
+            # also addons are now disabled until we figure out how to handle them.
             ratings_box = left_column.box()
             self.prefill_ratings()
             ratings.draw_ratings_menu(self, context, ratings_box)
@@ -3659,6 +3836,7 @@ def header_search_draw(self, context):
         "HDR": wm.blenderkit_HDR,
         "SCENE": wm.blenderkit_scene,
         "NODEGROUP": wm.blenderkit_nodegroup,
+        "ADDON": wm.blenderkit_addon,
     }
     props = props_dict[ui_props.asset_type]
     pcoll = icons.icon_collections["main"]
@@ -3672,6 +3850,7 @@ def header_search_draw(self, context):
         "HDR": "WORLD",
         "SCENE": "SCENE_DATA",
         "NODEGROUP": "NODETREE",
+        "ADDON": "PLUGIN",
     }
 
     asset_type_icon = icons_dict[ui_props.asset_type]
@@ -3806,6 +3985,12 @@ def header_search_draw(self, context):
     elif ui_props.asset_type == "NODEGROUP":
         layout.popover(
             panel="VIEW3D_PT_blenderkit_advanced_nodegroup_search",
+            text="",
+            icon_value=icon_id,
+        )
+    elif ui_props.asset_type == "ADDON":
+        layout.popover(
+            panel="VIEW3D_PT_blenderkit_advanced_addon_search",
             text="",
             icon_value=icon_id,
         )
@@ -4044,6 +4229,7 @@ classes = (
     VIEW3D_PT_blenderkit_advanced_HDR_search,
     VIEW3D_PT_blenderkit_advanced_brush_search,
     VIEW3D_PT_blenderkit_advanced_nodegroup_search,
+    VIEW3D_PT_blenderkit_advanced_addon_search,
     VIEW3D_PT_blenderkit_advanced_printable_search,
     VIEW3D_PT_blenderkit_categories,
     VIEW3D_PT_blenderkit_import_settings,

--- a/utils.py
+++ b/utils.py
@@ -304,6 +304,11 @@ def get_search_props():
         if not hasattr(wm, "blenderkit_nodegroup"):
             return
         props = wm.blenderkit_nodegroup
+
+    if uiprops.asset_type == "ADDON":
+        if not hasattr(wm, "blenderkit_addon"):
+            return
+        props = wm.blenderkit_addon
     return props
 
 
@@ -357,6 +362,8 @@ def get_active_asset():
         return get_active_brush()
     elif ui_props.asset_type == "NODEGROUP":
         return get_active_nodegroup()
+    elif ui_props.asset_type == "ADDON":
+        return None  # Addons don't have an active asset concept
 
     return None
 
@@ -394,6 +401,8 @@ def get_upload_props():
         b = get_active_nodegroup()
         if b is not None:
             return b.blenderkit
+    elif ui_props.asset_type == "ADDON":
+        return None  # Addons don't have upload props
     return None
 
 
@@ -1189,6 +1198,9 @@ def user_is_owner(asset_data: Optional[dict] = None) -> bool:
 
 def asset_from_newer_blender_version(asset_data, blender_version=None):
     """Check if asset is from a newer blender version, to avoid incompatibility. Give info if difference is in major, minor or patch version."""
+    # addons don't have a blender version, so we return False
+    if asset_data["assetType"] == "addon":
+        return False, ""
     asset_ver = asset_data["sourceAppVersion"].split(".")
     if blender_version is None:
         blender_version = bpy.app.version


### PR DESCRIPTION

- added Add-ons to asset types inside BlenderKit search/download 

- Introduced `BlenderKitAddonSearchProps` for managing addon search options.
- Added functionality to install, enable, and disable addons through the new `BlenderkitAddonManagerOperator`.
- Implemented pricing information display for addons, including handling for free and paid statuses.
- Updated UI panels and search functionalities to support addon-specific features, including filtering installed addons.
- Added temporary enabling of addons for session-based management.