### PR TITLE
Try to fix #522 - drawing and timers interference

### DIFF
--- a/append_link.py
+++ b/append_link.py
@@ -575,15 +575,7 @@ def append_objects(
                 if layer_collection:
                     bpy.context.view_layer.active_layer_collection = layer_collection  # type: ignore[union-attr]
 
-        try:
-            bpy.ops.object.select_all(action="DESELECT")
-        except Exception as e:
-            reports.add_report(
-                f"append_objects.1: {str(e)}",
-                3,
-                type="ERROR",
-            )
-            raise e
+        bpy.ops.object.select_all(action="DESELECT")
 
         path = file_name + "/Collection"
         collection_name = kwargs.get("name")
@@ -669,15 +661,7 @@ def append_objects(
                 utils.exclude_collection(hide_collection.name)
                 hidden_collections.append(hide_collection)
 
-        try:
-            bpy.ops.object.select_all(action="DESELECT")
-        except Exception as e:
-            reports.add_report(
-                f"append_objects.2: {str(e)}",
-                3,
-                type="ERROR",
-            )
-            raise e
+        bpy.ops.object.select_all(action="DESELECT")
 
         # Restore original active collection
         if orig_active_collection:
@@ -705,15 +689,7 @@ def append_objects(
     # link them to scene
     scene = bpy.context.scene
     sel = utils.selection_get()
-    try:
-        bpy.ops.object.select_all(action="DESELECT")
-    except Exception as e:
-        reports.add_report(
-            f"append_objects.3: {str(e)}",
-            3,
-            type="ERROR",
-        )
-        raise e
+    bpy.ops.object.select_all(action="DESELECT")
 
     return_obs = []  # this might not be needed, but better be sure to rewrite the list.
     main_object = None
@@ -747,15 +723,7 @@ def append_objects(
         main_object.parent = bpy.data.objects[parent]  # type: ignore[union-attr]
         main_object.matrix_world.translation = location  # type: ignore[union-attr]
 
-    try:
-        bpy.ops.object.select_all(action="DESELECT")
-    except Exception as e:
-        reports.add_report(
-            f"append_objects.4: {str(e)}",
-            3,
-            type="ERROR",
-        )
-        raise e
+    bpy.ops.object.select_all(action="DESELECT")
     utils.selection_set(sel)
 
     return main_object, return_obs

--- a/tasks_queue.py
+++ b/tasks_queue.py
@@ -85,6 +85,8 @@ def add_task(
 # @bpy.app.handlers.persistent
 def queue_worker():
     # utils.p('start queue worker timer')
+    if utils.is_context_restricted():
+        return 0.3
 
     # bk_logger.debug('timer queue worker')
     time_step = 0.3

--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,7 @@ import platform
 import re
 import shutil
 import sys
+import time
 import uuid
 from typing import Optional
 
@@ -1533,3 +1534,25 @@ class BlenderkitAppendException(BlenderkitException):
     """Exception raised when an append or link of the asset fails."""
 
     pass
+
+
+def is_context_restricted() -> bool:
+    """Return True if Blender currently blocks data modifications (e.g. drawing/rendering/modal state).
+    Detect by attempting a no-op assignment on an always-present datablock (scene name).
+    """
+    # let's measure the time it takes to execute this
+    start_time = time.time()
+    try:
+
+        bpy.context.scene.name += "1"
+        bpy.context.scene.name = bpy.context.scene.name[:-1]
+        end_time = time.time()
+        # bk_logger.debug(
+        #     f"Context is not restricted. Time taken: {end_time - start_time} seconds"
+        # )
+        return False
+    except Exception as e:
+        # bk_logger.debug(f"Exception in is_context_restricted: {str(e)}")
+        end_time = time.time()
+        # bk_logger.debug(f"Time taken: {end_time - start_time} seconds")
+        return True


### PR DESCRIPTION
This attempt on fixing tests the context before doing any of the operations that involve changing blender data, and adding random offsets to timers (which strangely seems to work a bit better). Still, there are errors that clearly stem from bad internal timing of blender's processes, because any operator in a chain of operators can cause the error even after context was already tested and accessible in the same function run.