### PR TITLE
feat: Increase default thumbnail size 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -524,11 +524,11 @@ class BlenderKitUIProps(PropertyGroup):
 
     ui_scale = 1
 
-    thumb_size_def = 96
+    thumb_size_def = 128
     margin_def = 0
 
     thumb_size: IntProperty(
-        name="Thumbnail Size", default=thumb_size_def, min=1, max=256
+        name="Thumbnail Size", default=thumb_size_def, min=48, max=256
     )
 
     margin: IntProperty(name="Margin", default=margin_def, min=-1, max=256)
@@ -2467,8 +2467,8 @@ In this case you should also set path to your system CA bundle containing proxy'
 
     thumb_size: IntProperty(
         name="Assetbar Thumbnail Size",
-        default=96,
-        min=1,  # must newer be zero
+        default=128,
+        min=48,  # must newer be zero
         max=256,
         update=utils.save_prefs,
         description="Size of thumbnails of the assetbar in 3D view",


### PR DESCRIPTION
and adjust minimum size for asset bar thumbnails

default 128
range 48-256

Request by Alex Hapon