### PR TITLE
Fix #1747 visualise invalid drop

### DIFF
--- a/ui_bgl.py
+++ b/ui_bgl.py
@@ -193,6 +193,31 @@ def draw_rect(x, y, width, height, color):
     batch.draw(shader)
 
 
+def draw_rect_outline(x, y, width, height, color, line_width=1.0):
+    """Used for drawing 2D rectangle outlines."""
+    xmax = x + width
+    ymax = y + height
+    coords = (
+        (x, y),  # (x, y)
+        (x, ymax),  # (x, y)
+        (xmax, ymax),  # (x, y)
+        (xmax, y),  # (x, y)
+    )
+    indices = ((0, 1), (1, 2), (2, 3), (3, 0))
+
+    if app.version < (4, 0, 0):
+        shader = gpu.shader.from_builtin("2D_UNIFORM_COLOR")
+    else:
+        shader = gpu.shader.from_builtin("UNIFORM_COLOR")
+    batch = batch_for_shader(shader, "LINES", {"pos": coords}, indices=indices)
+
+    gpu.state.blend_set("ALPHA")
+    gpu.state.line_width_set(line_width)
+    shader.bind()
+    shader.uniform_float("color", color)
+    batch.draw(shader)
+
+
 def draw_line2d(x1, y1, x2, y2, width, color):
     """Used for drawing line from dragged thumbnail to the 3D bounding box."""
     coords = ((x1, y1), (x2, y2))


### PR DESCRIPTION
fixes #1747 

Optimized way to show invalid drops.

no functional code changes to"rules" or other parts

<img width="715" height="495" alt="Image" src="https://github.com/user-attachments/assets/1a043378-40fe-4a6e-9c4b-c8b904bb7123" />

<img width="577" height="339" alt="Image" src="https://github.com/user-attachments/assets/0c232810-63bc-495d-9491-7a8ebb2a6590" />
