### PR TITLE
Fix #1701 #1702 Take empty upload Name from active object name

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1062,9 +1062,7 @@ def name_update(props, context=None):
     Checks for name change, because it decides if whole asset has to be re-uploaded. Name is stored in the blend file
     and that's the reason.
     """
-    scene = bpy.context.scene
     ui_props = bpy.context.window_manager.blenderkitUI
-
     # props = get_upload_props()
     if props.name_old != props.name:
         props.name_changed = True
@@ -1074,16 +1072,23 @@ def name_update(props, context=None):
 
         if nname.isupper():
             nname = nname.lower()
-        nname = nname[0].upper() + nname[1:]
-        props.name = nname
+        if nname != "":
+            nname = nname[0].upper() + nname[1:]
+        props.name = (
+            nname  # this recursively triggers the name_update() again, so we return
+        )
+        return
         # here we need to fix the name for blender data = ' or " give problems in path evaluation down the road.
     fname = props.name
     fname = fname.replace("'", "")
     fname = fname.replace('"', "")
-    asset = get_active_asset()
-    if ui_props.asset_type != "HDR":
-        # Here we actually rename assets datablocks, but don't do that with HDR's and possibly with others
-        asset.name = fname
+    if ui_props.asset_type == "HDR" or fname == "":
+        bk_logger.info(f"Skiping the rename")
+        return  # don't rename HDR's or with empty name
+    else:
+        asset = get_active_asset()
+        if asset.name != fname:  # Here we actually rename assets datablocks
+            asset.name = fname  # change name of active object to upload Name
 
 
 def fmt_dimensions(p):


### PR DESCRIPTION
fixes #1701
fixes #1702

- prefill the upload's name with the name of the active object
- prevent bug of renaming of active object to Object when upload name is set to empty string or whitespaces
- prevent duplicite run of utils.name_update()

V draw upload panely checkuju, jestli Name uploadu nahodou neni prazdny, v takovej moment volam timer (abych nezapisoval do datablocku z draw funkce) a v tom timeru potom zmenim ten samotnej name uploadu. Kdyztak prosim zkontroluj, jestli to dava smysl. @vilemduha 