### PR TITLE
feat: Experimental threaded BlenderKit-Client communication

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -135,6 +135,7 @@ else:
     from . import colors
     from . import client_lib
     from . import client_tasks
+    from . import client_thread
     from . import disclaimer_op
     from . import download
     from . import icons
@@ -2514,6 +2515,18 @@ In this case you should also set path to your system CA bundle containing proxy'
         update=utils.save_prefs,
     )
 
+    thread_communication: BoolProperty(
+        name="Threaded BlenderKit-Client communication",
+        description=(
+            "Move communication with the BlenderKit-Client (report polling and"
+            " selected fire-and-forget HTTP requests) onto a background thread."
+            " This keeps Blender responsive when the local Client is slow to"
+            " respond. Only takes effect while experimental features are enabled."
+        ),
+        default=False,
+        update=utils.save_prefs,
+    )
+
     categories_fix: BoolProperty(
         name="Enable category fixing mode",
         description="Enable category fixing mode",
@@ -2745,6 +2758,7 @@ In this case you should also set path to your system CA bundle containing proxy'
             experimental_settings.prop(self, "author_tab")
             experimental_settings.prop(self, "author_asset_type_picker")
             experimental_settings.prop(self, "ignore_env_for_thumbnails")
+            experimental_settings.prop(self, "thread_communication")
             # experimental_settings.prop(self, "enable_wire_thumbnail_upload")
 
 
@@ -2914,6 +2928,10 @@ def unregister():
     disclaimer_op.unregister()
 
     if bpy.app.background is False:
+        try:
+            client_thread.stop()
+        except Exception as e:
+            bk_logger.error(e)
         try:
             client_lib.unsubscribe_addon()
             bk_logger.info("Reported Blender quit to Client.")

--- a/client_lib.py
+++ b/client_lib.py
@@ -24,6 +24,7 @@ import os
 import platform
 import shutil
 import subprocess
+import threading
 from os import path
 from typing import Optional, Union
 from http.client import responses as http_responses
@@ -72,6 +73,22 @@ def get_base_url() -> str:
     return f"{address}/{vapi}"
 
 
+def _read_api_key_threadsafe() -> str:
+    """Return the user's API key without touching bpy from a non-main thread.
+    On the main thread we read the live preference. On a worker thread we read
+    the snapshot maintained by client_thread (updated each main timer tick).
+    """
+    if threading.current_thread() is threading.main_thread():
+        try:
+            return bpy.context.preferences.addons[__package__].preferences.api_key  # type: ignore
+        except (AttributeError, KeyError):
+            return ""
+    # Lazy import to avoid circular dependency at module load time.
+    from . import client_thread
+
+    return client_thread.get_cached_api_key()
+
+
 def ensure_minimal_data(data: Optional[dict] = None) -> dict:
     """Ensure that the data send to the BlenderKit-Client contains:
     - app_id is the process ID of the Blender instance, so BlenderKit-client can return reports to the correct instance.
@@ -84,10 +101,8 @@ def ensure_minimal_data(data: Optional[dict] = None) -> dict:
     av = global_vars.VERSION
     addon_version = f"{av[0]}.{av[1]}.{av[2]}.{av[3]}"
     if "api_key" not in data:
-        # for BG instances, where preferences are not available
-        data.setdefault(
-            "api_key", bpy.context.preferences.addons[__package__].preferences.api_key  # type: ignore
-        )
+        # for BG instances and worker threads, fall back to a thread-safe accessor
+        data.setdefault("api_key", _read_api_key_threadsafe())
     data.setdefault("app_id", os.getpid())
     data.setdefault("platform_version", platform.platform())
     data.setdefault("addon_version", addon_version)
@@ -131,23 +146,38 @@ def reorder_ports(port: str = ""):
     )
 
 
-def get_reports(app_id: int):
-    """Get reports for all tasks of app_id Blender instance at once.
-    If few last calls failed, then try to get reports also from other than default ports.
+def build_report_data(app_id: int) -> dict:
+    """Construct the JSON body sent to the /report endpoint.
+    Touches bpy and so MUST be called from the main thread.
+    Worker threads should consume the dict produced here, not call this themselves.
     """
     data = ensure_minimal_data({"app_id": app_id})
     data["project_name"] = utils.get_project_name()
     data["blender_version"] = utils.get_blender_version()
+    return data
+
+
+def get_report_url(port: Optional[str] = None) -> str:
+    """Return the /report endpoint URL for the current (or a specific) port."""
+    vapi = get_api_version()
+    if port is None:
+        return f"{get_base_url()}/report"
+    return f"http://127.0.0.1:{port}/{vapi}/report"
+
+
+def get_reports(app_id: int):
+    """Get reports for all tasks of app_id Blender instance at once.
+    If few last calls failed, then try to get reports also from other than default ports.
+    """
+    data = build_report_data(app_id)
 
     # on 10, there is second BlenderKit-Client start
     if global_vars.CLIENT_FAILED_REPORTS < 10:
-        url = f"{get_base_url()}/report"
-        return request_report(url, data)
+        return request_report(get_report_url(), data)
 
     last_exception = None
     for port in global_vars.CLIENT_PORTS:
-        vapi = get_api_version()
-        url = f"http://127.0.0.1:{port}/{vapi}/report"
+        url = get_report_url(port)
         try:
             report = request_report(url, data)
             bk_logger.warning(

--- a/client_thread.py
+++ b/client_thread.py
@@ -1,0 +1,327 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+"""Background communication thread for the BlenderKit-Client.
+
+The legacy code path makes every HTTP roundtrip to the local Go client on
+Blender's main thread. Even on 127.0.0.1 these calls can block long enough to
+stutter the UI when the client is busy. This module moves report polling and
+explicitly opted-in fire-and-forget requests onto a daemon worker thread.
+
+The module is opt-in: it is only activated when both ``experimental_features``
+and ``thread_communication`` preferences are True. When disabled the worker is
+stopped and timer.py falls back to the original synchronous path.
+
+Threading rules:
+    * The worker thread MUST NOT touch ``bpy.*`` or any Blender data.
+    * The main thread is the only writer of the request state snapshot; the
+      worker only reads it.
+    * Tasks parsed from reports are still dispatched (``handle_task``) on the
+      main thread. The worker just shuttles bytes over the wire.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from typing import Any, Callable, List, Optional, Tuple
+
+import requests
+
+
+bk_logger = logging.getLogger(__name__)
+
+NO_PROXIES = {"http": "", "https": ""}
+POLL_TIMEOUT = (0.05, 0.25)
+DEFAULT_TIMEOUT = (0.1, 1.0)
+# Cap the worker's self-throttling so we keep checking on the Client.
+_MAX_BACKOFF_SECONDS = 5.0
+# Worst-case sleep between iterations; keeps outbound queue latency bounded.
+_MAX_SLEEP_SECONDS = 0.1
+
+
+# --- Shared state (main thread writer, worker reader) ---
+_state_lock = threading.Lock()
+_report_url: Optional[str] = None
+_report_data: Optional[dict] = None
+_report_fallback_urls: List[str] = []
+_poll_interval: float = 0.2
+_api_key_snapshot: str = ""
+
+# --- Communication queues ---
+# Outbound: main thread -> worker. Each item is (callable, args, kwargs) or None (wakeup).
+_outbound_queue: "queue.Queue[Optional[Tuple[Callable, tuple, dict]]]" = queue.Queue()
+# Inbound: worker -> main thread. Each item is a list of report dicts from the Client.
+_reports_queue: "queue.Queue[List[Any]]" = queue.Queue()
+
+# --- Single-slot state surfaced from worker to main thread ---
+_error_lock = threading.Lock()
+_last_error: Optional[BaseException] = None
+# Port that started responding after a failover. Main thread reorders ports when set.
+_recovered_port: Optional[str] = None
+
+# --- Worker thread handle ---
+_thread_lock = threading.Lock()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+# Worker-local: number of consecutive failed polls. Used to back off the worker
+# without spamming the main thread with duplicate errors.
+_consecutive_failures = 0
+
+
+def is_running() -> bool:
+    """True when the worker thread is alive."""
+    with _thread_lock:
+        return _thread is not None and _thread.is_alive()
+
+
+def update_state(
+    report_url: str,
+    report_data: dict,
+    fallback_urls: Optional[List[str]] = None,
+    poll_interval: float = 0.2,
+    api_key: str = "",
+) -> None:
+    """Refresh the worker's view of the request state.
+    Called from the main thread on every ``client_communication_timer`` tick so
+    the worker always has fresh values for project_name / api_key / port list.
+    """
+    global _report_url, _report_data, _report_fallback_urls, _poll_interval
+    global _api_key_snapshot
+    with _state_lock:
+        _report_url = report_url
+        _report_data = dict(report_data)
+        _report_fallback_urls = list(fallback_urls) if fallback_urls else []
+        _poll_interval = max(0.05, float(poll_interval))
+        _api_key_snapshot = api_key
+
+
+def get_cached_api_key() -> str:
+    """Worker-thread accessor for the current api_key snapshot."""
+    with _state_lock:
+        return _api_key_snapshot
+
+
+def submit_request(func: Callable, *args, **kwargs) -> None:
+    """Queue a fire-and-forget callable to run on the worker thread.
+
+    The callable's return value is dropped. The callable MUST be safe to call
+    off the main thread - it cannot touch ``bpy.*``. Use this for outbound
+    requests where the caller does not need the response (ratings, comments
+    moderation, mark-notification-read, report_usages).
+    """
+    _outbound_queue.put((func, args, kwargs))
+
+
+def submit_post(
+    url: str, data: dict, timeout: Tuple[float, float] = DEFAULT_TIMEOUT
+) -> None:
+    """Fire-and-forget POST. The URL and data dict must be fully built on the
+    main thread before submission."""
+    _outbound_queue.put((_do_post, (url, data, timeout), {}))
+
+
+def submit_get(
+    url: str, data: dict, timeout: Tuple[float, float] = DEFAULT_TIMEOUT
+) -> None:
+    """Fire-and-forget GET. The URL and data dict must be fully built on the
+    main thread before submission."""
+    _outbound_queue.put((_do_get, (url, data, timeout), {}))
+
+
+def drain_reports() -> Tuple[List[List[Any]], Optional[BaseException], Optional[str]]:
+    """Pop everything the worker has produced since the last drain.
+    Returns ``(batches, last_error, recovered_port)``. Called on the main thread.
+
+    Errors are coalesced into a single slot - only the latest failure is surfaced
+    between drains. The worker self-throttles while errors persist, so the main
+    thread typically sees at most one error per drain in practice.
+    """
+    global _last_error, _recovered_port
+    batches: List[List[Any]] = []
+    while True:
+        try:
+            batches.append(_reports_queue.get_nowait())
+        except queue.Empty:
+            break
+    with _error_lock:
+        err = _last_error
+        port = _recovered_port
+        _last_error = None
+        _recovered_port = None
+    return batches, err, port
+
+
+def reset_failure_count() -> None:
+    """Main thread tells the worker that the client is healthy again."""
+    global _consecutive_failures
+    _consecutive_failures = 0
+
+
+def start() -> None:
+    """Ensure the worker thread is running. Idempotent."""
+    global _thread
+    with _thread_lock:
+        if _thread is not None and _thread.is_alive():
+            return
+        _stop_event.clear()
+        _thread = threading.Thread(
+            target=_worker_loop, name="BlenderKit-ClientComm", daemon=True
+        )
+        _thread.start()
+    bk_logger.info("BlenderKit client communication thread started")
+
+
+def stop(timeout: float = 1.0) -> None:
+    """Signal the worker to exit and wait briefly for it to do so."""
+    global _thread
+    with _thread_lock:
+        thread = _thread
+        if thread is None or not thread.is_alive():
+            _thread = None
+            return
+        _stop_event.set()
+    # Wake the worker if it is sleeping on the outbound queue.
+    try:
+        _outbound_queue.put_nowait(None)
+    except Exception:
+        pass
+    thread.join(timeout=timeout)
+    with _thread_lock:
+        _thread = None
+    bk_logger.info("BlenderKit client communication thread stopped")
+
+
+def _do_post(url: str, data: dict, timeout: Tuple[float, float]) -> None:
+    with requests.Session() as session:
+        session.post(url, json=data, timeout=timeout, proxies=NO_PROXIES)
+
+
+def _do_get(url: str, data: dict, timeout: Tuple[float, float]) -> None:
+    with requests.Session() as session:
+        session.get(url, json=data, timeout=timeout, proxies=NO_PROXIES)
+
+
+def _drain_outbound() -> None:
+    """Process every queued outbound request. Called from the worker thread."""
+    while True:
+        try:
+            item = _outbound_queue.get_nowait()
+        except queue.Empty:
+            return
+        if item is None:
+            continue  # wakeup sentinel from stop()
+        func, args, kwargs = item
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            bk_logger.exception("Outbound BlenderKit-Client request failed")
+
+
+def _extract_port(url: str) -> Optional[str]:
+    """Pull the port from a URL like http://127.0.0.1:62485/v1.2/report."""
+    try:
+        host_port = url.split("//", 1)[1].split("/", 1)[0]
+        return host_port.rsplit(":", 1)[1]
+    except (IndexError, ValueError):
+        return None
+
+
+def _poll_reports() -> None:
+    """Try to fetch reports. Push results or the latest error into the queues."""
+    global _consecutive_failures, _last_error, _recovered_port
+    with _state_lock:
+        url = _report_url
+        data = dict(_report_data) if _report_data is not None else None
+        fallback_urls = list(_report_fallback_urls)
+    if url is None or data is None:
+        return  # main thread has not seeded state yet
+
+    # On long failure streaks try the alternative ports the main thread knows
+    # about. The main thread will reorder its preferred port if we recover.
+    urls_to_try: List[str] = [url]
+    if _consecutive_failures >= 10 and fallback_urls:
+        urls_to_try = fallback_urls
+
+    last_exception: Optional[BaseException] = None
+    for try_url in urls_to_try:
+        try:
+            with requests.Session() as session:
+                resp = session.get(
+                    try_url, json=data, timeout=POLL_TIMEOUT, proxies=NO_PROXIES
+                )
+            if resp.status_code != 200:
+                raise requests.HTTPError(
+                    f"{resp.status_code}: {resp.text}", response=resp
+                )
+            results = resp.json()
+            _reports_queue.put(results)
+            _consecutive_failures = 0
+            with _error_lock:
+                _last_error = None
+                if try_url != url:
+                    _recovered_port = _extract_port(try_url)
+            return
+        except Exception as e:
+            last_exception = e
+            continue
+
+    _consecutive_failures += 1
+    if last_exception is not None:
+        with _error_lock:
+            # Single-slot: keep only the most recent error so we don't hand
+            # the main thread N copies to handle.
+            _last_error = last_exception
+
+
+def _worker_loop() -> None:
+    """Main loop of the worker thread."""
+    global _consecutive_failures
+    last_poll = 0.0
+    while not _stop_event.is_set():
+        _drain_outbound()
+
+        with _state_lock:
+            interval = _poll_interval
+
+        # Self-throttle on consecutive failures so the main thread isn't
+        # buried under duplicate errors before it can react.
+        if _consecutive_failures > 0:
+            effective_interval = min(
+                interval * (1 + _consecutive_failures), _MAX_BACKOFF_SECONDS
+            )
+        else:
+            effective_interval = interval
+
+        now = time.monotonic()
+        if now - last_poll >= effective_interval:
+            last_poll = now
+            try:
+                _poll_reports()
+            except Exception:
+                bk_logger.exception("Unexpected error in BlenderKit poll worker")
+                # Surface as a regular failure so backoff logic kicks in.
+                _consecutive_failures += 1
+
+        sleep_for = min(effective_interval / 4, _MAX_SLEEP_SECONDS)
+        if _stop_event.wait(timeout=sleep_for):
+            break
+
+    bk_logger.info("BlenderKit client communication worker exited")

--- a/timer.py
+++ b/timer.py
@@ -32,6 +32,7 @@ from . import (
     categories,
     client_lib,
     client_tasks,
+    client_thread,
     comments_utils,
     disclaimer_op,
     download,
@@ -128,25 +129,80 @@ def handle_failed_reports(exception: Exception) -> float:
     return min(30.0, 0.1 * global_vars.CLIENT_FAILED_REPORTS)
 
 
+def _thread_communication_enabled(user_preferences) -> bool:
+    """True when the experimental threaded client communication should be used."""
+    return bool(
+        getattr(user_preferences, "experimental_features", False)
+        and getattr(user_preferences, "thread_communication", False)
+    )
+
+
 @bpy.app.handlers.persistent
 def client_communication_timer():
     """Receive all responses from Client and run according followup commands.
     This function is the only one responsible for keeping the Client up and running.
+
+    When the experimental ``thread_communication`` preference is enabled, HTTP
+    polling is delegated to ``client_thread`` and we only drain the results
+    here. Task dispatch (``handle_task``) always happens on the main thread.
     """
     global pending_tasks
     bk_logger.log(5, "Getting tasks from Client")
     user_preferences = bpy.context.preferences.addons[__package__].preferences
     if user_preferences.use_clipboard_scan:
         search.check_clipboard()
-    results = list()
-    try:
-        results = client_lib.get_reports(os.getpid())
-        global_vars.CLIENT_FAILED_REPORTS = 0
-    except Exception as e:
-        download.prune_stalled_downloads(now=time.monotonic())
-        return handle_failed_reports(e)
 
-    if global_vars.CLIENT_ACCESSIBLE is False:
+    use_thread = _thread_communication_enabled(user_preferences)
+    results: list = []
+    got_successful_reports = False
+
+    if use_thread:
+        # Refresh the worker's view of our state, then start it if needed.
+        app_id = os.getpid()
+        report_data = client_lib.build_report_data(app_id)
+        fallback_urls = [
+            client_lib.get_report_url(port) for port in global_vars.CLIENT_PORTS
+        ]
+        api_key = getattr(user_preferences, "api_key", "") or ""
+        client_thread.update_state(
+            report_url=client_lib.get_report_url(),
+            report_data=report_data,
+            fallback_urls=fallback_urls,
+            poll_interval=user_preferences.client_polling,
+            api_key=api_key,
+        )
+        client_thread.start()
+
+        batches, err, recovered_port = client_thread.drain_reports()
+        if recovered_port:
+            client_lib.reorder_ports(recovered_port)
+        if err is not None:
+            download.prune_stalled_downloads(now=time.monotonic())
+            next_delay = handle_failed_reports(err)
+            # Batches collected alongside an error are stale; drop them so we
+            # process fresh ones once the Client recovers.
+            return next_delay
+
+        for batch in batches:
+            results.extend(batch)
+        if batches:
+            got_successful_reports = True
+            global_vars.CLIENT_FAILED_REPORTS = 0
+            client_thread.reset_failure_count()
+    else:
+        # Preference flipped off (or was never on) - make sure the worker is
+        # idle so two poll paths don't race.
+        if client_thread.is_running():
+            client_thread.stop()
+        try:
+            results = client_lib.get_reports(os.getpid())
+            got_successful_reports = True
+            global_vars.CLIENT_FAILED_REPORTS = 0
+        except Exception as e:
+            download.prune_stalled_downloads(now=time.monotonic())
+            return handle_failed_reports(e)
+
+    if global_vars.CLIENT_ACCESSIBLE is False and got_successful_reports:
         bk_logger.info(
             f"BlenderKit-Client is running on port {global_vars.CLIENT_PORTS[0]}!"
         )
@@ -221,10 +277,13 @@ def save_prefs_cancel_all_tasks_and_restart_client(user_preferences, context):
     except Exception:
         bk_logger.exception("Error shutting down client")
 
+    # Stop the worker so the next timer tick restarts it against the fresh port.
+    client_thread.stop()
     client_lib.reorder_ports(
         user_preferences.client_port
     )  # reorder after shutdown was requested
     global_vars.CLIENT_FAILED_REPORTS = 0  # reset failed reports so next attempt to get report or start client is immediate
+    client_thread.reset_failure_count()
     bpy.app.timers.unregister(client_communication_timer)
     bpy.app.timers.register(client_communication_timer, persistent=True)
 
@@ -454,6 +513,13 @@ def unregister_timers():
     """
     if bpy.app.background:
         return
+
+    # Stop the optional client communication worker before touching timers so
+    # it doesn't race against unregistration.
+    try:
+        client_thread.stop()
+    except Exception:
+        bk_logger.exception("Error stopping client communication thread")
 
     if bpy.app.timers.is_registered(check_timers_timer):
         bpy.app.timers.unregister(check_timers_timer)


### PR DESCRIPTION
Bring back threading, but just as an experimental feature for now. 

this should prevent stucking blender when waiting for client responses.


Add an opt-in worker thread that takes report polling and selected fire-and-forget HTTP requests off Blender's main thread. When the new thread_communication preference is enabled alongside experimental features, client_thread owns the /report GET loop and timer.py only drains results on the main thread.

client_lib.ensure_minimal_data is now thread-safe via a cached api_key snapshot. build_report_data / get_report_url are exposed as main-thread helpers so the worker never touches bpy.