### PR TITLE
Refactor search_by_author to use filter chip 

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -3531,21 +3531,34 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         history_step = search.get_active_history_step()
         sr = history_step.get("search_results", [])
         asset_data = sr[asset_index]
-        a = asset_data["author"]["id"]
-        if a is not None:
-            sprops = utils.get_search_props()
-            ui_props = bpy.context.window_manager.blenderkitUI
-            # if there is already an author id in the search keywords, remove it first, the author_id can be any so
-            # use regex to find it
-            # for validators, set verification status to ALL
-            if utils.profile_is_validator():
-                sprops.search_verification_status = "ALL"
-            ui_props.search_keywords = re.sub(
-                r"\+author_id:\d+", "", ui_props.search_keywords
-            )
-            ui_props.search_keywords += f"+author_id:{a}"
+        author_id = asset_data["author"]["id"]
+        if author_id is None:
+            return True
 
-            search.search()
+        # Resolve author name for the filter chip label
+        author_name = str(author_id)
+        author = global_vars.BKIT_AUTHORS.get(int(author_id))
+        if author:
+            full = f"{author.firstName} {author.lastName}".strip()
+            if full:
+                author_name = full
+
+        sprops = utils.get_search_props()
+        if utils.profile_is_validator():
+            sprops.search_verification_status = "ALL"
+
+        # Use filter system instead of embedding in keywords
+        search.set_active_filter(
+            term="author_id",
+            value=str(author_id),
+            label=author_name,
+            origin="data",
+        )
+        search.update_filters()
+        search.create_history_step(search.get_active_tab())
+        search.search()
+        self.update_ui_size(bpy.context)
+        self.scroll_update(always=True)
         return True
 
     def search_similar(self, asset_index):

--- a/search.py
+++ b/search.py
@@ -2169,15 +2169,13 @@ def update_tab_name(active_tab):
 
     # Update tab name based on search or category
     search_keywords = ui_state.get("ui_props", {}).get("search_keywords", "").strip()
-    # if there's author_id let's get the author's name from db of authors
-    # we need to get the number after +author_id:
-    author_id = re.search(r"\+author_id:(\d+)", search_keywords)
+    # Check active filters for author_id
     author_name = None
-    if author_id is not None:
-        author_id = author_id.group(1)
-        author = global_vars.BKIT_AUTHORS.get(int(author_id))
-        if author:
-            author_name = author.fullName
+    active_filters = ui_state.get("active_filters", [])
+    for flt in active_filters:
+        if flt.get("term") == "author_id":
+            author_name = flt.get("label")
+            break
 
     search_category = (
         ui_state.get("search_props", {}).get("search_category", "").strip()


### PR DESCRIPTION
Refactor search_by_author to use filter chip  instead of embedding in keywords

Author search now uses the active filter system (set_active_filter) to display the author's name as a removable chip on the asset bar, instead of injecting +author_id: into search_keywords. Tab naming also reads from active filters.