### PR TITLE
fix #1819 and same-name issue

### DIFF
--- a/append_link.py
+++ b/append_link.py
@@ -42,6 +42,7 @@ def find_layer_collection(layer_collection, collection_name):
 
 def append_brush(file_name, brushname=None, link=False, fake_user=True):
     """append a brush"""
+    brushes_before = bpy.data.brushes[:]
     with bpy.data.libraries.load(file_name, link=link, relative=True) as (
         data_from,
         data_to,
@@ -50,7 +51,10 @@ def append_brush(file_name, brushname=None, link=False, fake_user=True):
             if m == brushname or brushname is None:
                 data_to.brushes = [m]
                 brushname = m
-    brush = bpy.data.brushes[brushname]
+    for b in bpy.data.brushes:
+        if b not in brushes_before:
+            brush = b
+            break
     brush.use_fake_user = fake_user
     return brush
 

--- a/download.py
+++ b/download.py
@@ -877,8 +877,13 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
             if asset_blender_version < (4, 3, 0) and bpy.app.version >= (4, 3, 0):
                 brush.asset_clear()
                 brush.asset_mark()
-            brush.icon_filepath = asset_thumb_path
-
+            if bpy.app.version <= (4, 5, 0):
+                brush.icon_filepath = asset_thumb_path
+            else:
+                # load asset thumbnail into brush if it's not already present
+                if brush.preview is None:
+                    with bpy.context.temp_override(id=brush):
+                        bpy.ops.ed.lib_id_load_custom_preview(filepath=asset_thumb_path)
         # set the brush active
         if bpy.context.view_layer.objects.active.mode == "SCULPT":
             if bpy.app.version < (4, 3, 0):
@@ -897,7 +902,6 @@ def append_asset(asset_data, **kwargs):  # downloaders=[], location=None,
                     relative_asset_identifier=f"Brush{os.sep}{brush.name}"
                 )
         # TODO add grease pencil brushes!
-
         # bpy.context.tool_settings.image_paint.brush = brush
         asset_main = brush
 


### PR DESCRIPTION
previews were not loaded correclty for brushes
brushes with same names wouldn't be appended correclty (append link returned same-name brush already in scene instead of the new one which got a .00x name from blender)