### PR TITLE
Fix Fedora 43 bug by adding workaround for KeyError in make_annotations

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -97,7 +97,13 @@ def make_annotations(cls):
     if bl_props:
         if "__annotations__" not in cls.__dict__:
             setattr(cls, "__annotations__", {})
-        annotations = cls.__dict__["__annotations__"]
+
+        try:
+            annotations = cls.__dict__["__annotations__"]
+        except KeyError:
+            # Fedora 43 bug workaround #1823
+            annotations = getattr(cls, "__annotations__")
+
         for k, v in bl_props.items():
             annotations[k] = v
             delattr(cls, k)


### PR DESCRIPTION
Simple workaround for failing systems.
we still do not know why this happens.
But maybe some systems are hardened and prevent these data access methods
