### PR TITLE
Support zip files with dependency packing

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -2477,12 +2477,13 @@ func PackBlendFile(data AssetUploadRequestData, metadata AssetsCreateResponse, i
 		}
 
 		if filetype == "MAINFILE" {
-			file := UploadFile{
-				Type:     "blend",
-				Index:    0,
-				FilePath: fpath,
+			// Prefer uploading the exact archive if created; otherwise fallback to .blend
+			zipPath := filepath.Join(export_data.TempDir, upload_data.AssetBaseID+".zip")
+			if exists, _, _ := FileExists(zipPath); exists {
+				files = append(files, UploadFile{Type: "zip_file", Index: 0, FilePath: zipPath})
+			} else {
+				files = append(files, UploadFile{Type: "blend", Index: 0, FilePath: fpath})
 			}
-			files = append(files, file)
 			continue
 		}
 	}

--- a/download.py
+++ b/download.py
@@ -1339,7 +1339,7 @@ def available_resolutions_callback(self, context):
 def has_asset_files(asset_data):
     """Check if asset has files."""
     for f in asset_data["files"]:
-        if f["fileType"] == "blend":
+        if f["fileType"] in ("blend", "zip_file"):
             return True
     return False
 

--- a/paths.py
+++ b/paths.py
@@ -273,6 +273,7 @@ def get_res_file(asset_data, resolution, find_closest_with_url=False):
         resolution, so that other processess can pass correctly which resolution is downloaded.
     """
     orig = None
+    zipf = None
     res = None
     closest = None
     target_resolution = resolutions.get(resolution)
@@ -284,6 +285,8 @@ def get_res_file(asset_data, resolution, find_closest_with_url=False):
             if resolution == "blend":
                 # orig file found, return.
                 return orig, "blend"
+        if f.get("fileType") == "zip_file":
+            zipf = f
 
         if f["fileType"] == resolution:
             # exact match found, return.
@@ -296,7 +299,10 @@ def get_res_file(asset_data, resolution, find_closest_with_url=False):
                 closest = f
                 mindist = rdiff
     if not res and not closest:
-        return orig, "blend"
+        if orig is not None:
+            return orig, "blend"
+        if zipf is not None:
+            return zipf, "zip_file"
     return closest, closest["fileType"]
 
 


### PR DESCRIPTION
 - in download and upload processes.

 This is mainly useful to be able to share simulations with caches, but should be extendible to video textures and similar types of stuff that can't be packed into .blend files.


This patch needs some changes on the server - to be able to accept .zip file as main file and finish upload. That's why you get an error message now after upload of a simulation, but after reindexing in elastic search and download of such asset works. 