### PR TITLE
New button to expand assetbar.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2220,11 +2220,11 @@ In this case you should also set path to your system CA bundle containing proxy'
         update=utils.save_prefs,
     )
 
-    max_assetbar_rows: IntProperty(
+    maximized_assetbar_rows: IntProperty(
         name="Maximized Assetbar Rows",
         description="Maximum rows of assetbar in the 3D view when expanded",
         default=4,
-        min=1,
+        min=2,
         max=20,
         update=utils.save_prefs,
     )
@@ -2379,7 +2379,7 @@ In this case you should also set path to your system CA bundle containing proxy'
         gui_settings.label(text="GUI settings")
         gui_settings.prop(self, "show_on_start")
         gui_settings.prop(self, "thumb_size")
-        gui_settings.prop(self, "max_assetbar_rows")
+        gui_settings.prop(self, "maximized_assetbar_rows")
         gui_settings.prop(self, "search_field_width")
         gui_settings.prop(self, "search_in_header")
         gui_settings.prop(self, "sidebar_panels")

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -118,7 +118,7 @@ def modal_inside(self, context, event):
             # doesn't run that often.
             # Calculate current max rows based on expanded state
             if user_preferences.assetbar_expanded:
-                current_max_rows = user_preferences.max_assetbar_rows
+                current_max_rows = user_preferences.maximized_assetbar_rows
             else:
                 current_max_rows = 1
 
@@ -752,7 +752,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.max_hcount = math.floor(
             max(region.width, context.window.width) / self.button_size
         )
-        self.max_wcount = user_preferences.max_assetbar_rows
+        self.max_wcount = user_preferences.maximized_assetbar_rows
 
         history_step = search.get_active_history_step()
         search_results = history_step.get("search_results")
@@ -760,7 +760,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         # Calculate hcount based on expanded state
         if search_results is not None and self.wcount > 0:
             if user_preferences.assetbar_expanded:
-                max_rows = user_preferences.max_assetbar_rows
+                max_rows = user_preferences.maximized_assetbar_rows
             else:
                 max_rows = 1
             self.hcount = min(

--- a/datas.py
+++ b/datas.py
@@ -27,7 +27,7 @@ class Prefs:
     unpack_files: bool
     show_on_start: bool
     thumb_size: int
-    max_assetbar_rows: int
+    maximized_assetbar_rows: int
     search_field_width: int
     search_in_header: bool
     tips_on_start: bool

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -106,8 +106,8 @@ def load_preferences_from_JSON():
         "show_on_start", user_preferences.show_on_start
     )
     user_preferences.thumb_size = prefs.get("thumb_size", user_preferences.thumb_size)
-    user_preferences.max_assetbar_rows = prefs.get(
-        "max_assetbar_rows", user_preferences.max_assetbar_rows
+    user_preferences.maximized_assetbar_rows = prefs.get(
+        "maximized_assetbar_rows", user_preferences.maximized_assetbar_rows
     )
     user_preferences.search_field_width = prefs.get(
         "search_field_width", user_preferences.search_field_width

--- a/search.py
+++ b/search.py
@@ -1121,7 +1121,7 @@ def search(get_next=False, query=None, author_id=""):
 
     active_history_step["is_searching"] = True
 
-    page_size = min(40, ui_props.wcount * user_preferences.max_assetbar_rows + 5)
+    page_size = min(40, ui_props.wcount * user_preferences.maximized_assetbar_rows + 5)
 
     next_url = ""
     if get_next and active_history_step.get("search_results_orig"):

--- a/test_init.py
+++ b/test_init.py
@@ -71,7 +71,7 @@ class Test01Registration(unittest.TestCase):
             # GUI
             "show_on_start": user_preferences.show_on_start,
             "thumb_size": user_preferences.thumb_size,
-            "max_assetbar_rows": user_preferences.max_assetbar_rows,
+            "maximized_assetbar_rows": user_preferences.maximized_assetbar_rows,
             "search_field_width": user_preferences.search_field_width,
             "search_in_header": user_preferences.search_in_header,
             "tips_on_start": user_preferences.tips_on_start,

--- a/utils.py
+++ b/utils.py
@@ -449,7 +449,7 @@ def get_preferences_as_dict():
         # GUI
         "show_on_start": user_preferences.show_on_start,
         "thumb_size": user_preferences.thumb_size,
-        "max_assetbar_rows": user_preferences.max_assetbar_rows,
+        "maximized_assetbar_rows": user_preferences.maximized_assetbar_rows,
         "search_field_width": user_preferences.search_field_width,
         "search_in_header": user_preferences.search_in_header,
         "tips_on_start": user_preferences.tips_on_start,
@@ -500,7 +500,7 @@ def get_preferences() -> datas.Prefs:
         # GUI
         show_on_start=user_preferences.show_on_start,  # type: ignore[union-attr]
         thumb_size=user_preferences.thumb_size,  # type: ignore[union-attr]
-        max_assetbar_rows=user_preferences.max_assetbar_rows,  # type: ignore[union-attr]
+        maximized_assetbar_rows=user_preferences.maximized_assetbar_rows,  # type: ignore[union-attr]
         search_field_width=user_preferences.search_field_width,  # type: ignore[union-attr]
         search_in_header=user_preferences.search_in_header,  # type: ignore[union-attr]
         tips_on_start=user_preferences.tips_on_start,  # type: ignore[union-attr]


### PR DESCRIPTION
This replaces the old max assetbar rows setting, and users can expand/retract assetbar as needed to the height that is still set in the settings.