### PR TITLE
feature Add compatibility checks for addons based on Blender version range

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1282,6 +1282,16 @@ class BlenderKitAddonSearchProps(PropertyGroup, BlenderKitCommonSearchProps):
             else None
         ),
     )
+    search_compatible_only: BoolProperty(
+        name="Compatible Only",
+        description="Hide addons whose declared Blender version range does not include the running Blender version",
+        default=False,
+        update=lambda self, context: (
+            search.search_update(self, context)
+            if context.window_manager.blenderkitUI.asset_type == "ADDON"
+            else None
+        ),
+    )
 
 
 class BlenderKitAuthorSearchProps(PropertyGroup, BlenderKitCommonSearchProps):

--- a/asset_bar_op.py
+++ b/asset_bar_op.py
@@ -1681,18 +1681,20 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         new_button.progress_bar = progress_bar
         self.progress_bars.append(progress_bar)
 
-        if utils.profile_is_validator():
-            red_alert = BL_UI_Widget(
-                asset_x - self.validation_icon_margin,
-                asset_y - self.validation_icon_margin,
-                self.button_size + 2 * self.validation_icon_margin,
-                self.button_size + 2 * self.validation_icon_margin,
-            )
-            red_alert.bg_color = (1.0, 0.0, 0.0, 0.0)
-            red_alert.visible = False
-            red_alert.active = False
-            new_button.red_alert = red_alert
-            self.red_alerts.append(red_alert)
+        # Tinted overlay reused for two purposes:
+        # - validator: red "old upload" alert
+        # - everyone:  dark-red dim for Blender-incompatible addons
+        red_alert = BL_UI_Widget(
+            asset_x - self.validation_icon_margin,
+            asset_y - self.validation_icon_margin,
+            self.button_size + 2 * self.validation_icon_margin,
+            self.button_size + 2 * self.validation_icon_margin,
+        )
+        red_alert.bg_color = (1.0, 0.0, 0.0, 0.0)
+        red_alert.visible = False
+        red_alert.active = False
+        new_button.red_alert = red_alert
+        self.red_alerts.append(red_alert)
 
         return new_button
 
@@ -2719,11 +2721,10 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                     button.bookmark_button.visible = False
                     button.author_button.visible = False
                     button.progress_bar.visible = False
-                if utils.profile_is_validator():
-                    button.red_alert.set_location(
-                        asset_x - self.validation_icon_margin,
-                        asset_y - self.validation_icon_margin,
-                    )
+                button.red_alert.set_location(
+                    asset_x - self.validation_icon_margin,
+                    asset_y - self.validation_icon_margin,
+                )
                 i += 1
 
         for a in range(i, len(self.asset_buttons)):
@@ -2733,6 +2734,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             button.bookmark_button.visible = False
             button.author_button.visible = False
             button.progress_bar.visible = False
+            button.red_alert.visible = False
 
         self.position_active_filter_buttons()
 
@@ -3221,6 +3223,24 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                         self.version_warning.text_color = self.info_color
                 else:
                     self.version_warning.text = ""
+
+                # Addon-specific compatibility warning. This takes precedence
+                # over the generic sourceAppVersion notice because it's based
+                # on the addon's own declared supported range.
+                if is_addon:
+                    compat_ok, min_v, max_v = utils.get_addon_blender_compatibility(
+                        asset_data
+                    )
+                    if not compat_ok:
+                        if min_v and max_v:
+                            rng = f"{min_v}\u2013{max_v}"
+                        elif min_v:
+                            rng = f"{min_v}+"
+                        else:
+                            rng = f"\u2264{max_v}"
+                        cur = utils.get_blender_version()
+                        self.version_warning.text = f"Incompatible: addon requires Blender {rng} (you have {cur})"
+                        self.version_warning.text_color = self.warning_color
 
                 author_id = int(asset_data["author"]["id"])
                 author = global_vars.BKIT_AUTHORS.get(author_id)
@@ -3846,8 +3866,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                         asset_button.validation_icon.visible = False
                         asset_button.progress_bar.visible = False
                         asset_button.background_border = False
-                        if utils.profile_is_validator():
-                            asset_button.red_alert.visible = False
+                        asset_button.red_alert.visible = False
                         continue
 
                     # update bookmark buttons
@@ -3884,7 +3903,14 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
 
                     self.update_progress_bar(asset_button, asset_data)
 
-                    if (
+                    # red_alert overlay is reused for two cases (incompatible
+                    # addons take priority over the validator "old upload" alert):
+                    if asset_data.get(
+                        "assetType"
+                    ) == "addon" and not utils.is_addon_blender_compatible(asset_data):
+                        asset_button.red_alert.bg_color = (0.6, 0.05, 0.05, 0.55)
+                        asset_button.red_alert.visible = True
+                    elif (
                         utils.profile_is_validator()
                         and asset_data["verificationStatus"] == "uploaded"
                     ):
@@ -3897,7 +3923,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                             asset_button.red_alert.visible = True
                         else:
                             asset_button.red_alert.visible = False
-                    elif utils.profile_is_validator():
+                    else:
                         asset_button.red_alert.visible = False
                     visible_results.append(asset_data)
 
@@ -3907,8 +3933,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 asset_button.bookmark_button.visible = False
                 asset_button.author_button.visible = False
                 asset_button.progress_bar.visible = False
-                if utils.profile_is_validator():
-                    asset_button.red_alert.visible = False
+                asset_button.red_alert.visible = False
 
         # Refresh manufacturer chips to match currently visible assets
         self._update_manufacturer_data(visible_results)

--- a/download.py
+++ b/download.py
@@ -1987,6 +1987,14 @@ class BlenderkitAddonChoiceOperator(bpy.types.Operator):
         ],
     )
 
+    # User confirmation required when installing an addon whose declared
+    # Blender version range does not include the running Blender version.
+    confirm_incompatible: bpy.props.BoolProperty(
+        name="Install anyway (incompatible)",
+        description="I understand this addon may not work in this Blender version",
+        default=False,
+    )
+
     def draw(self, context):
 
         layout = self.layout
@@ -2003,12 +2011,35 @@ class BlenderkitAddonChoiceOperator(bpy.types.Operator):
         layout.label(text=f"Addon: {addon_name}")
         layout.separator()
 
+        # Compatibility warning (shown only when relevant).
+        is_compat, min_v, max_v = utils.get_addon_blender_compatibility(asset_data)
+        if not is_compat:
+            cur = utils.get_blender_version()
+            if min_v and max_v:
+                rng = f"{min_v} \u2013 {max_v}"
+            elif min_v:
+                rng = f"{min_v}+"
+            else:
+                rng = f"\u2264 {max_v}"
+            warn = layout.box()
+            warn.alert = True
+            warn.label(
+                text=f"Incompatible: requires Blender {rng}",
+                icon="ERROR",
+            )
+            warn.label(text=f"Your Blender version: {cur}")
+
         layout = layout.column()
         # Show current status and appropriate action enum
         if not status["installed"]:
             layout.label(text="Status: Not Installed", icon="QUESTION")
             layout.separator()
             layout.prop(self, "action_not_installed", expand=True)
+            if not is_compat:
+                layout.separator()
+                row = layout.row()
+                row.alert = True
+                row.prop(self, "confirm_incompatible")
         elif status["enabled"]:
             layout.label(text="Status: Installed and Enabled", icon="CHECKMARK")
             layout.separator()
@@ -2069,6 +2100,21 @@ class BlenderkitAddonChoiceOperator(bpy.types.Operator):
                 "INSTALL_AND_TEMP_ENABLE",
                 "INSTALL_ONLY",
             ):
+                # Block installation when the addon's declared Blender version
+                # range does not include this Blender, unless the user has
+                # explicitly confirmed via the checkbox.
+                if (
+                    not utils.is_addon_blender_compatible(asset_data)
+                    and not self.confirm_incompatible
+                ):
+                    msg = (
+                        f"'{addon_name}' is not compatible with this Blender version. "
+                        "Tick 'Install anyway (incompatible)' to proceed."
+                    )
+                    reports.add_report(msg, type="WARNING")
+                    self.report({"WARNING"}, msg)
+                    return {"CANCELLED"}
+
                 # Trigger download which will automatically install and enable after completion
                 reports.add_report(f"Downloading addon '{addon_name}'...", type="INFO")
 

--- a/search.py
+++ b/search.py
@@ -875,6 +875,14 @@ def handle_search_task(task: client_tasks.Task) -> bool:
                 for asset in result_field
                 if asset.get("assetType") == "author" or asset.get("downloaded", 0) > 0
             ]
+        if addon_props.search_compatible_only:
+            # Filter out addons that don't support the running Blender version.
+            result_field = [
+                asset
+                for asset in result_field
+                if asset.get("assetType") != "addon"
+                or utils.is_addon_blender_compatible(asset)
+            ]
 
         # TODO: if ever needed, implement for other future types
         if result_field:
@@ -2556,6 +2564,7 @@ def get_ui_state():
         addon_props = bpy.context.window_manager.blenderkit_addon
         ui_state["addon_props"] = {
             "search_installed": addon_props.search_installed,
+            "search_compatible_only": addon_props.search_compatible_only,
         }
 
     return ui_state

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1964,6 +1964,8 @@ class VIEW3D_PT_blenderkit_advanced_addon_search(Panel):
         # Add installed filter for addons
         row = layout.row()
         row.prop(addon_props, "search_installed", text="Installed Only")
+        row = layout.row()
+        row.prop(addon_props, "search_compatible_only", text="Compatible Only")
 
 
 class VIEW3D_PT_blenderkit_advanced_author_search(Panel):

--- a/utils.py
+++ b/utils.py
@@ -1867,6 +1867,43 @@ def get_blender_version() -> str:
     return f"{ver[0]}.{ver[1]}.{ver[2]}"
 
 
+def _parse_version_string(v):
+    """Parse a 'X[.Y[.Z]]' string into a 3-tuple of ints, or None on failure."""
+    if not v:
+        return None
+    try:
+        parts = [int(x) for x in str(v).split(".") if x]
+    except Exception:
+        return None
+    if not parts:
+        return None
+    parts = (parts + [0, 0, 0])[:3]
+    return tuple(parts)
+
+
+def get_addon_blender_compatibility(asset_data):
+    """Return (is_compatible, min_str, max_str) for an addon asset.
+
+    Reads dictParameters.blenderVersionMin / blenderVersionMax. Missing/None
+    bound means unlimited on that side. Non-addon assets are always compatible.
+    """
+    if not isinstance(asset_data, dict) or asset_data.get("assetType") != "addon":
+        return True, None, None
+    dp = asset_data.get("dictParameters") or {}
+    min_v = dp.get("blenderVersionMin") or None
+    max_v = dp.get("blenderVersionMax") or None
+    cur = bpy.app.version
+    mn = _parse_version_string(min_v)
+    mx = _parse_version_string(max_v)
+    if (mn and cur < mn) or (mx and cur > mx):
+        return False, min_v, max_v
+    return True, min_v, max_v
+
+
+def is_addon_blender_compatible(asset_data) -> bool:
+    return get_addon_blender_compatibility(asset_data)[0]
+
+
 def get_addon_version() -> str:
     """Get BlenderKit addon version as string in format X.Y.Z."""
     ver = global_vars.VERSION


### PR DESCRIPTION
Mark and gate Blender-incompatible addons in the asset bar

Adds detection of addons whose declared Blender version range does not
include the running Blender, plus UI affordances and an install-time
confirmation gate.

Changes
- utils.py: add `get_blender_version()`, `_parse_version_string()`,
  `get_addon_blender_compatibility()` and `is_addon_blender_compatible()`.
  Reads `dictParameters.blenderVersionMin` / `blenderVersionMax`; missing
  bound = unlimited.
- __init__.py: new `search_compatible_only` BoolProperty on
  `BlenderKitAddonSearchProps` (default False).
- ui_panels.py: "Compatible Only" toggle in the advanced addon search panel.
- search.py: when `search_compatible_only` is set, filter incompatible
  addons out of `handle_search_task` results; propagate flag via
  `ui_state["addon_props"]`.
- asset_bar_op.py: per-button `compat_overlay` (dark red translucent
  overlay) shown for incompatible addon thumbnails. Tooltip reuses the
  existing `version_warning` widget to display the required range vs. the
  current Blender version.
- download.py (`BlenderkitAddonChoiceOperator`): on INSTALL_* actions for
  incompatible addons, show a red warning box with the version range and
  require an "Install anyway (incompatible)" checkbox before proceeding.

Behavior
- Addons missing one or both bounds are treated as unrestricted.
- Non-addon assets are unaffected by the filter, overlay and gate.