### PR TITLE
FIX dark hdri thumbnails

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -624,6 +624,32 @@ class BlenderKitUIProps(PropertyGroup):
         name="Upload HDR", type=bpy.types.Image, description="Pick an image to upload"
     )
 
+    hdr_use_custom_thumbnail_tone: BoolProperty(
+        name="Use Custom Thumbnail Tone",
+        description="Use custom exposure and gamma for HDR thumbnail conversion",
+        default=False,
+    )
+
+    hdr_thumbnail_exposure: FloatProperty(
+        name="Thumbnail Exposure",
+        description="Exposure offset used only for HDR thumbnail conversion",
+        default=0.0,
+        min=-5.0,
+        max=5.0,
+        soft_min=-2.0,
+        soft_max=2.0,
+    )
+
+    hdr_thumbnail_gamma: FloatProperty(
+        name="Thumbnail Gamma",
+        description="Gamma used only for HDR thumbnail conversion",
+        default=1.0,
+        min=0.2,
+        max=3.0,
+        soft_min=0.7,
+        soft_max=1.6,
+    )
+
     nodegroup_upload: PointerProperty(
         name="Upload Tool",
         type=bpy.types.GeometryNodeTree,

--- a/client/download.go
+++ b/client/download.go
@@ -443,11 +443,13 @@ func UnpackAsset(
 	writeAssetMetadata bool,
 	//prefs PREFS,
 ) error {
-	if assetType == "hdr" && !writeAssetMetadata { // Skip unpacking for HDRi files unless metadata is requested
+	// Unpacking and metadata write require opening a .blend in background Blender.
+	// Skip safely for raw files (e.g. .hdr) to avoid startup/unpack errors.
+	if !strings.EqualFold(filepath.Ext(blendPath), ".blend") {
 		TaskMessageCh <- &TaskMessageUpdate{
 			AppID:   appID,
 			TaskID:  taskID,
-			Message: "HDRi file doesn't need unpacking",
+			Message: fmt.Sprintf("Skipping unpack: downloaded file is not a .blend (%s)", filepath.Ext(blendPath)),
 		}
 		return nil
 	}

--- a/image_utils.py
+++ b/image_utils.py
@@ -16,11 +16,11 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import os
-import time
-from functools import lru_cache
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
+import os
+import time
 
 import bpy
 
@@ -183,10 +183,94 @@ def analyze_image_is_true_hdr(image):
     image.blenderkit.true_hdr = numpy.amax(tempBuffer) > 1.05
 
 
-def generate_hdr_thumbnail():
+def _save_hdr_thumbnail_image(
+    hdr_image,
+    output_path: str,
+    max_thumbnail_size: int,
+    use_custom_tone: bool,
+    exposure: float,
+    gamma: float,
+):
     import numpy
 
-    scene = bpy.context.scene
+    image_width, image_height = hdr_image.size
+    ratio = image_width / image_height
+    thumbnail_width = min(image_width, max_thumbnail_size)
+    thumbnail_height = min(image_height, int(max_thumbnail_size / ratio))
+
+    # Read once so we can both detect HDR and safely create a scaled temp image.
+    pixel_count = image_width * image_height
+    pixel_buffer = numpy.empty(pixel_count * 4, dtype=numpy.float32)
+    hdr_image.pixels.foreach_get(pixel_buffer)
+    hdr_image.blenderkit.true_hdr = numpy.amax(pixel_buffer) > 1.05
+
+    source_image = hdr_image
+    temp_image = None
+
+    if thumbnail_width < image_width:
+        temp_name = f"{hdr_image.name}_thumb_tmp"
+        temp_image = bpy.data.images.new(
+            temp_name,
+            width=image_width,
+            height=image_height,
+            alpha=False,
+            float_buffer=True,
+        )
+        temp_image.pixels.foreach_set(pixel_buffer)
+        temp_image.scale(thumbnail_width, thumbnail_height)
+        source_image = temp_image
+
+    try:
+        scene = bpy.context.scene
+        view_settings = scene.view_settings
+        orig_exposure = view_settings.exposure
+        orig_gamma = view_settings.gamma
+
+        try:
+            if use_custom_tone:
+                view_settings.exposure = exposure
+                view_settings.gamma = gamma
+
+            img_save_as(
+                source_image,
+                filepath=output_path,
+                view_transform="Standard",
+            )
+        finally:
+            view_settings.exposure = orig_exposure
+            view_settings.gamma = orig_gamma
+    finally:
+        if temp_image is not None:
+            bpy.data.images.remove(temp_image)
+
+
+def generate_hdr_thumbnail_preview(
+    hdr_image,
+    use_custom_tone: bool,
+    exposure: float,
+    gamma: float,
+    max_preview_size: int = 256,
+) -> str:
+    from . import paths
+
+    safe_name = "".join(
+        c if c.isalnum() or c in ("-", "_", ".") else "_" for c in hdr_image.name
+    )
+    preview_dir = paths.get_temp_dir(subdir="hdr_thumbnail_preview")
+    preview_path = os.path.join(preview_dir, f"{safe_name}_preview.jpg")
+
+    _save_hdr_thumbnail_image(
+        hdr_image=hdr_image,
+        output_path=preview_path,
+        max_thumbnail_size=max_preview_size,
+        use_custom_tone=use_custom_tone,
+        exposure=exposure,
+        gamma=gamma,
+    )
+    return preview_path
+
+
+def generate_hdr_thumbnail():
     ui_props = bpy.context.window_manager.blenderkitUI
     hdr_image = (
         ui_props.hdr_upload_image
@@ -194,35 +278,14 @@ def generate_hdr_thumbnail():
 
     base, ext = os.path.splitext(hdr_image.filepath)
     thumb_path = base + ".jpg"
-    thumb_name = os.path.basename(thumb_path)
-
-    max_thumbnail_size = 2048
-    size = hdr_image.size
-    ratio = size[0] / size[1]
-
-    imageWidth = size[0]
-    imageHeight = size[1]
-    thumbnailWidth = min(size[0], max_thumbnail_size)
-    thumbnailHeight = min(size[1], int(max_thumbnail_size / ratio))
-
-    tempBuffer = numpy.empty(imageWidth * imageHeight * 4, dtype=numpy.float32)
-    inew = bpy.data.images.new(
-        thumb_name, imageWidth, imageHeight, alpha=False, float_buffer=False
+    _save_hdr_thumbnail_image(
+        hdr_image=hdr_image,
+        output_path=thumb_path,
+        max_thumbnail_size=2048,
+        use_custom_tone=ui_props.hdr_use_custom_thumbnail_tone,
+        exposure=ui_props.hdr_thumbnail_exposure,
+        gamma=ui_props.hdr_thumbnail_gamma,
     )
-
-    hdr_image.pixels.foreach_get(tempBuffer)
-
-    hdr_image.blenderkit.true_hdr = numpy.amax(tempBuffer) > 1.05
-
-    inew.filepath = thumb_path
-    set_colorspace(inew, "Linear")
-    inew.pixels.foreach_set(tempBuffer)
-
-    bpy.context.view_layer.update()
-    if thumbnailWidth < imageWidth:
-        inew.scale(thumbnailWidth, thumbnailHeight)
-
-    img_save_as(inew, filepath=inew.filepath)
 
 
 def find_color_mode(image):

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -41,6 +41,7 @@ from . import (
     download,
     global_vars,
     icons,
+    image_utils,
     keymap_utils,
     paths,
     ratings,
@@ -290,6 +291,10 @@ def draw_panel_hdr_upload(self, context):
     ui_props = bpy.context.window_manager.blenderkitUI
 
     layout.prop(ui_props, "hdr_upload_image")
+
+    tone_box = layout.box()
+    tone_box.label(text="Thumbnail Conversion", icon="IMAGE_RGB")
+    tone_box.prop(ui_props, "hdr_use_custom_thumbnail_tone")
 
     hdr = utils.get_active_HDR()
 
@@ -2221,6 +2226,166 @@ class OpenTempDirectory(OpenSystemDirectory):
 
     bl_idname = "wm.blenderkit_open_temp_directory"
     bl_label = "Open temp directory"
+
+
+class BLENDERKIT_OT_hdr_thumbnail_tune(bpy.types.Operator):
+    """Edit HDR thumbnail conversion settings with live preview."""
+
+    bl_idname = "wm.blenderkit_hdr_thumbnail_tune"
+    bl_label = "Edit Thumbnail Before Upload"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    use_custom_tone: bpy.props.BoolProperty(  # type: ignore[valid-type]
+        name="Use Custom Thumbnail Tone",
+        default=False,
+    )
+    exposure: bpy.props.FloatProperty(  # type: ignore[valid-type]
+        name="Exposure",
+        default=0.0,
+        min=-5.0,
+        max=5.0,
+        soft_min=-2.0,
+        soft_max=2.0,
+        precision=3,
+        step=1,
+    )
+    gamma: bpy.props.FloatProperty(  # type: ignore[valid-type]
+        name="Gamma",
+        default=1.0,
+        min=0.2,
+        max=3.0,
+        soft_min=0.7,
+        soft_max=1.6,
+        precision=3,
+        step=1,
+    )
+
+    _preview_image_prefix = "blenderkit_hdr_thumbnail_preview_"
+    _created_preview_names: set[str] = set()
+    preview_image_name: bpy.props.StringProperty(  # type: ignore[valid-type]
+        name="Preview Image Name",
+        default="",
+        options={"SKIP_SAVE", "HIDDEN"},
+    )
+    _preview_error = ""
+
+    trigger_upload: bpy.props.BoolProperty(  # type: ignore[valid-type]
+        name="Trigger Upload",
+        default=False,
+        options={"SKIP_SAVE"},
+    )
+    upload_reupload: bpy.props.BoolProperty(  # type: ignore[valid-type]
+        name="Reupload",
+        default=False,
+        options={"SKIP_SAVE"},
+    )
+
+    @classmethod
+    def poll(cls, context):
+        ui_props = context.window_manager.blenderkitUI
+        return ui_props.hdr_upload_image is not None
+
+    def _cleanup_preview_image(self):
+        # Cleanup only images created by this operator instance.
+        for name in list(self._created_preview_names):
+            img = bpy.data.images.get(name)
+            if img is None:
+                self._created_preview_names.discard(name)
+                continue
+            try:
+                bpy.data.images.remove(img)
+            except Exception:
+                pass
+            self._created_preview_names.discard(name)
+
+    def _refresh_preview(self, context):
+        ui_props = context.window_manager.blenderkitUI
+        hdr_image = ui_props.hdr_upload_image
+        if hdr_image is None:
+            return
+        self._preview_error = ""
+        try:
+            preview_path = image_utils.generate_hdr_thumbnail_preview(
+                hdr_image=hdr_image,
+                use_custom_tone=self.use_custom_tone,
+                exposure=self.exposure,
+                gamma=self.gamma,
+                max_preview_size=512,
+            )
+            preview_image = bpy.data.images.load(preview_path, check_existing=False)
+            preview_image.name = f"{self._preview_image_prefix}{time.time_ns()}"
+            preview_image.reload()
+            if hasattr(preview_image, "preview"):
+                preview_image.preview_ensure()
+            self.preview_image_name = preview_image.name
+            self._created_preview_names.add(preview_image.name)
+        except Exception as e:
+            self.preview_image_name = ""
+            self._preview_error = str(e)
+
+        # Force dialog refresh in Blender 3.x/4.x where icon updates can lag.
+        if context.area is not None:
+            context.area.tag_redraw()
+
+    def check(self, context):
+        self._refresh_preview(context)
+        return True
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "use_custom_tone")
+        col = layout.column(align=True)
+        col.enabled = self.use_custom_tone
+        col.prop(self, "exposure")
+        col.prop(self, "gamma")
+
+        preview_box = layout.box()
+        preview_box.label(text="Thumbnail Preview (live)", icon="IMAGE_DATA")
+
+        preview_image = bpy.data.images.get(self.preview_image_name)
+        if preview_image is not None:
+            # Use preview icon rendering for reliable display in popup dialogs.
+            if hasattr(preview_image, "preview"):
+                preview_image.preview_ensure()
+                preview_box.template_icon(
+                    icon_value=preview_image.preview.icon_id,
+                    scale=14,
+                )
+        elif self._preview_error:
+            preview_box.label(
+                text=f"Preview failed: {self._preview_error}", icon="ERROR"
+            )
+        else:
+            preview_box.label(text="Preparing preview...", icon="TIME")
+
+    def invoke(self, context, event):
+        ui_props = context.window_manager.blenderkitUI
+        self._cleanup_preview_image()
+        self.preview_image_name = ""
+        self.use_custom_tone = ui_props.hdr_use_custom_thumbnail_tone
+        self.exposure = ui_props.hdr_thumbnail_exposure
+        self.gamma = ui_props.hdr_thumbnail_gamma
+        self._refresh_preview(context)
+        return context.window_manager.invoke_props_dialog(self, width=560)
+
+    def execute(self, context):
+        ui_props = context.window_manager.blenderkitUI
+        ui_props.hdr_use_custom_thumbnail_tone = self.use_custom_tone
+        ui_props.hdr_thumbnail_exposure = self.exposure
+        ui_props.hdr_thumbnail_gamma = self.gamma
+        self._cleanup_preview_image()
+
+        if self.trigger_upload:
+            bpy.ops.object.blenderkit_upload(
+                "INVOKE_DEFAULT",
+                asset_type="HDR",
+                reupload=self.upload_reupload,
+                skip_hdr_tune_popup=True,
+            )
+        return {"FINISHED"}
+
+    def cancel(self, context):
+        self._cleanup_preview_image()
 
 
 def draw_asset_context_menu(
@@ -4528,6 +4693,7 @@ class NodegroupDropDialog(bpy.types.Operator):
 
 
 classes = (
+    BLENDERKIT_OT_hdr_thumbnail_tune,
     BLENDERKIT_OT_show_validation_popup,
     SetCategoryOperatorOrigin,
     SetCategoryOperator,

--- a/upload.py
+++ b/upload.py
@@ -1257,9 +1257,10 @@ def apply_asset_preview(data_block, props) -> None:
     If that fails, it falls back to generating a preview within Blender."""
     if data_block is None:
         return
-    if not props.thumbnail:
+    thumbnail = getattr(props, "thumbnail", "")
+    if not thumbnail:
         return
-    thmb_path = bpy.path.abspath(props.thumbnail)
+    thmb_path = bpy.path.abspath(thumbnail)
     if not os.path.exists(thmb_path):
         return
     if thmb_path:
@@ -1324,7 +1325,7 @@ def prepare_asset_data(self, context, asset_type, reupload, upload_set):
         return False, None, None
 
     ensure_asset_metadata_on_datablock(asset_type, props)
-    apply_asset_preview(asset_type, props)
+    apply_asset_preview(_get_upload_datablock(asset_type), props)
 
     if not reupload:
         props.asset_base_id = ""
@@ -1434,6 +1435,12 @@ class UploadOperator(Operator):
     wire_thumbnail: BoolProperty(name="wire thumbnail", default=False, options={"SKIP_SAVE"})  # type: ignore[valid-type]
 
     main_file: BoolProperty(name="main file", default=False, options={"SKIP_SAVE"})  # type: ignore[valid-type]
+
+    skip_hdr_tune_popup: BoolProperty(  # type: ignore[valid-type]
+        name="Skip HDR tune popup",
+        default=False,
+        options={"SKIP_SAVE", "HIDDEN"},
+    )
 
     @classmethod
     def poll(cls, context):
@@ -1581,6 +1588,20 @@ class UploadOperator(Operator):
         if not utils.user_logged_in():
             ui_panels.draw_not_logged_in(
                 self, message="To upload assets you need to login/signup."
+            )
+            return {"CANCELLED"}
+
+        ui_props = bpy.context.window_manager.blenderkitUI
+
+        if (
+            self.asset_type == "HDR"
+            and ui_props.hdr_use_custom_thumbnail_tone
+            and not self.skip_hdr_tune_popup
+        ):
+            bpy.ops.wm.blenderkit_hdr_thumbnail_tune(
+                "INVOKE_DEFAULT",
+                trigger_upload=True,
+                upload_reupload=self.reupload,
             )
             return {"CANCELLED"}
 


### PR DESCRIPTION
Default HDRI to thumbnail was optimized for better results.
Added HDR thumbnail customization options and preview functionality before upload.

- Introduced properties for custom thumbnail tone, exposure, and gamma in BlenderKit UI.
- Implemented a new operator for editing HDR thumbnail settings with live preview.
- Enhanced thumbnail generation logic to utilize custom settings.
- Updated upload process to trigger HDR thumbnail tuning when applicable.

<img width="1494" height="911" alt="image" src="https://github.com/user-attachments/assets/9bf1abd1-5780-4c4e-8d71-5b815f915a1d" />