### PR TITLE
Fix: Write permission checks for blenderkit_data folder

### DIFF
--- a/client_lib.py
+++ b/client_lib.py
@@ -639,6 +639,7 @@ def start_blenderkit_client():
     1. Check if binary is available at global_dir/client/vX.Y.Z/blenderkit-client-<os>-<arch>(.exe)
     2. Copy the binary from add-on directory to global_dir/client/vX.Y.Z/
     3. Start the BlenderKit-Client process which serves as bridge between BlenderKit add-on and BlenderKit server.
+    Raises PermissionError if ensure_client_binary_installed fails due to write permissions.
     """
     ensure_client_binary_installed()
     log_path = get_client_log_path()
@@ -761,6 +762,7 @@ def ensure_client_binary_installed():
     """Ensure that the BlenderKit-Client binary is installed in global_dir/client/bin/vX.Y.Z.
     If not, copy the binary from the add-on directory blenderkit/client.
     As side effect, this function also creates the global_dir/client/bin/vX.Y.Z directory.
+    Raises PermissionError if the target directory is not writable.
     """
     client_binary_path, _ = get_client_binary_path()
     if path.exists(client_binary_path):
@@ -768,9 +770,19 @@ def ensure_client_binary_installed():
 
     preinstalled_client_path = get_preinstalled_client_path()
     bk_logger.info("Copying BlenderKit-Client binary %s", preinstalled_client_path)
-    os.makedirs(path.dirname(client_binary_path), exist_ok=True)
-    shutil.copy(preinstalled_client_path, client_binary_path)
-    os.chmod(client_binary_path, 0o711)
+    try:
+        os.makedirs(path.dirname(client_binary_path), exist_ok=True)
+        shutil.copy(preinstalled_client_path, client_binary_path)
+        os.chmod(client_binary_path, 0o711)
+    except (PermissionError, OSError) as e:
+        bk_logger.error(
+            "Cannot install BlenderKit-Client to %s: %s",
+            path.dirname(client_binary_path),
+            e,
+        )
+        raise PermissionError(
+            f"Cannot install BlenderKit-Client to {path.dirname(client_binary_path)}: {e}"
+        ) from e
     bk_logger.info("BlenderKit-Client binary copied to %s", client_binary_path)
 
 

--- a/paths.py
+++ b/paths.py
@@ -161,6 +161,22 @@ def get_temp_dir(subdir=None):
     return tempdir
 
 
+def _try_makedirs(dirpath, label="download"):
+    """Try to create directory, report error on failure. Returns True on success."""
+    if os.path.exists(dirpath):
+        return True
+    try:
+        os.makedirs(dirpath)
+        return True
+    except OSError as e:
+        bk_logger.error("Cannot create download directory: %s - %s", dirpath, e)
+        reports.add_report(
+            f"Cannot create {label} folder: {dirpath}\n{e}",
+            type="ERROR",
+        )
+        return False
+
+
 def get_download_dirs(asset_type):
     """get directories where assets will be downloaded"""
     plurals_mapping = {
@@ -185,10 +201,9 @@ def get_download_dirs(asset_type):
         if ddir.startswith("//"):
             ddir = bpy.path.abspath(ddir)
 
-        subd = plurals_mapping[asset_type]
-        subdir = os.path.join(ddir, subd)
-        if not os.path.exists(subdir):
-            os.makedirs(subdir)
+        subdir = os.path.join(ddir, plurals_mapping[asset_type])
+        if not _try_makedirs(subdir, "download"):
+            return dirs
         dirs.append(subdir)
 
     if (
@@ -205,8 +220,8 @@ def get_download_dirs(asset_type):
             return (
                 dirs  # project subdir is over 250, no space for adding filenames later
             )
-        if not os.path.exists(subdir):
-            os.makedirs(subdir)  # this would fail if path was over 260
+        if not _try_makedirs(subdir, "project download"):
+            return dirs
         dirs.append(subdir)
 
     return dirs

--- a/paths.py
+++ b/paths.py
@@ -254,7 +254,9 @@ def ensure_asset_library_path(
     try:
         os.makedirs(target_path, exist_ok=True)
     except OSError as e:
-        bk_logger.warning("Cannot create asset library directory %s: %s", target_path, e)
+        bk_logger.warning(
+            "Cannot create asset library directory %s: %s", target_path, e
+        )
         return
 
     previous_path = _normalize_path(previous_global_dir) if previous_global_dir else ""

--- a/paths.py
+++ b/paths.py
@@ -251,7 +251,11 @@ def ensure_asset_library_path(
     if not target_path:
         return
 
-    os.makedirs(target_path, exist_ok=True)
+    try:
+        os.makedirs(target_path, exist_ok=True)
+    except OSError as e:
+        bk_logger.warning("Cannot create asset library directory %s: %s", target_path, e)
+        return
 
     previous_path = _normalize_path(previous_global_dir) if previous_global_dir else ""
     if previous_path:

--- a/timer.py
+++ b/timer.py
@@ -80,7 +80,11 @@ def handle_failed_reports(exception: Exception) -> float:
             bk_logger.warning(
                 f"First request for BKClient reports failed unexpectedly: {str(exception).strip()} {type(exception)}"
             )
-        client_lib.start_blenderkit_client()
+        try:
+            client_lib.start_blenderkit_client()
+        except PermissionError as pe:
+            bk_logger.error("Cannot start client due to permission error: %s", pe)
+            return 5.0  # retry after 5s, user needs to fix permissions first
     else:
         bk_logger.warning(
             f"Request for BKClient reports failed: {str(exception).strip()} {type(exception)}"
@@ -107,7 +111,11 @@ def handle_failed_reports(exception: Exception) -> float:
         # The catch is that the error message printed to user is outdated now.
         # But there is not a better solution.
         client_lib.reorder_ports()
-        client_lib.start_blenderkit_client()
+        try:
+            client_lib.start_blenderkit_client()
+        except PermissionError as pe:
+            bk_logger.error("Cannot start client due to permission error: %s", pe)
+            return 5.0  # retry after 5s, user needs to fix permissions first
     else:  # On FAILED_REPORTS == 12..20,22..30,32..40 we just log into terminal
         bk_logger.warning(log_msg)
 
@@ -386,7 +394,14 @@ def on_startup_timer():
     """Run once on the startup of add-on (Blender start with enabled add-on, add-on enabled)."""
     persistent_preferences.load_preferences_from_JSON()
     addon_updater_ops.check_for_update_background()
-    utils.check_globaldir_permissions()
+    ok, message = utils.check_globaldir_permissions()
+    if not ok:
+        recovered = utils.try_recover_global_dir()
+        if not recovered:
+            global_dir = bpy.context.preferences.addons[
+                __package__
+            ].preferences.global_dir
+            utils._show_permission_popup(global_dir, message)
 
     return None
 

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -249,6 +249,127 @@ class BLENDERKIT_OT_show_validation_popup(bpy.types.Operator):
             utils.label_multiline(layout, text=paragraph, width=480)
 
 
+class BLENDERKIT_OT_permissions_error_popup(bpy.types.Operator):
+    """Show a large centered dialog when BlenderKit cannot write to the asset directory.
+    Dynamically updates to show success when the path is fixed.
+    """
+
+    bl_idname = "wm.blenderkit_permissions_error_popup"
+    bl_label = "BlenderKit - Directory Permission Error"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    error_message: StringProperty(name="Error", default="", options={"SKIP_SAVE"})  # type: ignore
+    directory_path: StringProperty(name="Path", default="", options={"SKIP_SAVE"})  # type: ignore
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        try:
+            return wm.invoke_props_dialog(
+                self, width=600, confirm_text="Open Preferences"
+            )
+        except TypeError:
+            return wm.invoke_props_dialog(self, width=600)
+
+    def execute(self, context):
+        # Check if path is already fixed (e.g. user clicked Set Default Folder)
+        current_dir = context.preferences.addons[__package__].preferences.global_dir
+        current_dir = os.path.normpath(bpy.path.abspath(current_dir))
+        current_ok, _ = utils._check_dir_permissions(current_dir, "Global directory")
+        if not current_ok:
+            bpy.ops.preferences.addon_show(module=__package__)
+        return {"FINISHED"}
+
+    def draw(self, context):
+        layout = self.layout
+
+        # Light check for live UI — draw() runs on each redraw, avoid file I/O here
+        current_dir = context.preferences.addons[__package__].preferences.global_dir
+        current_dir = os.path.normpath(bpy.path.abspath(current_dir))
+        current_ok = os.path.isdir(current_dir)
+
+        if current_ok:
+            # === PATH IS NOW FIXED — show success ===
+            layout.separator()
+            row = layout.row()
+            row.scale_y = 2.0
+            row.alert = False
+            row.label(text="  Directory is now accessible!", icon="CHECKMARK")
+            layout.separator()
+            layout.label(text=f"Path: {current_dir}")
+            layout.separator()
+            layout.label(text="You can close this dialog now.")
+            return
+
+        # === PATH IS BROKEN — show big red warning ===
+        # Large red alert header
+        box_header = layout.box()
+        box_header.alert = True
+        row = box_header.row()
+        row.scale_y = 2.0
+        row.alignment = "CENTER"
+        row.label(text="  CANNOT ACCESS DOWNLOAD FOLDER  ", icon="ERROR")
+
+        layout.separator()
+
+        # Error details
+        clean_text = self.error_message.replace("\r\n", "\n").replace("\r", "\n")
+        for paragraph in clean_text.split("\n"):
+            if paragraph.strip():
+                utils.label_multiline(layout, text=paragraph, width=560)
+
+        layout.separator()
+
+        # === Fix options ===
+        box = layout.box()
+        box.label(text="How to fix this:", icon="TOOL_SETTINGS")
+        box.separator(factor=0.5)
+
+        # Option 1: Set default folder (show if parent dir exists)
+        default_dir = paths.default_global_dict()
+        default_parent = os.path.dirname(default_dir)
+        if os.path.isdir(default_dir) or os.path.isdir(default_parent):
+            row = box.row()
+            row.scale_y = 1.5
+            row.operator(
+                "wm.blenderkit_set_default_directory",
+                text=f"  Set Default Folder:  {default_dir}  ",
+                icon="CHECKMARK",
+            )
+            box.separator(factor=0.5)
+
+        # Option 2: Open preferences
+        col = box.column(align=True)
+        col.label(text="Or click 'Open Preferences' below to choose a folder manually.")
+
+        layout.separator()
+
+        # Current broken path
+        row = layout.row()
+        row.alert = True
+        row.label(text=f"Current folder: {self.directory_path}", icon="INFO")
+
+
+class BLENDERKIT_OT_set_default_directory(bpy.types.Operator):
+    """Set the Global Directory to the default blenderkit_data folder"""
+
+    bl_idname = "wm.blenderkit_set_default_directory"
+    bl_label = "Set Default Folder"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    def execute(self, context):
+        default_dir = paths.default_global_dict()
+        ok, message = utils._check_dir_permissions(default_dir, "Default directory")
+        if not ok:
+            self.report({"ERROR"}, f"Default folder is not writable: {message}")
+            return {"CANCELLED"}
+
+        preferences = context.preferences.addons[__package__].preferences
+        preferences.global_dir = default_dir
+        self.report({"INFO"}, f"Global directory set to: {default_dir}")
+        utils.restart_client_after_path_fix()
+        return {"FINISHED"}
+
+
 def draw_validated_manufacturer(
     layout: bpy.types.UILayout, asset: Any, props: Any = None
 ) -> None:
@@ -4834,6 +4955,8 @@ class NodegroupDropDialog(bpy.types.Operator):
 classes = (
     BLENDERKIT_OT_hdr_thumbnail_tune,
     BLENDERKIT_OT_show_validation_popup,
+    BLENDERKIT_OT_permissions_error_popup,
+    BLENDERKIT_OT_set_default_directory,
     SetCategoryOperatorOrigin,
     SetCategoryOperator,
     SetCategoryOperatorInPopupCard,

--- a/utils.py
+++ b/utils.py
@@ -636,6 +636,24 @@ def save_prefs(user_preferences, context, **kwargs):
     paths.ensure_asset_library_path(
         global_vars.PREFS.get("global_dir"), previous_global_dir
     )
+
+    # Validate permissions when global_dir changes — reject invalid paths
+    current_global_dir = global_vars.PREFS.get("global_dir")
+    if previous_global_dir is not None and current_global_dir != previous_global_dir:
+        ok, message = check_globaldir_permissions()
+        if not ok:
+            reports.add_report(
+                "Cannot write to selected folder. Path reverted to previous value.",
+                type="ERROR",
+            )
+            bk_logger.warning(
+                "Reverting global_dir from %s back to %s",
+                current_global_dir,
+                previous_global_dir,
+            )
+            user_preferences.global_dir = previous_global_dir
+            return  # don't save the invalid path — the revert triggers save_prefs again with the valid path
+
     if user_preferences.preferences_lock is True:
         return
 
@@ -1672,39 +1690,144 @@ def list2string(lst: list) -> str:
 
 
 def check_globaldir_permissions():
-    """Check if the user has the required permissions to upload assets."""
-    global_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
-    if os.path.isfile(global_dir):
-        reports.add_report(
-            "Global dir is a file. Please remove it or change global dir path in preferences.",
-            type="ERROR",
-        )
-        return False
-    if not os.path.isdir(global_dir):
-        bk_logger.info("Global dir does not exist. Creating it at %s", global_dir)
-        try:
-            os.mkdir(global_dir)
-        except Exception as e:
-            reports.add_report(
-                f"Cannot create Global dir. Check global dir path in preferences. {e}",
-                type="ERROR",
-            )
-            return False
+    """Check if the user has the required permissions for the global directory.
+    Verifies the directory can be created, written to, and files can be deleted.
 
-    exists = os.access(global_dir, os.F_OK)
-    can_write = os.access(global_dir, os.W_OK)
-    can_execute = os.access(global_dir, os.X_OK)
-    if exists and can_write and can_execute:
-        bk_logger.info("Global dir permissions are OK.")
-        return True
-    reports.add_report(
-        f"Change path or give permissions to Global dir, wrong permissions now: exists={exists}, write={can_write}, execute={can_execute}.",
-        type="ERROR",
+    Returns:
+        tuple: (ok: bool, message: str) - True if permissions are OK, False otherwise.
+    """
+    global_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
+    global_dir = os.path.normpath(bpy.path.abspath(global_dir))
+    ok, message = _check_dir_permissions(global_dir, "Global directory")
+    if ok:
+        bk_logger.info("Global dir permissions are OK: %s", global_dir)
+    else:
+        bk_logger.error(message)
+    return ok, message
+
+
+def _check_dir_permissions(dir_path, dir_label="Directory"):
+    """Check if a directory path is valid, writable and usable for storing assets.
+
+    Returns:
+        tuple: (ok: bool, message: str)
+    """
+    if os.path.isfile(dir_path):
+        return False, (
+            f"{dir_label} path points to a file, not a folder.\n"
+            f"Please remove the file or change the path in BlenderKit preferences.\n"
+            f"Path: {dir_path}"
+        )
+
+    if not os.path.isdir(dir_path):
+        bk_logger.info("%s does not exist. Creating it at %s", dir_label, dir_path)
+        try:
+            os.makedirs(dir_path, exist_ok=True)
+        except PermissionError:
+            return False, (
+                f"No permission to create {dir_label}.\n"
+                f"Please choose a different folder or run Blender as administrator.\n"
+                f"Path: {dir_path}"
+            )
+        except OSError as e:
+            return False, (
+                f"Cannot create {dir_label}: {e}\n"
+                f"Please check the path in BlenderKit preferences.\n"
+                f"Path: {dir_path}"
+            )
+
+    # os.access() can be unreliable on Windows (NTFS ACLs), so we do a real write test
+    test_file = os.path.join(
+        dir_path, f".blenderkit_permission_test_{uuid.uuid4().hex[:8]}"
     )
+    try:
+        with open(test_file, "w") as f:
+            f.write("permission test")
+        os.remove(test_file)
+    except PermissionError:
+        return False, (
+            f"No write permission to {dir_label}.\n"
+            f"BlenderKit needs to save downloaded assets into this folder.\n"
+            f"Please choose a folder where you have write access, or fix the permissions.\n"
+            f"Path: {dir_path}"
+        )
+    except OSError as e:
+        return False, (
+            f"Cannot write to {dir_label}: {e}\n"
+            f"Please check the path in BlenderKit preferences.\n"
+            f"Path: {dir_path}"
+        )
+
+    return True, ""
+
+
+def try_recover_global_dir():
+    """Attempt to auto-recover by resetting global_dir to the default path.
+    This is called when the current global_dir is not writable (e.g. C:\\Windows).
+    Returns True if the default path is usable and global_dir was reset, False otherwise.
+    """
+    default_dir = paths.default_global_dict()
+    current_dir = bpy.context.preferences.addons[__package__].preferences.global_dir
+    current_dir = os.path.normpath(bpy.path.abspath(current_dir))
+    default_dir_norm = os.path.normpath(default_dir)
+
+    if current_dir == default_dir_norm:
+        return False  # already at default and it's still broken
+
+    ok, message = _check_dir_permissions(default_dir, "Default directory")
+    if not ok:
+        bk_logger.error("Default directory also not writable: %s", message)
+        return False
+
+    bk_logger.warning(
+        "Auto-recovering: resetting global_dir from %s to default: %s",
+        current_dir,
+        default_dir,
+    )
+    prefs = bpy.context.preferences.addons[__package__].preferences
+    prefs.global_dir = default_dir
+    reports.add_report(
+        f"BlenderKit download folder was not accessible. Reset to default: {default_dir}",
+        type="INFO",
+    )
+    restart_client_after_path_fix()
+    return True
+
+
+def restart_client_after_path_fix():
+    """Reset client failure counter and re-register the timer so the client starts immediately.
+    Called after global_dir is changed to a valid, writable path.
+    """
+    from . import timer
+
+    global_vars.CLIENT_FAILED_REPORTS = 0
+    try:
+        if bpy.app.timers.is_registered(timer.client_communication_timer):
+            bpy.app.timers.unregister(timer.client_communication_timer)
+        bpy.app.timers.register(timer.client_communication_timer, persistent=True)
+        bk_logger.info("Client communication timer restarted after path fix")
+    except Exception as e:
+        bk_logger.warning("Could not restart client timer: %s", e)
+
+
+def _show_permission_popup(dir_path, message):
+    """Show a large centered dialog about permission issues.
+    Uses invoke_props_dialog for a prominent, hard-to-miss warning.
+    The dialog dynamically updates to show success when the path is fixed.
+    """
+    try:
+        bpy.ops.wm.blenderkit_permissions_error_popup(
+            "INVOKE_DEFAULT",
+            error_message=message,
+            directory_path=dir_path,
+        )
+    except Exception as e:
+        bk_logger.warning("Could not show permission popup: %s", e)
+        reports.add_report(message, type="ERROR")
 
 
 def shorten_text(text: str, max_len: int = -1) -> str:
-    """Shorten text to max_len characters and end it with '…' (horizontal elipsis) if the text was shortened
+    """Shorten text to max_len characters and end it with '…' (horizontal ellipsis) if the text was shortened
     (max_len-1 characters will be used, last one will be '…').
     If max_len is -1, then no shortening is done."""
     if max_len == -1:


### PR DESCRIPTION

Some users cannot download assets because their global_dir is set to a
path without write permissions (e.g. C:\Windows). This caused silent
download failures and a crash loop in the client startup timer that
made the addon unusable.

Changes:
- Add real write-test permission checking (temp file create/delete)
  instead of unreliable os.access() on Windows NTFS
- Reject and revert invalid paths immediately in save_prefs so bad
  paths can no longer be persisted
- Auto-recover on startup: if global_dir is broken, reset to default
  ~/blenderkit_data and show a prominent error dialog
- Prevent PermissionError crash loop in client timer by wrapping
  start_blenderkit_client() calls
- Add centered 600px error dialog with one-click Set Default Folder fix
- Deduplicate makedirs error handling in get_download_dirs

Criticality: High - affected users have a completely broken addon with
no way to diagnose or fix the issue from the UI.