### PR TITLE
Enhance version compatibility warnings

### DIFF
--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -2778,7 +2778,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         self.scroll_offset = ui_props.scroll_offset
 
         self.text_color = (0.9, 0.9, 0.9, 1.0)
-        self.warning_color = (0.9, 0.5, 0.5, 1.0)
+        self.info_color = (0.6, 0.6, 0.6, 1.0)
+        self.caution_color = (0.7, 0.7, 0.5, 1.0)
+        self.warning_color = (0.9, 0.3, 0.3, 1.0)
 
         self.init_ui()
         self.init_tooltip()
@@ -3181,16 +3183,19 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 # preview comments for validators
                 self.update_comments_for_validators(asset_data)
 
-                from_newer, difference = utils.asset_from_newer_blender_version(
+                has_warning, difference = utils.asset_from_newer_blender_version(
                     asset_data
                 )
-                if from_newer:
-                    if difference == "major":
+                if has_warning:
+                    if difference in {"major_newer", "major_older"}:
                         self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}! Use at your own risk."
+                        self.version_warning.text_color = self.warning_color
                     elif difference == "minor":
-                        self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}! Caution advised."
+                        self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}. Caution advised."
+                        self.version_warning.text_color = self.caution_color
                     else:
-                        self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}! Some features may not work."
+                        self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}. Some features may not work."
+                        self.version_warning.text_color = self.info_color
                 else:
                     self.version_warning.text = ""
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -103,43 +103,55 @@ class TestUtilsRemoveUrlProtocol(unittest.TestCase):
 
 
 class TestAssetFromNewerBlenderVersion(unittest.TestCase):
-    def test_older_asset(self):
+    def test_older_major_asset(self):
         asset = {"assetType": "model", "sourceAppVersion": "3.6.0"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertFalse(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
+        self.assertTrue(has_warning)
+        self.assertEqual(level, "major_older")
+
+    def test_older_minor_asset(self):
+        asset = {"assetType": "model", "sourceAppVersion": "4.0.0"}
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 1, 0))
+        self.assertFalse(has_warning)
 
     def test_newer_major(self):
         asset = {"assetType": "model", "sourceAppVersion": "5.0.0"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertTrue(is_newer)
-        self.assertEqual(level, "major")
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
+        self.assertTrue(has_warning)
+        self.assertEqual(level, "major_newer")
 
     def test_newer_minor(self):
         asset = {"assetType": "model", "sourceAppVersion": "4.2.0"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 1, 0))
-        self.assertTrue(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 1, 0))
+        self.assertTrue(has_warning)
         self.assertEqual(level, "minor")
 
     def test_newer_patch(self):
         asset = {"assetType": "model", "sourceAppVersion": "4.0.3"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 2))
-        self.assertTrue(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 2))
+        self.assertTrue(has_warning)
         self.assertEqual(level, "patch")
 
     def test_same_version(self):
         asset = {"assetType": "model", "sourceAppVersion": "4.0.0"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertFalse(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
+        self.assertFalse(has_warning)
 
     def test_addon_type_always_false(self):
         asset = {"assetType": "addon", "sourceAppVersion": "99.0.0"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertFalse(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
+        self.assertFalse(has_warning)
 
     def test_short_version_string(self):
         asset = {"assetType": "model", "sourceAppVersion": "4"}
-        is_newer, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertFalse(is_newer)
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
+        self.assertFalse(has_warning)
+
+    def test_two_major_versions_older(self):
+        asset = {"assetType": "model", "sourceAppVersion": "2.93.0"}
+        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 2, 0))
+        self.assertTrue(has_warning)
+        self.assertEqual(level, "major_older")
 
 
 class TestAssetVersionAsTuple(unittest.TestCase):

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3390,12 +3390,16 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                 self.asset_data.get("dictParameters", {}).get("sexualizedContent"),
             )
 
-        from_newer, difference = utils.asset_from_newer_blender_version(self.asset_data)
-        if from_newer:
-            if difference == "major":
+        has_warning, difference = utils.asset_from_newer_blender_version(
+            self.asset_data
+        )
+        if has_warning:
+            if difference == "major_newer":
                 warning = (
                     f"{self.asset_data['sourceAppVersion']} - newer major version!"
                 )
+            elif difference == "major_older":
+                warning = f"{self.asset_data['sourceAppVersion']} - older major version, may be incompatible!"
             elif difference == "minor":
                 warning = (
                     f"{self.asset_data['sourceAppVersion']} - newer minor version!"

--- a/utils.py
+++ b/utils.py
@@ -1396,7 +1396,16 @@ def user_is_owner(asset_data: Optional[dict] = None) -> bool:
 
 
 def asset_from_newer_blender_version(asset_data, blender_version=None):
-    """Check if asset is from a newer blender version, to avoid incompatibility. Give info if difference is in major, minor or patch version."""
+    """Check asset vs Blender version compatibility. Warn on any major version
+    difference (per Blender compatibility docs) and on newer minor/patch versions.
+
+    Returns (needs_warning: bool, difference: str) where difference is one of:
+    - "major_newer": asset from a newer major version (high risk)
+    - "major_older": asset from an older major version (possible incompatibility)
+    - "minor": asset from a newer minor version within same major
+    - "patch": asset from a newer patch version within same major.minor
+    - "": no compatibility concern
+    """
     # addons don't have a blender version, so we return False
     if asset_data["assetType"] == "addon":
         return False, ""
@@ -1410,9 +1419,9 @@ def asset_from_newer_blender_version(asset_data, blender_version=None):
         asset_ver.append("0")
 
     if blender_version[0] < int(asset_ver[0]):
-        return True, "major"
+        return True, "major_newer"
     elif blender_version[0] > int(asset_ver[0]):
-        return False, ""
+        return True, "major_older"
 
     if blender_version[1] < int(asset_ver[1]):
         return True, "minor"


### PR DESCRIPTION
Display the asset origin version difference warning in more vivid way.

<img width="736" height="1011" alt="image" src="https://github.com/user-attachments/assets/e83f96d5-2c30-44e3-a661-266bf9212ae7" />

<img width="717" height="1009" alt="image" src="https://github.com/user-attachments/assets/29fbde96-4131-465c-a221-e746a4986957" />
