### PR TITLE
Fix #1717 scene.world.use_nodes was removed in Blender 5.0

### DIFF
--- a/append_link.py
+++ b/append_link.py
@@ -341,15 +341,18 @@ def hdr_swap(name, hdr):
     :return: None
     """
     w = bpy.context.scene.world
-    if w:
+    if not w:
+        new_hdr_world(name, hdr)
+
+    if bpy.app.version < (5, 0, 0):
         w.use_nodes = True
-        w.name = name
-        nt = w.node_tree
-        for n in nt.nodes:
-            if "ShaderNodeTexEnvironment" == n.bl_rna.identifier:
-                env_node = n
-                env_node.image = hdr
-                return
+    w.name = name
+    nt = w.node_tree
+    for n in nt.nodes:
+        if "ShaderNodeTexEnvironment" == n.bl_rna.identifier:
+            env_node = n
+            env_node.image = hdr
+            return
     new_hdr_world(name, hdr)
 
 
@@ -361,7 +364,8 @@ def new_hdr_world(name, hdr):
     :return: None
     """
     w = bpy.data.worlds.new(name=name)
-    w.use_nodes = True
+    if bpy.app.version < (5, 0, 0):
+        w.use_nodes = True
     bpy.context.scene.world = w
 
     nt = w.node_tree

--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -1132,6 +1132,7 @@ class AssetDragOperator(bpy.types.Operator):
 
                 active_material = active_object.active_material
                 # Use active material
+                # TODO: material.use_nodes is expected to be removed in Blender 6.0
                 if not active_material.use_nodes:
                     active_material.use_nodes = True
                 node_tree = active_material.node_tree
@@ -1140,6 +1141,8 @@ class AssetDragOperator(bpy.types.Operator):
                 node_space.spaces[0].node_tree = node_tree
 
             # Fourth case: need to switch to compositor nodes for compositor nodegroup
+            # TODO: scene.use_nodes was removed in Blender 5
+            # TODO: scene.node_tree was removed in Blender 5, use scene.compositing_node_group instead
             elif nodegroup_type == "compositor":
 
                 # Try to find the compositor node tree


### PR DESCRIPTION
fixes #1717

skips fix to compositor nodes because AFAIU it cannot be tested right now - compositor nodes cannot be uploaded so they also cannot be downloaded