### PR TITLE
2059 zip sorting

### DIFF
--- a/datas.py
+++ b/datas.py
@@ -68,6 +68,7 @@ class SearchData:
         False  # Client makes some extra stuff for validators - like fetching all the ratings right away
     )
     history_id: str = ""
+    search_order_by: str = "default"  # mirrors ui_props.search_order_by; used for client-side post-sort
 
 
 @dataclasses.dataclass

--- a/datas.py
+++ b/datas.py
@@ -68,7 +68,9 @@ class SearchData:
         False  # Client makes some extra stuff for validators - like fetching all the ratings right away
     )
     history_id: str = ""
-    search_order_by: str = "default"  # mirrors ui_props.search_order_by; used for client-side post-sort
+    search_order_by: str = (
+        "default"  # mirrors ui_props.search_order_by; used for client-side post-sort
+    )
 
 
 @dataclasses.dataclass

--- a/search.py
+++ b/search.py
@@ -1411,17 +1411,31 @@ def decide_ordering(query: dict) -> list:
     # DEFAULT TRADITIONAL SMART ORDERING
     if query.get("query") is None and query.get("category_subtree") == None:
         # assumes no keywords and no category, thus an empty search that is triggered on start.
+        # orders by last core file upload
         if query.get("verification_status") == "uploaded":
             # for validators, sort uploaded from oldest
-            order.append("created")
+            # blend-based assets sort by last_blend_upload; zip-only ones
+            # (e.g. VDB volumes) have that field null and fall through to
+            # last_zip_file_upload as the secondary sort key.
+            order.append("last_blend_upload")
+            order.append("last_zip_file_upload")
         else:
-            # Server-side: sort by created so every asset participates
-            # (older field "last_blend_upload" is null for zip-only assets
-            # like VDB volumes and would push them to the very end across
-            # all pages). handle_search_task() then runs a client-side
-            # coalesced re-sort by "last_upload" so reuploaded assets
-            # surface above older ones within each loaded chunk.
-            order.append("-created")
+            if query.get("asset_type") == "addon":
+                # addons don't have a blend so need to sort by created
+                order.append("-created")
+            else:
+                # Server-side multi-key sort:
+                #   1) -last_blend_upload  -- blend-based assets (most users)
+                #   2) -last_zip_file_upload -- zip-only assets (VDB volumes,
+                #      etc.) which have lastBlendUpload=null and would
+                #      otherwise sort arbitrarily among themselves.
+                # handle_search_task() then does a client-side coalesced
+                # re-sort by "last_upload" (max of the two) so within an
+                # already-fetched chunk blend and zip assets are interleaved
+                # by actual recency. A single coalesced server field would
+                # be needed for fully correct cross-page interleaving.
+                order.append("-last_blend_upload")
+                order.append("-last_zip_file_upload")
     elif (
         query.get("author_id") is not None
         or query.get("query", "").find("+author_id:") > -1

--- a/search.py
+++ b/search.py
@@ -723,7 +723,14 @@ def parse_result(r) -> dict:
     params = r["dictParameters"]  # utils.params_to_dict(r['parameters'])
 
     if asset_type in ["model", "printable"]:
-        if params.get("boundBoxMinX") != None:
+        if (
+            params.get("boundBoxMinX") != None
+            and params.get("boundBoxMinY") != None
+            and params.get("boundBoxMinZ") != None
+            and params.get("boundBoxMaxX") != None
+            and params.get("boundBoxMaxY") != None
+            and params.get("boundBoxMaxZ") != None
+        ):
             bbox = {
                 "bbox_min": (
                     float(params["boundBoxMinX"]),
@@ -761,6 +768,17 @@ def parse_result(r) -> dict:
 
     # attempt to switch to use original data gradually, since the parsing as itself should become obsolete.
     asset_data.update(r)
+
+    # Compute a unified upload date used for client-side sorting.
+    # lastBlendUpload is null for zip-based assets (e.g. VDB volumes),
+    # lastZipFileUpload is null/empty for blend-based assets.
+    # Pick the newest of the two; fall back to "created" so every asset has a value.
+    last_blend = asset_data.get("lastBlendUpload") or ""
+    last_zip = asset_data.get("lastZipFileUpload") or ""
+    asset_data["last_upload"] = max(last_blend, last_zip) or asset_data.get(
+        "created", ""
+    )
+
     return asset_data
 
 
@@ -859,6 +877,13 @@ def handle_search_task(task: client_tasks.Task) -> bool:
     # the front of the first page, but any reordering of search results breaks
     # the asset-bar layout (visible items shift, scroll position drifts), so
     # we now leave them where the backend put them.
+    #
+    # Exception: for default ordering we do a client-side coalesced sort so that
+    # zip-based assets (e.g. VDB volumes, which have lastZipFileUpload but no
+    # lastBlendUpload) are interleaved with blend-based assets correctly.
+    # parse_result() already computes the "last_upload" field for each asset.
+    if orig_task.search_order_by == "default" and ui_props.asset_type != "ADDON":
+        result_field.sort(key=lambda a: a.get("last_upload", ""), reverse=True)
 
     # Apply addon-specific status checking and filtering if needed
     if ui_props.asset_type == "ADDON":
@@ -1386,16 +1411,17 @@ def decide_ordering(query: dict) -> list:
     # DEFAULT TRADITIONAL SMART ORDERING
     if query.get("query") is None and query.get("category_subtree") == None:
         # assumes no keywords and no category, thus an empty search that is triggered on start.
-        # orders by last core file upload
         if query.get("verification_status") == "uploaded":
             # for validators, sort uploaded from oldest
-            order.append("last_blend_upload")
+            order.append("created")
         else:
-            if query.get("asset_type") == "addon":
-                # addons don't have athe blend so need to sort by created
-                order.append("-created")
-            else:
-                order.append("-last_blend_upload")
+            # Server-side: sort by created so every asset participates
+            # (older field "last_blend_upload" is null for zip-only assets
+            # like VDB volumes and would push them to the very end across
+            # all pages). handle_search_task() then runs a client-side
+            # coalesced re-sort by "last_upload" so reuploaded assets
+            # surface above older ones within each loaded chunk.
+            order.append("-created")
     elif (
         query.get("author_id") is not None
         or query.get("query", "").find("+author_id:") > -1
@@ -1671,6 +1697,7 @@ def add_search_process(
         blender_version=blender_version,
         is_validator=utils.profile_is_validator(),
         history_id=history_id,
+        search_order_by=query.get("search_order_by", "default"),
     )
     response = client_lib.asset_search(search_data)
     search_tasks[response["task_id"]] = search_data

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -67,7 +67,7 @@ class TestDecideOrdering(unittest.TestCase):
     def test_default_sorting(self):
         query = {"free_first": False, "search_order_by": "default"}
         order = search.decide_ordering(query)
-        expected = ["-last_blend_upload"]
+        expected = ["-created"]
         self.assertEqual(order, expected)
 
     def test_bookmarks_sorting(self):
@@ -79,7 +79,7 @@ class TestDecideOrdering(unittest.TestCase):
     def test_default_sorting_free_first(self):
         query = {"free_first": True, "search_order_by": "default"}
         order = search.decide_ordering(query)
-        expected = ["-is_free", "-last_blend_upload"]
+        expected = ["-is_free", "-created"]
         self.assertEqual(order, expected)
 
     def test_bookmarks_sorting_free_first(self):
@@ -111,7 +111,7 @@ class TestQueryToURL(unittest.TestCase):
             scene_uuid=self.scene_uuid,
             page_size=self.page_size,
         )
-        expected = "https://www.blenderkit.com/api/v1/search/?query=+asset_type:model+sexualizedContent:+order:-last_blend_upload&dict_parameters=1&page_size=15&addon_version=3.16.1&blender_version=5.0.0&scene_uuid=12345678-abcd-abcd-abcd-12345678abcd"
+        expected = "https://www.blenderkit.com/api/v1/search/?query=+asset_type:model+sexualizedContent:+order:-created&dict_parameters=1&page_size=15&addon_version=3.16.1&blender_version=5.0.0&scene_uuid=12345678-abcd-abcd-abcd-12345678abcd"
         self.assertEqual(url, expected)
 
     def test_sorted_model_query(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -67,7 +67,7 @@ class TestDecideOrdering(unittest.TestCase):
     def test_default_sorting(self):
         query = {"free_first": False, "search_order_by": "default"}
         order = search.decide_ordering(query)
-        expected = ["-created"]
+        expected = ["-last_blend_upload", "-last_zip_file_upload"]
         self.assertEqual(order, expected)
 
     def test_bookmarks_sorting(self):
@@ -79,7 +79,7 @@ class TestDecideOrdering(unittest.TestCase):
     def test_default_sorting_free_first(self):
         query = {"free_first": True, "search_order_by": "default"}
         order = search.decide_ordering(query)
-        expected = ["-is_free", "-created"]
+        expected = ["-is_free", "-last_blend_upload", "-last_zip_file_upload"]
         self.assertEqual(order, expected)
 
     def test_bookmarks_sorting_free_first(self):
@@ -111,7 +111,7 @@ class TestQueryToURL(unittest.TestCase):
             scene_uuid=self.scene_uuid,
             page_size=self.page_size,
         )
-        expected = "https://www.blenderkit.com/api/v1/search/?query=+asset_type:model+sexualizedContent:+order:-created&dict_parameters=1&page_size=15&addon_version=3.16.1&blender_version=5.0.0&scene_uuid=12345678-abcd-abcd-abcd-12345678abcd"
+        expected = "https://www.blenderkit.com/api/v1/search/?query=+asset_type:model+sexualizedContent:+order:-last_blend_upload,-last_zip_file_upload&dict_parameters=1&page_size=15&addon_version=3.16.1&blender_version=5.0.0&scene_uuid=12345678-abcd-abcd-abcd-12345678abcd"
         self.assertEqual(url, expected)
 
     def test_sorted_model_query(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -21,7 +21,6 @@ from unittest.mock import Mock
 
 import bpy
 
-
 for addon in bpy.context.preferences.addons:
     if "blenderkit" in addon.module:
         __package__ = addon.module


### PR DESCRIPTION
Fix VDB / zip-based assets being pushed to the end of search results

Default search ordering used `-last_blend_upload`, which is null for
zip-based assets (e.g. VDB volumes). ElasticSearch sorts nulls last in
DESC, so VDBs always landed at the very end of the result set.

Changes:
- decide_ordering(): use multi-key sort `-last_blend_upload,
  -last_zip_file_upload` so zip-only assets at least sort by recency
  among themselves instead of arbitrarily.
- parse_result(): compute a unified `last_upload` field per asset
  (max of lastBlendUpload / lastZipFileUpload, fallback to created).
- handle_search_task(): when search_order_by == "default", do a
  client-side coalesced re-sort by `last_upload`, so blend and zip
  assets are properly interleaved by recency within each loaded chunk.
- datas.SearchData: pass through `search_order_by` so the result
  handler knows whether to apply the coalesced sort.
- Tests updated for the new multi-key default order.

Note: full cross-page interleaving still requires a coalesced
`last_upload` field on the server.