### PR TITLE
Implement #1677 Add 'Sort by:' to search filters

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -380,6 +380,61 @@ class BlenderKitUIProps(PropertyGroup):
         max=10,
         update=search.search_update_delayed,
     )
+    search_order_by: EnumProperty(
+        name="Order",
+        description="Order the search results",
+        items=(
+            (
+                "default",
+                "Default",
+                "Sets the sorting algorithm dynamically based on the context of other search filters. This is the default behaviour well known from BlenderKit 3.16.1 and less.",
+            ),
+            ("-created", "Newest", "Sort the results from newest to oldest."),
+            ("created", "Oldest", "Sort the results from oldest to newest."),
+            (
+                "-bookmarks",
+                "▼ Bookmarks",
+                "Sort the results from most bookmarked to least.",
+            ),
+            (
+                "bookmarks",
+                "▲ Bookmarks",
+                "Sort the results from least bookmarked to most.",
+            ),
+            (
+                "-score",
+                "▼ Score",
+                "Sort the results from highest asset score to lowest.",
+            ),
+            (
+                "score",
+                "▲ Score",
+                "Sort the results from lowest asset score to highest.",
+            ),
+            (
+                "-working_hours",
+                "▼ Complexity",
+                "Sort the results from most complex to lest.",
+            ),
+            (
+                "working_hours",
+                "▲ Complexity",
+                "Sort the results from least complex to most.",
+            ),
+            (
+                "-quality",
+                "▼ Quality",
+                "Sort the results from highest quality rating to lowest.",
+            ),
+            (
+                "quality",
+                "▲ Quality",
+                "Sort the results from lowest quality rating to highest.",
+            ),
+        ),
+        default="default",
+        update=search.search_update,
+    )
     search_license: EnumProperty(
         name="License",
         items=(

--- a/__init__.py
+++ b/__init__.py
@@ -382,54 +382,54 @@ class BlenderKitUIProps(PropertyGroup):
     )
     search_order_by: EnumProperty(
         name="Order",
-        description="Order the search results",
+        description="Search result order",
         items=(
             (
                 "default",
                 "Default",
-                "Sets the sorting algorithm dynamically based on the context of other search filters. This is the default behaviour well known from BlenderKit 3.16.1 and less.",
+                "By default, the sorting algorithm changes dynamically based on search filters.",
             ),
-            ("-created", "Newest", "Sort the results from newest to oldest."),
-            ("created", "Oldest", "Sort the results from oldest to newest."),
+            ("-created", "Newest", "Sort results from newest to oldest."),
+            ("created", "Oldest", "Sort results from oldest to newest."),
             (
                 "-bookmarks",
                 "▼ Bookmarks",
-                "Sort the results from most bookmarked to least.",
+                "Sort results from most bookmarked to least.",
             ),
             (
                 "bookmarks",
                 "▲ Bookmarks",
-                "Sort the results from least bookmarked to most.",
+                "Sort results from least bookmarked to most.",
             ),
             (
                 "-score",
                 "▼ Score",
-                "Sort the results from highest asset score to lowest.",
+                "Sort results from highest asset score to the lowest.",
             ),
             (
                 "score",
                 "▲ Score",
-                "Sort the results from lowest asset score to highest.",
+                "Sort results from lowest asset score to the highest.",
             ),
             (
                 "-working_hours",
                 "▼ Complexity",
-                "Sort the results from most complex to lest.",
+                "Sort results from most complex to the least.",
             ),
             (
                 "working_hours",
                 "▲ Complexity",
-                "Sort the results from least complex to most.",
+                "Sort results from least complex to the most.",
             ),
             (
                 "-quality",
                 "▼ Quality",
-                "Sort the results from highest quality rating to lowest.",
+                "Sort results from highest quality rating to the lowest.",
             ),
             (
                 "quality",
                 "▲ Quality",
-                "Sort the results from lowest quality rating to highest.",
+                "Sort results from lowest quality rating to the highest.",
             ),
         ),
         default="default",

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -271,6 +271,7 @@ def draw_common_filters(layout, ui_props):
     layout.prop(ui_props, "free_only")
     layout.prop(ui_props, "quality_limit", slider=True)
     layout.prop(ui_props, "search_license")
+    layout.prop(ui_props, "search_order_by")
 
 
 def draw_thumbnail_upload_panel(layout, props):
@@ -1395,6 +1396,9 @@ class VIEW3D_PT_blenderkit_advanced_model_search(Panel):
         # NSFW filter
         layout.prop(preferences, "nsfw_filter")
 
+        # ORDER
+        layout.prop(ui_props, "search_order_by")
+
     def draw(self, context):
         self.draw_layout(self.layout)
 
@@ -1453,6 +1457,9 @@ class VIEW3D_PT_blenderkit_advanced_material_search(Panel):
             row.prop(props, "search_file_size_max", text="Max")
         layout.prop(ui_props, "quality_limit", slider=True)
         layout.prop(ui_props, "search_license")
+
+        # ORDER
+        layout.prop(ui_props, "search_order_by")
 
     def draw(self, context):
         self.draw_layout(self.layout)
@@ -3791,7 +3798,7 @@ def header_search_draw(self, context):
         icon_value=icon_id,
     )
 
-    # FILTER ICON
+    # FILTER ICON: filters are default or modified
     if props.use_filters:
         icon_id = pcoll["filter_active"].icon_id
     else:


### PR DESCRIPTION
fixes #1677

- keeps current 'dynamic' and somehow smart sorting as the default
- adds sorting by created, bookmarks, score, complexity, quality

<img width="737" height="720" alt="Screenshot 2025-09-24 at 15 52 30" src="https://github.com/user-attachments/assets/2483949a-836d-47af-bed7-7543973f9e49" />

<img width="737" height="720" alt="Screenshot 2025-09-24 at 15 52 40" src="https://github.com/user-attachments/assets/f105aa21-71a6-4dd2-9049-d1552f924278" />

