### PR TITLE
Fix unpack corrupting .blend files across Blender versions

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -362,17 +362,13 @@ func doAssetDownload(
 	}
 
 	// UNPACKING / METADATA WRITE
-	// Trigger unpack when either unpacking is enabled or metadata should be written.
-	// Skip when just placing an already-existing file: it was already unpacked on first
-	// download. Re-running unpack with a different Blender version would re-save the
-	// .blend, upgrading its format and making it unreadable by older Blender versions.
-	shouldUnpack := (unpackFiles || writeAssetMetadata) && action != "place"
+	// Trigger unpack only on fresh downloads. The unpack script opens the .blend in a
+	// background Blender and re-saves it (bpy.ops.wm.save_as_mainfile), which upgrades
+	// the file format to match that Blender version. Re-running unpack on an already
+	// existing file ("place" or "sync") with a different Blender version would make the
+	// .blend unreadable by older Blenders.
+	shouldUnpack := (unpackFiles || writeAssetMetadata) && action == "download"
 	if shouldUnpack {
-		// If there was no download, there's risk that the file to be unpacked
-		// is only in local, but not in global directory
-		if action != "download" {
-			fp = existingFiles[0]
-		}
 		//err := UnpackAsset(fp, data, taskID)
 		assetDataRaw, _ := origJSON["asset_data"]
 
@@ -452,6 +448,18 @@ func UnpackAsset(
 			AppID:   appID,
 			TaskID:  taskID,
 			Message: fmt.Sprintf("Skipping unpack: downloaded file is not a .blend (%s)", filepath.Ext(blendPath)),
+		}
+		return nil
+	}
+
+	// Microsoft Store Blender installs live under WindowsApps which blocks
+	// external processes from exec-ing the binary ("access is denied").
+	// Detect this early and skip unpack with a clear message.
+	if runtime.GOOS == "windows" && strings.Contains(strings.ToLower(binaryPath), "windowsapps") {
+		TaskMessageCh <- &TaskMessageUpdate{
+			AppID:   appID,
+			TaskID:  taskID,
+			Message: "Skipping unpack: Microsoft Store Blender cannot be launched as background process",
 		}
 		return nil
 	}

--- a/client/download.go
+++ b/client/download.go
@@ -363,7 +363,10 @@ func doAssetDownload(
 
 	// UNPACKING / METADATA WRITE
 	// Trigger unpack when either unpacking is enabled or metadata should be written.
-	shouldUnpack := unpackFiles || writeAssetMetadata
+	// Skip when just placing an already-existing file: it was already unpacked on first
+	// download. Re-running unpack with a different Blender version would re-save the
+	// .blend, upgrading its format and making it unreadable by older Blender versions.
+	shouldUnpack := (unpackFiles || writeAssetMetadata) && action != "place"
 	if shouldUnpack {
 		// If there was no download, there's risk that the file to be unpacked
 		// is only in local, but not in global directory
@@ -386,13 +389,12 @@ func doAssetDownload(
 			writeAssetMetadata,
 		)
 		if err != nil {
-			e := fmt.Errorf("error unpacking asset: %w", err)
-			TaskErrorCh <- &TaskError{
-				AppID:  appID,
-				TaskID: taskID,
-				Error:  e,
+			BKLog.Printf("%s error unpacking asset (non-fatal, asset will still be placed): %v", EmoWarning, err)
+			TaskMessageCh <- &TaskMessageUpdate{
+				AppID:   appID,
+				TaskID:  taskID,
+				Message: fmt.Sprintf("Unpacking failed (asset will still be placed): %v", err),
 			}
-			return
 		}
 	}
 
@@ -505,6 +507,12 @@ func UnpackAsset(
 		color.FgGray.Printf("   %s\n", line)
 	}
 	if err != nil {
+		// Include Blender's output in the error so callers can see why it failed
+		// (e.g. "not a blend file" when old Blender can't read a newer .blend format).
+		output := strings.TrimSpace(combinedOutput.String())
+		if output != "" {
+			return fmt.Errorf("%w, Blender output: %s", err, output)
+		}
 		return err
 	}
 

--- a/client/utils.go
+++ b/client/utils.go
@@ -266,6 +266,12 @@ func GetSafeTempPath() (string, error) {
 	}
 
 	username := currentUser.Username
+	// On Windows, user.Current().Username returns "DOMAIN\username".
+	// Python's getpass.getuser() returns just "username".
+	// We must match Python's behavior so both use the same temp directory.
+	if idx := strings.LastIndex(username, "\\"); idx >= 0 {
+		username = username[idx+1:]
+	}
 	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fix: prevent unpack from corrupting .blend files and failing on restricted installs

Only run background unpack on fresh downloads, not on already-existing files. Re-unpacking with a different Blender version re-saves the .blend, upgrading its format and making it unreadable by older Blenders.
Skip unpack for Microsoft Store Blender installs (WindowsApps sandbox blocks exec).
Make unpack errors non-fatal — log a warning but still place the asset.
Include Blender's output in unpack error messages for easier debugging.
Fix Go/Python temp directory mismatch: strip Windows domain prefix from username so both use the same bktemp_<user> path.