### PR TITLE
Fix #1765 Assets without any files are filtered out from the search results

### DIFF
--- a/search.py
+++ b/search.py
@@ -180,7 +180,8 @@ def check_clipboard():
 # TODO: type annotate and check this crazy function!
 # Are we sure it behaves correctly on network issues, malfunctioning search etc?
 def parse_result(r) -> dict:
-    """Needed to generate some extra data in the result(by now)
+    """Parse search result into an asset_data by tweaking some of its parameters.
+    We need to generate some extra data in the result (for now).
     Parameters
     ----------
     r - search result, also called asset_data
@@ -195,10 +196,6 @@ def parse_result(r) -> dict:
         utils.p("asset with no files-size")
 
     asset_type = r["assetType"]
-    # TODO remove this condition so all assets are parsed?
-    if len(r["files"]) == 0:
-        return {}
-
     adata = r["author"]
     social_networks = datas.parse_social_networks(adata.pop("socialNetworks", []))
     author = datas.UserProfile(**adata, socialNetworks=social_networks)


### PR DESCRIPTION
fixes #1765

- as requested by the team, lets add these assets without files to search results
- there is meaningful error message when user tries to download the asset


Funnily enough this is not some recent bug, but a feature which is in the add-on since its first commit [BlenderKit initial commit.](https://github.com/BlenderKit/BlenderKit/commit/99da040edfa5dfa542cceb1809409e985118b8c0) by @vilemduha on 29th March 2019.

Here it is: https://github.com/BlenderKit/BlenderKit/blob/99da040edfa5dfa542cceb1809409e985118b8c0/search.py#L135-L143.