### PR TITLE
Separate thumbnail upload for brushes.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1207,6 +1207,15 @@ class BlenderKitHDRUploadProps(PropertyGroup, BlenderKitCommonUploadProps):
 
 
 class BlenderKitBrushUploadProps(PropertyGroup, BlenderKitCommonUploadProps):
+    thumbnail: StringProperty(
+        name="Thumbnail",
+        description="Thumbnail path - at least 1024x1024 .jpg or .png",
+        subtype="FILE_PATH",
+        default="",
+        update=autothumb.update_upload_brush_preview,
+        **EXTRA_PATH_OPTIONS,
+    )
+
     mode: EnumProperty(
         name="Mode",
         items=(

--- a/autothumb.py
+++ b/autothumb.py
@@ -178,7 +178,7 @@ def update_upload_brush_preview(self, context):
     brush = utils.get_active_brush()
     if brush is not None:
         props = brush.blenderkit
-        imgpath = bpy.path.abspath(brush.icon_filepath)
+        imgpath = props.thumbnail
         check_thumbnail(props, imgpath)
 
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1320,6 +1320,10 @@ def draw_panel_brush_upload(self, context):
 
         draw_upload_common(layout, props, "BRUSH", context)
 
+        col = layout.column()
+        draw_thumbnail_upload_panel(col, props)
+        prop_needed(col, props, "thumbnail", props.thumbnail)
+
 
 def draw_panel_brush_search(self, context):
     wm = context.window_manager

--- a/upload.py
+++ b/upload.py
@@ -199,7 +199,7 @@ def check_missing_data(asset_type, props, upload_set):
             )
 
     if "THUMBNAIL" in upload_set:
-        if asset_type in ("MODEL", "SCENE", "MATERIAL", "PRINTABLE"):
+        if asset_type in ("MODEL", "SCENE", "MATERIAL", "PRINTABLE", "BRUSH"):
             thumb_path = bpy.path.abspath(props.thumbnail)
             if props.thumbnail == "":
                 write_to_report(
@@ -213,23 +213,6 @@ def check_missing_data(asset_type, props, upload_set):
                     "Thumbnail filepath does not exist on the disk.\n"
                     "   Please check the filepath and try again.",
                 )
-
-        if asset_type == "BRUSH":
-            brush = utils.get_active_brush()
-            if brush is not None:
-                thumb_path = bpy.path.abspath(brush.icon_filepath)
-                if thumb_path == "":
-                    write_to_report(
-                        props,
-                        "Brush Icon Filepath has not been provided.\n"
-                        "   Please check Custom Icon option add a Brush Icon in JPG or PNG format, ensuring at least 1024x1024 pixels.",
-                    )
-                elif not os.path.exists(Path(thumb_path)):
-                    write_to_report(
-                        props,
-                        "Brush Icon Filepath does not exist on the disk.\n"
-                        "   Please check the filepath and try again.",
-                    )
     if "PHOTO_THUMBNAIL" in upload_set:  # for printable assets
         # Add validation for the photo thumbnail for printable assets
         # only if it's in the upload set
@@ -609,7 +592,7 @@ def get_upload_data(caller=None, context=None, asset_type=None):
         # props.name = brush.name
 
         export_data["brush"] = str(brush.name)
-        export_data["thumbnail_path"] = bpy.path.abspath(brush.icon_filepath)
+        export_data["thumbnail_path"] = bpy.path.abspath(props.thumbnail)
 
         eval_path_computing = "bpy.data.brushes['%s'].blenderkit.uploading" % brush.name
         eval_path_state = "bpy.data.brushes['%s'].blenderkit.upload_state" % brush.name


### PR DESCRIPTION
Uploading of brushes was broken since blender 5.0 because icon_filepath was dropped.