### PR TITLE
FIX: local asset library marking

### DIFF
--- a/ratings.py
+++ b/ratings.py
@@ -36,7 +36,6 @@ from . import (
     utils,
 )
 
-
 bk_logger = logging.getLogger(__name__)
 
 
@@ -170,7 +169,7 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         else:
             if bpy.context.view_layer.objects.active is not None:
                 ob = utils.get_active_model()
-                ad = ob.get("asset_data")
+                ad = utils.get_asset_data_from_ob(ob)
                 if ad:
                     self.asset_data = ad
                     self.asset_id = self.asset_data["id"]
@@ -330,7 +329,7 @@ class RatingStarWidget(Gizmo):
 
 
 def should_be_rated(ob) -> bool:
-    ad = ob.get("asset_data")
+    ad = utils.get_asset_data_from_ob(ob)
     if ad is None:
         return False
     rating = ratings_utils.get_rating_local(ad["id"])
@@ -361,7 +360,8 @@ class RatingStarWidgetGroup(GizmoGroup):
         ob = utils.get_active_model()
         gz = self.gizmos.new(RatingStarWidget.bl_idname)
         props = gz.target_set_operator("wm.blenderkit_menu_rating_upload")
-        props.asset_id = ob["asset_data"]["assetBaseId"]
+        ad = utils.get_asset_data_from_ob(ob)
+        props.asset_id = ad["assetBaseId"] if ad else ""
         gz.color = 0.5, 0.5, 0.0
         gz.alpha = 0.5
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -55,7 +55,6 @@ from . import (
     utils,
 )
 
-
 ACCEPTABLE_ENGINES = ("CYCLES", "BLENDER_EEVEE", "BLENDER_EEVEE_NEXT")
 
 bk_logger = logging.getLogger(__name__)
@@ -648,15 +647,14 @@ def draw_model_context_menu(self, context):
     o = utils.get_active_model()
     if not o:
         return
-    if o.get("asset_data") is None:
+    ad = utils.get_asset_data_from_ob(o)
+    if ad is None:
         utils.label_multiline(
             layout,
             text="To upload this asset to BlenderKit, go to the Find and Upload Assets panel.",
         )
         layout.prop(o, "name")
-
-    if o.get("asset_data") is not None:
-        ad = o["asset_data"]
+    else:
         layout.label(text=str(ad["name"]))
         if o.instance_type == "COLLECTION" and o.instance_collection is not None:
             layout.operator("object.blenderkit_bring_to_scene", text="Bring to scene")

--- a/unpack_asset_bg.py
+++ b/unpack_asset_bg.py
@@ -29,6 +29,26 @@ import logging
 import bpy
 
 bk_logger = logging.getLogger(__name__)
+
+_INT32_MIN = -2_147_483_648
+_INT32_MAX = 2_147_483_647
+
+
+def _sanitize_for_idprops(value):
+    """Recursively sanitize a value so it can be stored as a Blender IDProperty.
+    Large integers that would overflow int32 are converted to strings.
+    """
+    if isinstance(value, int):
+        if value < _INT32_MIN or value > _INT32_MAX:
+            return str(value)
+        return value
+    if isinstance(value, dict):
+        return {k: _sanitize_for_idprops(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_for_idprops(v) for v in value]
+    return value
+
+
 _ASSET_TYPE_DIRS = {
     "models",
     "materials",
@@ -566,11 +586,49 @@ def unpack_asset(data):
     print("🏷️  marking asset")
     data_block = None
     if asset_data["assetType"] in ("model", "printable"):
+        # Mark the main collection as the asset instead of the root object.
+        # When upload_bg.py prepares a model for upload it places ALL objects
+        # (including children) as direct members of a single named collection that
+        # is a direct child of the scene collection.  If we mark only the root
+        # object, Blender's asset browser will import just that one object and
+        # its children are left behind, resulting in an empty appearing in the
+        # scene.  Marking the collection lets Blender create a proper collection
+        # instance that shows every object in the hierarchy.
+        #
+        # upload_bg.py calls asset_mark() on the root object before uploading, so
+        # every downloaded .blend arrives with the root object already marked as an
+        # asset.  Clear those object-level marks first so only the collection entry
+        # appears in the asset browser (no duplicates).
         for ob in bpy.data.objects:
-            if ob.parent is None and ob in bpy.context.visible_objects:
-                if bpy.app.version >= (3, 0, 0):
-                    ob.asset_mark()
-                data_block = ob
+            if ob.asset_data is not None:
+                ob.asset_clear()
+
+        scene_collection = bpy.context.scene.collection
+        main_collection = None
+        for col in scene_collection.children:
+            has_root_objects = any(
+                ob.parent is None and ob in bpy.context.visible_objects
+                for ob in col.objects
+            )
+            if has_root_objects:
+                main_collection = col
+                break
+
+        if main_collection is not None:
+            if bpy.app.version >= (3, 0, 0):
+                main_collection.asset_mark()
+            # Store asset_data on the collection so that collection-instance
+            # EMPTYs added via Blender's native asset browser can be identified
+            # as BlenderKit assets (rating, bookmarking, etc.).
+            main_collection["asset_data"] = _sanitize_for_idprops(asset_data)
+            data_block = main_collection
+        else:
+            # Fallback: no suitable collection found – mark root visible objects.
+            for ob in bpy.data.objects:
+                if ob.parent is None and ob in bpy.context.visible_objects:
+                    if bpy.app.version >= (3, 0, 0):
+                        ob.asset_mark()
+                    data_block = ob
     elif asset_data["assetType"] == "material":
         for m in bpy.data.materials:
             if bpy.app.version >= (3, 0, 0):

--- a/utils.py
+++ b/utils.py
@@ -43,7 +43,6 @@ from . import (
     search,
 )
 
-
 bk_logger = logging.getLogger(__name__)
 
 ABOVE_NORMAL_PRIORITY_CLASS = 0x00008000
@@ -125,6 +124,24 @@ def selection_set(sel):
             ob.select_set(True)
     except Exception:
         bk_logger.exception("Failed to select objects:")
+
+
+def get_asset_data_from_ob(ob) -> Optional[dict]:
+    """Return the BlenderKit asset_data dict for an object.
+
+    Checks the object's own IDProperty first. When the object is a
+    collection-instance EMPTY (imported from a local asset library) it falls
+    back to the asset_data stored on the instanced collection, which
+    unpack_asset_bg.py writes there during local-library processing.
+    """
+    if ob is None:
+        return None
+    ad = ob.get("asset_data")
+    if ad is not None:
+        return ad
+    if ob.instance_collection is not None:
+        return ob.instance_collection.get("asset_data")
+    return None
 
 
 def get_active_model() -> Optional[bpy.types.Object]:


### PR DESCRIPTION
fixed marking of assets in library

(only empty was importing into the blender if asset was complex)


Right click menu now also works on assets imported from local library.


<img width="1664" height="1179" alt="image" src="https://github.com/user-attachments/assets/f6e671bc-033a-486e-8d54-2344e2384b09" />
