### PR TITLE
Fix #1885 Detect code signature even when the cert name, organization and region metadata are reordered

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -114,8 +114,14 @@ def verify_client_binaries(binaries_path: str):
             )
             output, error = process.communicate()
             # print(f"out:{output}, err:{error}")
-            expected = "Subject: /C=CZ/ST=Prague/L=Prague/O=Blender Kit s.r.o./CN=Blender Kit s.r.o."
-            if expected in str(output):
+            stdout = str(output)
+            if (
+                "CN=Blender Kit s.r.o." in stdout
+                and "O=Blender Kit s.r.o." in stdout
+                and "L=Prague" in stdout
+                and "ST=Prague" in stdout
+                and "C=CZ" in stdout
+            ):
                 print(f">>> OK!")
             elif expected in str(error):
                 print(f">>> WARNING")


### PR DESCRIPTION
fixes #1885