### PR TITLE
Fix outliner drag drop:

### DIFF
--- a/asset_drag_op.py
+++ b/asset_drag_op.py
@@ -1514,7 +1514,7 @@ class AssetDragOperator(bpy.types.Operator):
         orig_active_object = active_object
         orig_active_collection = view_layer.active_layer_collection
 
-        
+        selected_element = None
         if bpy.app.version > (3, 1, 9):
             # doesn't make sense for lower versions, we wouldn't get the selected_ids anyway.
             #  Simply drops into active_layer_collection in prehistoric Blender.
@@ -1533,10 +1533,11 @@ class AssetDragOperator(bpy.types.Operator):
                 )
 
                 # Get the newly selected element using selected_ids
-                selected_element = None
-                if hasattr(bpy.context, "selected_ids") and len(bpy.context.selected_ids) > 0:
+                if (
+                    hasattr(bpy.context, "selected_ids")
+                    and len(bpy.context.selected_ids) > 0
+                ):
                     selected_element = bpy.context.selected_ids[0]
-                    
 
         if selected_element is None and hasattr(view_layer, "active_layer_collection"):
             alc = view_layer.active_layer_collection


### PR DESCRIPTION
Because of wrong context, only objects were detected, now it detects all collections/ again. There probably disappeared some indentation in some of the merges.

Also blender 3.1 and lower won't have better outliner drop, because of worse context override possibilities.