### PR TITLE
feat: Add system_id to OAuth login URL

### DIFF
--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -23,6 +23,7 @@ import random
 import secrets
 import string
 import time
+import uuid
 from urllib.parse import quote as urlquote
 from webbrowser import open_new_tab
 
@@ -39,6 +40,7 @@ from . import (
     tasks_queue,
     utils,
 )
+
 
 if bpy.app.version >= (4, 2, 0):
     from . import override_extension_draw
@@ -138,7 +140,12 @@ def login(signup: bool) -> None:
     code_verifier, code_challenge = generate_pkce_pair()
     state = secrets.token_urlsafe()
     client_lib.send_oauth_verification_data(code_verifier, state)
-    authorize_url = f"/o/authorize?client_id={CLIENT_ID}&response_type=code&state={state}&redirect_uri={redirect_URI}&code_challenge={code_challenge}&code_challenge_method=S256"
+    system_id = get_system_id()
+    authorize_url = (
+        f"/o/authorize?client_id={CLIENT_ID}&response_type=code&state={state}"
+        f"&redirect_uri={redirect_URI}&code_challenge={code_challenge}"
+        f"&code_challenge_method=S256&system_id={system_id}"
+    )
     if signup:
         authorize_url = urlquote(authorize_url)
         authorize_url = f"{global_vars.SERVER}/accounts/register/?next={authorize_url}"
@@ -159,6 +166,10 @@ def generate_pkce_pair() -> tuple[str, str]:
     b64 = base64.urlsafe_b64encode(code_sha_256)
     code_challenge = b64.decode("utf-8").replace("=", "")
     return code_verifier, code_challenge
+
+
+def get_system_id() -> str:
+    return f"{uuid.getnode():015d}"
 
 
 def write_tokens(auth_token, refresh_token, oauth_response):

--- a/tests/test_bkit_oauth.py
+++ b/tests/test_bkit_oauth.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest import mock
+from urllib.parse import parse_qs, unquote, urlsplit
+
+import bpy
+
+
+for addon in bpy.context.preferences.addons:
+    if "blenderkit" in addon.module:
+        __package__ = addon.module
+        break
+from . import bkit_oauth, global_vars
+
+
+class TestOAuthLoginURL(unittest.TestCase):
+    def test_get_system_id_zero_pads_uuid_node(self):
+        with mock.patch.object(bkit_oauth.uuid, "getnode", return_value=123):
+            self.assertEqual(bkit_oauth.get_system_id(), "000000000000123")
+
+    def test_login_adds_system_id_to_authorize_url(self):
+        with (
+            mock.patch.object(global_vars, "SERVER", "https://example.com"),
+            mock.patch.object(bkit_oauth.client_lib, "get_port", return_value="12345"),
+            mock.patch.object(
+                bkit_oauth, "generate_pkce_pair", return_value=("verifier", "challenge")
+            ),
+            mock.patch.object(
+                bkit_oauth.secrets, "token_urlsafe", return_value="state-token"
+            ),
+            mock.patch.object(
+                bkit_oauth, "get_system_id", return_value="000000000000123"
+            ),
+            mock.patch.object(bkit_oauth.client_lib, "send_oauth_verification_data"),
+            mock.patch.object(
+                bkit_oauth, "open_new_tab", return_value=True
+            ) as open_new_tab,
+        ):
+            bkit_oauth.login(signup=False)
+
+        authorize_url = open_new_tab.call_args.args[0]
+        parsed = urlsplit(authorize_url)
+        query = parse_qs(parsed.query)
+
+        self.assertEqual(authorize_url.split("?")[0], "https://example.com/o/authorize")
+        self.assertEqual(query["client_id"], [bkit_oauth.CLIENT_ID])
+        self.assertEqual(query["response_type"], ["code"])
+        self.assertEqual(query["state"], ["state-token"])
+        self.assertEqual(
+            query["redirect_uri"], ["http://localhost:12345/consumer/exchange/"]
+        )
+        self.assertEqual(query["code_challenge"], ["challenge"])
+        self.assertEqual(query["code_challenge_method"], ["S256"])
+        self.assertEqual(query["system_id"], ["000000000000123"])
+
+    def test_signup_wraps_authorize_url_with_system_id(self):
+        with (
+            mock.patch.object(global_vars, "SERVER", "https://example.com"),
+            mock.patch.object(bkit_oauth.client_lib, "get_port", return_value="12345"),
+            mock.patch.object(
+                bkit_oauth, "generate_pkce_pair", return_value=("verifier", "challenge")
+            ),
+            mock.patch.object(
+                bkit_oauth.secrets, "token_urlsafe", return_value="state-token"
+            ),
+            mock.patch.object(
+                bkit_oauth, "get_system_id", return_value="000000000000123"
+            ),
+            mock.patch.object(bkit_oauth.client_lib, "send_oauth_verification_data"),
+            mock.patch.object(
+                bkit_oauth, "open_new_tab", return_value=True
+            ) as open_new_tab,
+        ):
+            bkit_oauth.login(signup=True)
+
+        signup_url = open_new_tab.call_args.args[0]
+        parsed_signup = urlsplit(signup_url)
+        signup_query = parse_qs(parsed_signup.query)
+        authorize_url = unquote(signup_query["next"][0])
+        parsed_authorize = urlsplit(authorize_url)
+        authorize_query = parse_qs(parsed_authorize.query)
+
+        self.assertEqual(
+            signup_url.split("?")[0], "https://example.com/accounts/register/"
+        )
+        self.assertEqual(parsed_authorize.path, "/o/authorize")
+        self.assertEqual(authorize_query["system_id"], ["000000000000123"])


### PR DESCRIPTION
Include the machine identifier in the authorize URL so the server can distinguish known devices from new ones before issuing tokens.

Made-with: Cursor