### PR TITLE
FIX: UI scaled by 2x on MacOS

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1190,12 +1190,6 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
     def get_ui_scale(self):
         """Get the UI scale"""
         ui_scale = bpy.context.preferences.view.ui_scale
-        pixel_size = bpy.context.preferences.system.pixel_size
-        if pixel_size > 1:
-            # for a reason unknown,
-            #  the pixel size is modified only on mac
-            # where pixel size is 2.0
-            ui_scale = pixel_size
         return ui_scale
 
     def update_assetbar_sizes(self, context):


### PR DESCRIPTION
The reason pixel size = 2 is because on Apple Retina displays, the physical pixels are much smaller and more numerous, but the OS pretends they’re grouped into bigger “virtual” pixels so things on screen stay about the same apparent size.

Since Blender already handles UI scaling behind the scenes, using a ui_scale of 1 works just fine on MacOS.

Commit `f61f7b9c776918ee47bf4adfaa9634a9cfb9a4d8` attempted to compensate for this manually by setting UI scaling to pixel size:
```
        pixel_size = bpy.context.preferences.system.pixel_size
        if pixel_size > 1:
            # for a reason unknown,
            #  the pixel size is modified only on mac
            # where pixel size is 2.0
            ui_scale = pixel_size
```
but this was unnecessary and caused the UI to be scaled up 2x, highlighted in this [bug](https://github.com/BlenderKit/BlenderKit/issues/1868)
Reverting this change change fixes the issue.
