### PR TITLE
New cliend endpoint - run_blender_script that can work on assets.

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -324,6 +324,12 @@ func main() {
 	mux.HandleFunc("/blender/asset_upload", assetUploadHandler)
 	mux.HandleFunc("/"+vapi+"/blender/asset_upload", assetUploadHandler)
 
+	// HOST-AGNOSTIC: run a Python recipe under headless Blender.
+	// Used by external embedders (e.g. the Rhino plug-in) and
+	// available for the add-on's own future bg-script migrations.
+	mux.HandleFunc("/run_blender_script", runBlenderScriptHandler)
+	mux.HandleFunc("/"+vapi+"/run_blender_script", runBlenderScriptHandler)
+
 	// API HANDLERS
 	mux.HandleFunc("/profiles/download_gravatar_image", DownloadGravatarImageHandler)
 	mux.HandleFunc("/"+vapi+"/profiles/download_gravatar_image", DownloadGravatarImageHandler)

--- a/client/run_blender_script.go
+++ b/client/run_blender_script.go
@@ -1,0 +1,281 @@
+/*##### BEGIN GPL LICENSE BLOCK #####
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+##### END GPL LICENSE BLOCK #####*/
+
+// POST /run_blender_script — generic "run a Python recipe under
+// headless Blender" endpoint.
+//
+// Caller picks a recipe via:
+//   - script_id   : looks up <exe_dir>/tools/<id>.py (set
+//                   $BLENDERKIT_TOOLS_DIR to override). Use this for
+//                   stable recipes shipped with the binary.
+//   - script_path : absolute path to a caller-supplied script. Escape
+//                   hatch for embedder-specific work.
+//
+// `params` is forwarded to the script as a temp JSON file (passed as
+// the last arg after `--`); the recipe parses it. The client never
+// inspects the params, so embedders evolve schemas freely.
+//
+// `blender_exe_path` is required: callers know where their Blender is
+// (Blender add-on uses `bpy.app.binary_path`; external embedders
+// resolve it themselves). Keeps the client out of platform-specific
+// install-path discovery.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// RunBlenderScriptData is the JSON body of POST /run_blender_script.
+// Caller MUST set exactly one of ScriptID or ScriptPath, plus
+// BlenderExePath.
+type RunBlenderScriptData struct {
+	ScriptID   string `json:"script_id,omitempty"`
+	ScriptPath string `json:"script_path,omitempty"`
+
+	BlenderExePath string `json:"blender_exe_path"`
+
+	BlendPath  string                 `json:"blend_path,omitempty"`
+	OutputPath string                 `json:"output_path,omitempty"`
+	Params     map[string]interface{} `json:"params,omitempty"`
+
+	StatusMessage   string `json:"status_message,omitempty"`
+	AppID           int    `json:"app_id"`
+	AddonVersion    string `json:"addon_version"`
+	PlatformVersion string `json:"platform_version"`
+	Software        string `json:"software"`
+}
+
+func runBlenderScriptHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error reading request body: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	var data RunBlenderScriptData
+	if err := json.Unmarshal(body, &data); err != nil {
+		http.Error(w, "Error parsing JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if data.ScriptID == "" && data.ScriptPath == "" {
+		http.Error(w, "either script_id or script_path is required", http.StatusBadRequest)
+		return
+	}
+	if data.ScriptID != "" && data.ScriptPath != "" {
+		http.Error(w, "set either script_id or script_path, not both", http.StatusBadRequest)
+		return
+	}
+	if data.BlenderExePath == "" {
+		http.Error(w, "blender_exe_path is required", http.StatusBadRequest)
+		return
+	}
+
+	taskID := uuid.New().String()
+	go doRunBlenderScript(data, taskID)
+
+	respJSON, _ := json.Marshal(map[string]string{"task_id": taskID})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respJSON)
+}
+
+// resolveBundledScript maps a script_id to an absolute file path.
+// Lookup order:
+//  1. $BLENDERKIT_TOOLS_DIR/<id>.py   - explicit override (dev)
+//  2. <exe_dir>/tools/<id>.py         - production layout
+//  3. <cwd>/tools/<id>.py             - `go run` dev fallback
+func resolveBundledScript(id string) (string, error) {
+	if env := os.Getenv("BLENDERKIT_TOOLS_DIR"); env != "" {
+		p := filepath.Join(env, id+".py")
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	if exe, err := os.Executable(); err == nil {
+		p := filepath.Join(filepath.Dir(exe), "tools", id+".py")
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		p := filepath.Join(cwd, "tools", id+".py")
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("script_id %q not found (looked under $BLENDERKIT_TOOLS_DIR, <exe>/tools/, <cwd>/tools/)", id)
+}
+
+func doRunBlenderScript(data RunBlenderScriptData, taskID string) {
+	TasksMux.Lock()
+	if Tasks[data.AppID] == nil {
+		BKLog.Printf("%s run_blender_script: AppID %d not subscribed yet — registering it.", EmoWarning, data.AppID)
+		SubscribeNewApp(MinimalTaskData{AppID: data.AppID})
+	}
+	task := NewTask(data, data.AppID, taskID, "run_blender_script")
+	task.Message = "Queued"
+	Tasks[data.AppID][taskID] = task
+	TasksMux.Unlock()
+
+	scriptPath := data.ScriptPath
+	if scriptPath == "" {
+		var err error
+		scriptPath, err = resolveBundledScript(data.ScriptID)
+		if err != nil {
+			TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID, Error: err}
+			return
+		}
+	}
+
+	// Cache: skip the run if the requested output already exists.
+	if data.OutputPath != "" {
+		if info, err := os.Stat(data.OutputPath); err == nil && info.Size() > 0 {
+			TaskFinishCh <- &TaskFinish{
+				AppID: data.AppID, TaskID: taskID,
+				Message: "Cached output already present",
+				Result:  map[string]interface{}{"file_path": data.OutputPath},
+			}
+			return
+		}
+	}
+
+	if data.BlendPath != "" {
+		if _, err := os.Stat(data.BlendPath); err != nil {
+			TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+				Error: fmt.Errorf("blend file missing: %s", data.BlendPath)}
+			return
+		}
+	}
+	if _, err := os.Stat(scriptPath); err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+			Error: fmt.Errorf("script file missing: %s", scriptPath)}
+		return
+	}
+	if _, err := os.Stat(data.BlenderExePath); err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+			Error: fmt.Errorf("blender_exe_path not found: %s", data.BlenderExePath)}
+		return
+	}
+
+	statusMsg := data.StatusMessage
+	if statusMsg == "" {
+		statusMsg = "Running script…"
+	}
+
+	// Materialize Params to a temp JSON file. The recipe reads it from
+	// sys.argv[-1] (every script in tools/ follows this convention).
+	var paramsPath string
+	if data.Params != nil {
+		f, err := os.CreateTemp("", "blenderkit_params_*.json")
+		if err != nil {
+			TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+				Error: fmt.Errorf("creating params tempfile: %w", err)}
+			return
+		}
+		paramsPath = f.Name()
+		if err := json.NewEncoder(f).Encode(data.Params); err != nil {
+			f.Close()
+			os.Remove(paramsPath)
+			TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+				Error: fmt.Errorf("writing params json: %w", err)}
+			return
+		}
+		f.Close()
+		defer os.Remove(paramsPath)
+	}
+
+	TaskProgressUpdateCh <- &TaskProgressUpdate{
+		AppID: data.AppID, TaskID: taskID, Progress: 10, Message: "Launching Blender",
+	}
+
+	// blender --background [<blend>] --python <script> -- [<params.json>]
+	cmdArgs := []string{"--background"}
+	if data.BlendPath != "" {
+		cmdArgs = append(cmdArgs, data.BlendPath)
+	}
+	cmdArgs = append(cmdArgs, "--python", scriptPath, "--")
+	if paramsPath != "" {
+		cmdArgs = append(cmdArgs, paramsPath)
+	}
+
+	cmd := exec.Command(data.BlenderExePath, cmdArgs...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID, Error: fmt.Errorf("stdout pipe: %w", err)}
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID, Error: fmt.Errorf("stderr pipe: %w", err)}
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID, Error: fmt.Errorf("starting blender: %w", err)}
+		return
+	}
+
+	// Stream stdout/stderr as task messages with non-blocking sends so a
+	// flooded TaskMessageCh can't wedge cmd.Wait.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	streamReader := func(r io.Reader, prefix string) {
+		defer wg.Done()
+		s := bufio.NewScanner(r)
+		s.Buffer(make([]byte, 64*1024), 1024*1024)
+		for s.Scan() {
+			update := &TaskMessageUpdate{
+				AppID: data.AppID, TaskID: taskID,
+				Message: statusMsg, MessageDetailed: prefix + s.Text(),
+			}
+			select {
+			case TaskMessageCh <- update:
+			default:
+			}
+		}
+	}
+	go streamReader(stdout, "[blender] ")
+	go streamReader(stderr, "[blender err] ")
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+			Error: fmt.Errorf("blender exited with error: %w", err)}
+		return
+	}
+
+	result := map[string]interface{}{}
+	if data.OutputPath != "" {
+		info, err := os.Stat(data.OutputPath)
+		if err != nil || info.Size() == 0 {
+			TaskErrorCh <- &TaskError{AppID: data.AppID, TaskID: taskID,
+				Error: errors.New("script produced no output at " + data.OutputPath)}
+			return
+		}
+		result["file_path"] = data.OutputPath
+	}
+	TaskFinishCh <- &TaskFinish{
+		AppID:   data.AppID,
+		TaskID:  taskID,
+		Message: "Script finished",
+		Result:  result,
+	}
+}

--- a/client/tools/export_glb.py
+++ b/client/tools/export_glb.py
@@ -11,6 +11,7 @@ Recipe ABI (every script in tools/ follows this):
         draco       : bool  (default False)
         export_apply: bool  (default True)
 """
+
 import json
 import sys
 
@@ -20,7 +21,7 @@ argv = sys.argv
 if "--" not in argv:
     print("export_glb: missing -- separator", file=sys.stderr)
     sys.exit(2)
-argv = argv[argv.index("--") + 1:]
+argv = argv[argv.index("--") + 1 :]
 if not argv:
     print("export_glb: no params.json path given after --", file=sys.stderr)
     sys.exit(2)

--- a/client/tools/export_glb.py
+++ b/client/tools/export_glb.py
@@ -77,8 +77,10 @@ def ensure_gltf_addon():
                 candidates.append(modname)
                 seen.add(modname)
     except Exception as scan_exc:  # noqa: BLE001
-        print(f"export_glb: addon_utils scan failed ({scan_exc!r}); falling back to known names.",
-              file=sys.stderr)
+        print(
+            f"export_glb: addon_utils scan failed ({scan_exc!r}); falling back to known names.",
+            file=sys.stderr,
+        )
 
     # 2) Always also try well-known module names — covers the case
     #    where the extensions repo index hasn't been built yet on a

--- a/client/tools/export_glb.py
+++ b/client/tools/export_glb.py
@@ -1,0 +1,44 @@
+"""tools/export_glb.py - bundled BlenderKit-client recipe.
+
+Re-exports the active scene to .glb. Invoked via
+POST /run_blender_script with `script_id="export_glb"`.
+
+Recipe ABI (every script in tools/ follows this):
+    sys.argv = [..., "--", <params.json>]
+    params.json keys (this script):
+        output_path : str   (required) - destination .glb
+        yup         : bool  (default True)
+        draco       : bool  (default False)
+        export_apply: bool  (default True)
+"""
+import json
+import sys
+
+import bpy
+
+argv = sys.argv
+if "--" not in argv:
+    print("export_glb: missing -- separator", file=sys.stderr)
+    sys.exit(2)
+argv = argv[argv.index("--") + 1:]
+if not argv:
+    print("export_glb: no params.json path given after --", file=sys.stderr)
+    sys.exit(2)
+
+with open(argv[-1], "r", encoding="utf-8") as fh:
+    params = json.load(fh)
+
+out_glb = params["output_path"]
+print("export_glb: writing", out_glb)
+
+bpy.ops.export_scene.gltf(
+    filepath=out_glb,
+    export_format="GLB",
+    export_draco_mesh_compression_enable=bool(params.get("draco", False)),
+    export_yup=bool(params.get("yup", True)),
+    use_visible=False,
+    use_active_collection=False,
+    export_apply=bool(params.get("export_apply", True)),
+)
+
+print("export_glb: done")

--- a/client/tools/export_glb.py
+++ b/client/tools/export_glb.py
@@ -17,6 +17,111 @@ import sys
 
 import bpy
 
+
+def ensure_gltf_addon():
+    """Make sure ``bpy.ops.export_scene.gltf`` is callable.
+
+    The glTF I/O addon ships with Blender but isn't always enabled by
+    default — when it isn't, ``export_scene.gltf`` raises
+    ``AttributeError: ... has no attribute 'gltf'`` and the export
+    fails before we get a useful error. Worse, the module name has
+    moved over time:
+
+      * Blender 3.x / 4.0 / 4.1: classic addon ``io_scene_gltf2``.
+      * Blender 4.2+: bundled extensions repo. Module is
+        ``bl_ext.<repo_id>.io_scene_gltf2`` where ``repo_id`` varies
+        per install (``system``, ``user_default``, ``blender_org``).
+
+    A hand-maintained list of names will rot, so we discover candidates
+    dynamically with ``addon_utils.modules()`` and pick anything whose
+    bl_info advertises a glTF importer/exporter — then fall back to a
+    short list of known names if the scan didn't find any (e.g. the
+    extensions repo wasn't refreshed yet).
+
+    Enabling goes through ``addon_utils.enable(default_set=True)`` so
+    the change is persistent (saved into userprefs after we
+    ``save_userpref`` — non-fatal if that step can't write to the prefs
+    file in a sandboxed background run).
+    """
+    if hasattr(bpy.ops.export_scene, "gltf"):
+        return  # already available — nothing to do
+
+    try:
+        import addon_utils
+    except Exception as exc:  # noqa: BLE001
+        # No addon_utils means we're inside something that's not real
+        # Blender — bail with a clear error instead of carrying on.
+        raise RuntimeError(
+            f"export_glb: addon_utils unavailable ({exc!r}); cannot enable glTF addon."
+        )
+
+    # 1) Discover by scanning installed modules. Survives the
+    #    addon→extension rename without us tracking module paths.
+    candidates = []
+    seen = set()
+    try:
+        for mod in addon_utils.modules(refresh=False):
+            modname = getattr(mod, "__name__", None)
+            if not modname or modname in seen:
+                continue
+            try:
+                info = addon_utils.module_bl_info(mod) or {}
+            except Exception:  # noqa: BLE001
+                info = {}
+            name = (info.get("name") or "").lower()
+            cat = (info.get("category") or "").lower()
+            # bl_info names are stable: "glTF 2.0 format" for both the
+            # classic addon and the extension. Match on substring so
+            # any future rename (eg. "glTF 3.0") still picks it up.
+            if "gltf" in name or ("import-export" in cat and "gltf" in modname.lower()):
+                candidates.append(modname)
+                seen.add(modname)
+    except Exception as scan_exc:  # noqa: BLE001
+        print(f"export_glb: addon_utils scan failed ({scan_exc!r}); falling back to known names.",
+              file=sys.stderr)
+
+    # 2) Always also try well-known module names — covers the case
+    #    where the extensions repo index hasn't been built yet on a
+    #    fresh Blender install.
+    for name in (
+        "io_scene_gltf2",
+        "bl_ext.system.io_scene_gltf2",
+        "bl_ext.user_default.io_scene_gltf2",
+        "bl_ext.blender_org.io_scene_gltf2",
+    ):
+        if name not in seen:
+            candidates.append(name)
+            seen.add(name)
+
+    last_err = None
+    for module in candidates:
+        try:
+            mod = addon_utils.enable(module, default_set=True, persistent=True)
+        except Exception as exc:  # noqa: BLE001 - Blender raises mixed types
+            last_err = exc
+            continue
+        if mod is None:
+            # enable() returns None when the module wasn't found.
+            continue
+        if hasattr(bpy.ops.export_scene, "gltf"):
+            print(f"export_glb: enabled glTF addon ({module})")
+            try:
+                bpy.ops.wm.save_userpref()
+            except Exception as save_exc:  # noqa: BLE001
+                # Headless / read-only-prefs runs can't persist; the
+                # in-process enable is still enough for THIS export.
+                print(
+                    f"export_glb: enabled but couldn't save prefs ({save_exc!r})",
+                    file=sys.stderr,
+                )
+            return
+
+    raise RuntimeError(
+        "export_glb: could not enable glTF addon. "
+        f"tried_candidates={candidates} last_err={last_err!r}"
+    )
+
+
 argv = sys.argv
 if "--" not in argv:
     print("export_glb: missing -- separator", file=sys.stderr)
@@ -28,6 +133,8 @@ if not argv:
 
 with open(argv[-1], "r", encoding="utf-8") as fh:
     params = json.load(fh)
+
+ensure_gltf_addon()
 
 out_glb = params["output_path"]
 print("export_glb: writing", out_glb)


### PR DESCRIPTION
This is by now made so Rhino can export it's own .glb files. 
The logic is- each app can have specific requirements for export. each app can use asset resolutions.

 That would make possibly hundreds of files per asset, so it's best to make and store those which users really need on users computers. 

It also allows us to ship rhino plugin before we regenerate all the gltfs on our server. 

The setbacks is mainly time needed for conversion on users machines, and lack of proper compatibility matrix that we need to finish asap. 

Since some .blends simply don't convert to .glb and we need to mark that and not show those to rhino users.