### PR TITLE
fix: Handle missing comments widget 

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -1595,6 +1595,13 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         if not utils.profile_is_validator():
             return
 
+        # The comments label widget is only created during tooltip setup when
+        # the validator/popup-counter condition was true at that moment. If
+        # the profile only became a validator after the asset bar was already
+        # built, the widget won't exist — silently skip in that case.
+        if not hasattr(self, "comments"):
+            return
+
         if asset_data.get("assetType") == "author":
             self.comments.text = ""
             return

--- a/download.py
+++ b/download.py
@@ -1366,8 +1366,11 @@ def download_write_progress(task_id, task):
     # go through search results to write progress to display progress bars
     sr = search.get_search_results()
     if sr is not None:
+        asset_id = task.data["asset_data"]["id"]
         for r in sr:
-            if task.data["asset_data"]["id"] == r["id"]:
+            # Some entries (e.g. authors, very old assets) may not have an
+            # "id" field — skip them rather than crashing.
+            if r.get("id") == asset_id:
                 r["downloaded"] = task.progress
 
 

--- a/search.py
+++ b/search.py
@@ -873,17 +873,20 @@ def handle_search_task(task: client_tasks.Task) -> bool:
     for aid in pending_comment_ids:
         client_lib.get_comments(aid)
 
-    # Results are kept in arrival order. Previously authors were promoted to
-    # the front of the first page, but any reordering of search results breaks
-    # the asset-bar layout (visible items shift, scroll position drifts), so
-    # we now leave them where the backend put them.
+    # Results are kept strictly in arrival order. The asset bar relies on
+    # stable positions: once an asset is placed it must never move, otherwise
+    # the layout (and the user's scroll position) jumps every time a new page
+    # arrives. This applies to authors as well — they are appended in the
+    # order the backend returned them and are never promoted/resorted on the
+    # client.
     #
-    # Exception: for default ordering we do a client-side coalesced sort so that
-    # zip-based assets (e.g. VDB volumes, which have lastZipFileUpload but no
-    # lastBlendUpload) are interleaved with blend-based assets correctly.
-    # parse_result() already computes the "last_upload" field for each asset.
-    if orig_task.search_order_by == "default" and ui_props.asset_type != "ADDON":
-        result_field.sort(key=lambda a: a.get("last_upload", ""), reverse=True)
+    # A previous version did a client-side coalesced sort by
+    # max(lastBlendUpload, lastZipFileUpload) here so that zip-only assets
+    # (e.g. VDB volumes) interleaved with blend-based ones. That re-sort was
+    # applied to the union of all already-fetched pages on every get_next,
+    # which actively reshuffled previously-placed items. The proper fix
+    # belongs on the server (a single coalesced "-last_core_upload" sort
+    # key); until then, we trust the server order verbatim.
 
     # Apply addon-specific status checking and filtering if needed
     if ui_props.asset_type == "ADDON":


### PR DESCRIPTION
and improve asset download progress handling

Changes:

    Stop client-side resorting of accumulated search results to keep asset-bar item positions stable across paged results.
    Make download progress propagation resilient to search-result rows missing "id".
    Guard validator comment-tooltip updates when the comments widget wasn’t created.
