### PR TITLE
Add asset bar follow cursor preference

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2117,6 +2117,12 @@ class BlenderKitAddonPreferences(AddonPreferences):
         default=True,
     )
 
+    assetbar_follows_cursor: BoolProperty(
+        name="Assetbar follows active viewport",
+        description="Make the assetbar follow the cursor across the screen",
+        default=False,
+    )
+
     global_dir: StringProperty(
         name="Global Directory",
         description="Global storage for your assets, will use subdirectories for the contents. Client will place its files in subdirectory 'client'",
@@ -2533,6 +2539,7 @@ In this case you should also set path to your system CA bundle containing proxy'
         gui_settings.prop(self, "show_VIEW3D_MT_blenderkit_model_properties")
         gui_settings.prop(self, "tips_on_start")
         gui_settings.prop(self, "announcements_on_start")
+        gui_settings.prop(self, "assetbar_follows_cursor")
         gui_settings.prop(self, "use_clipboard_scan")
 
         # NETWORKING SETTINGS

--- a/__init__.py
+++ b/__init__.py
@@ -2558,7 +2558,7 @@ In this case you should also set path to your system CA bundle containing proxy'
             experimental_settings.alignment = "EXPAND"
             experimental_settings.label(text="Experimental settings")
             experimental_settings.prop(self, "ignore_env_for_thumbnails")
-            experimental_settings.prop(self, "enable_wire_thumbnail_upload")
+            # experimental_settings.prop(self, "enable_wire_thumbnail_upload")
 
         # RUNTIME INFO
         globdir_op = layout.operator(

--- a/autothumb_model_bg.py
+++ b/autothumb_model_bg.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 import json
 import math
 import os
-import random
-import colorsys
 import sys
 from traceback import print_exc
 from typing import Any, Union
@@ -158,7 +156,7 @@ def replace_materials(
     return material
 
 
-def _str_to_color(s: str) -> tuple[float, float, float] | None:
+def _str_to_color(s: str) -> Union[tuple[float, float, float], None]:
     """Convert a color string to an RGB tuple.
 
     Args:

--- a/client_lib.py
+++ b/client_lib.py
@@ -25,7 +25,7 @@ import platform
 import shutil
 import subprocess
 from os import path
-from typing import Optional
+from typing import Optional, Union
 from http.client import responses as http_responses
 
 
@@ -359,7 +359,7 @@ def get_rating(asset_id: str):
         )
 
 
-def send_rating(asset_id: str, rating_type: str, rating_value: str | int):
+def send_rating(asset_id: str, rating_type: str, rating_value: Union[str, int]):
     data = {
         "asset_id": asset_id,
         "rating_type": rating_type,

--- a/datas.py
+++ b/datas.py
@@ -32,6 +32,7 @@ class Prefs:
     search_in_header: bool
     tips_on_start: bool
     announcements_on_start: bool
+    assetbar_follows_cursor: bool
     client_port: str
     ip_version: str
     ssl_context: str

--- a/download.py
+++ b/download.py
@@ -16,16 +16,16 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+from __future__ import annotations
+
 import addon_utils
 import copy
 import json
 import logging
 import os
 import shutil
-import tempfile
 import time
-import urllib.request
-
+from typing import Optional
 
 from . import (
     append_link,
@@ -1261,7 +1261,7 @@ def cancel_running_downloads(reason: str = ""):
 
 
 def prune_stalled_downloads(
-    max_idle_seconds: float = STALE_DOWNLOAD_TIMEOUT, now: float | None = None
+    max_idle_seconds: float = STALE_DOWNLOAD_TIMEOUT, now: Optional[float] = None
 ) -> None:
     """Cancel downloads that have not reported progress for too long."""
 

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -121,6 +121,9 @@ def load_preferences_from_JSON():
     user_preferences.announcements_on_start = prefs.get(
         "announcements_on_start", user_preferences.announcements_on_start
     )
+    user_preferences.assetbar_follows_cursor = prefs.get(
+        "assetbar_follows_cursor", user_preferences.assetbar_follows_cursor
+    )
 
     # NETWORK
     user_preferences.client_port = prefs.get(

--- a/test_init.py
+++ b/test_init.py
@@ -76,6 +76,7 @@ class Test01Registration(unittest.TestCase):
             "search_in_header": user_preferences.search_in_header,
             "tips_on_start": user_preferences.tips_on_start,
             "announcements_on_start": user_preferences.announcements_on_start,
+            "assetbar_follows_cursor": user_preferences.assetbar_follows_cursor,
             # NETWORK
             "client_port": user_preferences.client_port,
             "ip_version": user_preferences.ip_version,

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -343,6 +343,9 @@ def draw_panel_model_upload(self, context):
     # DISABLED WIRE THUMBNAIL FOR NOW
     # TODO: re-enable later, when the shaders are fixed for it.
     user_preferences = bpy.context.preferences.addons[__package__].preferences
+
+    # TODO: reenable in future
+    user_preferences.enable_wire_thumbnail_upload = False
     if user_preferences.enable_wire_thumbnail_upload:
         layout.prop(props, "wire_thumbnail_will_upload_on_website")
         if not props.wire_thumbnail_will_upload_on_website:
@@ -367,14 +370,16 @@ def draw_panel_model_upload(self, context):
     elif props.thumbnail_generating_state != "":
         utils.label_multiline(layout, text=props.thumbnail_generating_state)
 
-    if getattr(props, "is_generating_wire_thumbnail", False):
-        row = layout.row(align=True)
-        row.label(text=props.wire_thumbnail_generating_state)
-        op = row.operator("object.kill_bg_process", text="", icon="CANCEL")
-        op.process_source = asset_type
-        op.process_type = "THUMBNAILER"
-    elif getattr(props, "wire_thumbnail_generating_state", "") != "":
-        utils.label_multiline(layout, text=props.wire_thumbnail_generating_state)
+    # must be experimental feature enabled
+    if user_preferences.enable_wire_thumbnail_upload:
+        if getattr(props, "is_generating_wire_thumbnail", False):
+            row = layout.row(align=True)
+            row.label(text=props.wire_thumbnail_generating_state)
+            op = row.operator("object.kill_bg_process", text="", icon="CANCEL")
+            op.process_source = asset_type
+            op.process_type = "THUMBNAILER"
+        elif getattr(props, "wire_thumbnail_generating_state", "") != "":
+            utils.label_multiline(layout, text=props.wire_thumbnail_generating_state)
 
     # Only show these properties for MODEL type
     if asset_type == "MODEL":

--- a/utils.py
+++ b/utils.py
@@ -482,6 +482,7 @@ def get_preferences_as_dict():
         "search_in_header": user_preferences.search_in_header,
         "tips_on_start": user_preferences.tips_on_start,
         "announcements_on_start": user_preferences.announcements_on_start,
+        "assetbar_follows_cursor": user_preferences.assetbar_follows_cursor,
         # NETWORK
         "client_port": user_preferences.client_port,
         "ip_version": user_preferences.ip_version,
@@ -533,6 +534,7 @@ def get_preferences() -> datas.Prefs:
         search_in_header=user_preferences.search_in_header,  # type: ignore[union-attr]
         tips_on_start=user_preferences.tips_on_start,  # type: ignore[union-attr]
         announcements_on_start=user_preferences.announcements_on_start,  # type: ignore[union-attr]
+        assetbar_follows_cursor=user_preferences.assetbar_follows_cursor,  # type: ignore[union-attr]
         # NETWORK
         client_port=user_preferences.client_port,  # type: ignore[union-attr]
         ip_version=user_preferences.ip_version,  # type: ignore[union-attr]


### PR DESCRIPTION
- by default assetbar no longer follows mouse across viewports (old behavior)

- in quad view, assetbar is shown only perspective corner

<img width="3186" height="1968" alt="image" src="https://github.com/user-attachments/assets/96bb3372-7a8b-4e93-90a0-f6f1ee5d159e" />
