### PR TITLE
FIX - BBOX for printables download

### DIFF
--- a/asset_inspector.py
+++ b/asset_inspector.py
@@ -344,7 +344,7 @@ def check_meshprops(props, obs):
     props.manifold = manifold
 
 
-def countObs(props, obs):
+def count_objects(props, obs):
     ob_types = {}
     count = len(obs)
     for ob in obs:
@@ -425,7 +425,21 @@ def get_autotags():
         check_anim(props, obs)
         check_meshprops(props, obs)
         check_modifiers(props, obs)
-        countObs(props, obs)
+        count_objects(props, obs)
+
+    elif ui.asset_type == "SCENE":
+        scene = bpy.context.scene
+        props = scene.blenderkit
+        if props.name == "":
+            props.name = scene.name
+        dim, bbox_min, bbox_max = utils.get_scene_dimensions(scene)
+        props.dimensions = dim
+        props.bbox_min = bbox_min
+        props.bbox_max = bbox_max
+        scene_objects = list(scene.objects)
+        check_meshprops(props, scene_objects)
+        count_objects(props, scene_objects)
+
     elif ui.asset_type == "MATERIAL":
         # reset some properties here, because they might not get re-filled at all when they aren't needed anymore.
 
@@ -434,6 +448,7 @@ def get_autotags():
         props.texture_resolution_max = 0
         props.texture_resolution_min = 0
         check_material(props, mat)
+
     elif ui.asset_type == "HDR":
         # reset some properties here, because they might not get re-filled at all when they aren't needed anymore.
 

--- a/download.py
+++ b/download.py
@@ -1727,7 +1727,7 @@ def start_download(asset_data, **kwargs) -> bool:
         except Exception as e:
             bk_logger.info("Failed to append asset: %s, continuing with download", e)
 
-    if asset_data["assetType"] in ("model", "material", "printable"):
+    if asset_data["assetType"] in ("model", "material", "printable", "scene"):
         downloader = {
             "location": kwargs["model_location"],
             "rotation": kwargs["model_rotation"],

--- a/download.py
+++ b/download.py
@@ -1485,7 +1485,7 @@ def check_downloading(asset_data, **kwargs) -> bool:
         p_asset_data = task["asset_data"]
         if p_asset_data["id"] == asset_data["id"]:
             at = asset_data["assetType"]
-            if at in ("model", "material"):
+            if at in ("model", "material", "printable", "scene"):
                 downloader = {
                     "location": kwargs["model_location"],
                     "rotation": kwargs["model_rotation"],
@@ -1727,7 +1727,7 @@ def start_download(asset_data, **kwargs) -> bool:
         except Exception as e:
             bk_logger.info("Failed to append asset: %s, continuing with download", e)
 
-    if asset_data["assetType"] in ("model", "material"):
+    if asset_data["assetType"] in ("model", "material", "printable"):
         downloader = {
             "location": kwargs["model_location"],
             "rotation": kwargs["model_rotation"],

--- a/upload.py
+++ b/upload.py
@@ -517,9 +517,9 @@ def get_upload_data(caller=None, context=None, asset_type=None):
             "animated": props.animated,
             # "simulation": props.simulation,
             "purePbr": props.pbr,
-            "faceCount": 1,  # props.face_count,
-            "faceCountRender": 1,  # props.face_count_render,
-            "objectCount": 1,  # props.object_count,
+            "faceCount": max(0, props.face_count),
+            "faceCountRender": max(0, props.face_count_render),
+            "objectCount": max(0, props.object_count),
             # "scene": props.is_scene,
         }
         if props.use_design_year:
@@ -1375,6 +1375,7 @@ class UploadOperator(Operator):
             # add wire_thumbnail for models if it exists
             if (
                 self.asset_type in {"MODEL", "SCENE", "PRINTABLE"}
+                and hasattr(props, "wire_thumbnail")
                 and props.wire_thumbnail
             ):
                 upload_set.append("wire_thumbnail")

--- a/utils.py
+++ b/utils.py
@@ -1030,6 +1030,58 @@ def get_dimensions(obs):
     return dim, bbmin, bbmax
 
 
+def get_scene_dimensions(scene: bpy.types.Scene) -> tuple[Vector, Vector, Vector]:
+    """Calculate world-space bounds for the entire scene."""
+
+    minx = miny = minz = float("inf")
+    maxx = maxy = maxz = float("-inf")
+    has_geometry = False
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+
+    def accumulate(coord: Vector) -> None:
+        nonlocal minx, miny, minz, maxx, maxy, maxz, has_geometry
+        has_geometry = True
+        minx = min(minx, coord.x)
+        miny = min(miny, coord.y)
+        minz = min(minz, coord.z)
+        maxx = max(maxx, coord.x)
+        maxy = max(maxy, coord.y)
+        maxz = max(maxz, coord.z)
+
+    mesh_like_types = {"MESH", "CURVE", "SURFACE", "META", "FONT", "GPENCIL"}
+
+    for ob in scene.objects:
+        object_eval = ob.evaluated_get(depsgraph)
+        mw = object_eval.matrix_world
+
+        if ob.type in mesh_like_types:
+            to_mesh = getattr(object_eval, "to_mesh", None)
+            mesh = to_mesh() if callable(to_mesh) else None
+            if mesh:
+                for vert in mesh.vertices:
+                    accumulate(mw @ vert.co)
+            to_mesh_clear = getattr(object_eval, "to_mesh_clear", None)
+            if callable(to_mesh_clear):
+                to_mesh_clear()
+        elif ob.type == "VOLUME":
+            for corner in object_eval.bound_box:
+                accumulate(mw @ Vector(corner))
+        elif hasattr(object_eval, "bound_box") and object_eval.bound_box:
+            for corner in object_eval.bound_box:
+                accumulate(mw @ Vector(corner))
+        else:
+            accumulate(mw @ Vector((0.0, 0.0, 0.0)))
+
+    if not has_geometry:
+        zero = Vector((0.0, 0.0, 0.0))
+        return zero.copy(), zero.copy(), zero.copy()
+
+    bbmin = Vector((minx, miny, minz))
+    bbmax = Vector((maxx, maxy, maxz))
+    dim = Vector((maxx - minx, maxy - miny, maxz - minz))
+    return dim, bbmin, bbmax
+
+
 def get_simple_headers() -> dict[str, str]:
     headers = {
         "accept": "application/json",


### PR DESCRIPTION
- Renamed `countObs` to `count_objects` for clarity.
- Added scene dimension calculations in `get_autotags`.
- Updated download logic to include "printable" and "scene" asset types.
- Improved upload data retrieval to handle face and object counts correctly.
- Introduced `get_scene_dimensions` utility function for bounding box calculations.