### PR TITLE
fix: smooth scrolling disabled for old Blender versions

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional, Union
 
 import bpy
+import gpu
 from bpy.props import BoolProperty, StringProperty
 
 from .. import (
@@ -96,6 +97,15 @@ SCROLL_SETTLE_PX = 0.5  # px; below this the animation stops entirely
 SCROLL_INPUT_GAP = 0.05  # s; idle gap before inertia takes over
 SCROLL_DT_CAP = 0.1  # s; max frame dt (avoid jumps after lag spikes)
 SCROLL_VELOCITY_SAMPLE = 0.06  # s; window over which trackpad velocity is averaged
+
+# Smooth scroll relies on per-frame partial-row offsets that need the
+# GPU scissor API (gpu.state.scissor_test_set / scissor_set) to clip
+# top/bottom rows during the animation so they don't spill outside the
+# asset bar. That API is reliably available from Blender 3.6+; on older
+# versions we fall back to immediate integer-row scrolling.
+SMOOTH_SCROLL_SUPPORTED = bpy.app.version >= (3, 6, 0) and hasattr(
+    gpu.state, "scissor_test_set"
+)
 # Per wheel-notch velocity boost, expressed as a multiple of one slot per
 # second. With v0 = step_px * SCROLL_WHEEL_NOTCH_VELOCITY and exponential
 # friction decay at SCROLL_FRICTION, each notch glides ~one slot before
@@ -4585,6 +4595,42 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             self._scroll_velocity = 0.0
             self._scroll_animating = False
             self._scroll_travel_dir = 0
+
+        # On Blender versions without GPU scissor we can't clip partial rows,
+        # so smooth-scroll rows would visibly spill outside the bar. Fall
+        # back to immediate integer-row stepping for wheel events and just
+        # ignore trackpad pan (which has no natural discrete equivalent).
+        if not SMOOTH_SCROLL_SUPPORTED:
+            if event.type == "TRACKPADPAN":
+                # Accumulate trackpad delta into whole-slot steps without
+                # animating phase. We still respect the user's sensitivity.
+                dx = event.mouse_x - event.mouse_prev_x
+                dy = event.mouse_y - event.mouse_prev_y
+                axis_delta = float(dy) if abs(dy) >= abs(dx) else float(-dx)
+                sensitivity = self._get_trackpad_sensitivity()
+                self._legacy_trackpad_accum = (
+                    getattr(self, "_legacy_trackpad_accum", 0.0) + axis_delta
+                )
+                steps_committed = 0
+                while self._legacy_trackpad_accum >= sensitivity:
+                    self._legacy_trackpad_accum -= sensitivity
+                    steps_committed += 1
+                while self._legacy_trackpad_accum <= -sensitivity:
+                    self._legacy_trackpad_accum += sensitivity
+                    steps_committed -= 1
+                if steps_committed:
+                    self.scroll_offset += steps_committed * slot_per_step
+                    self.scroll_update()
+                    if context.region is not None:
+                        context.region.tag_redraw()
+                return True
+
+            steps = 1 if event.type in _WHEEL_FORWARD else -1
+            self.scroll_offset += steps * slot_per_step
+            self.scroll_update()
+            if context.region is not None:
+                context.region.tag_redraw()
+            return True
 
         if event.type == "TRACKPADPAN":
             dx = event.mouse_x - event.mouse_prev_x

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -12,6 +12,20 @@ from .bl_ui_widget import region_redraw
 bk_logger = logging.getLogger(__name__)
 
 
+def _widget_outside_clip(widget, clip):
+    """Return True when widget's screen rect is fully outside the clip rect.
+
+    ``clip`` is a (top, bottom, left, right) tuple in widget (top-down) coords.
+    """
+    gt, gb, gl, gr = clip
+    return (
+        widget.y_screen + widget.height <= gt
+        or widget.y_screen >= gb
+        or widget.x_screen + widget.width <= gl
+        or widget.x_screen >= gr
+    )
+
+
 def get_safely(obj, attr_name, default=None):
     """Get attribute from object while tolerating freed data."""
     try:
@@ -115,15 +129,12 @@ class BL_UI_OT_draw_operator(Operator):
         grid_clip = _compute_grid_clip(self)
         # Iterate reversed so top/front widgets get priority on overlap.
         for widget in reversed(self.widgets):
-            if getattr(widget, "_is_grid_widget", False) and grid_clip is not None:
-                gt, gb, gl, gr = grid_clip
-                if (
-                    widget.y_screen + widget.height <= gt
-                    or widget.y_screen >= gb
-                    or widget.x_screen + widget.width <= gl
-                    or widget.x_screen >= gr
-                ):
-                    continue
+            if (
+                getattr(widget, "_is_grid_widget", False)
+                and grid_clip is not None
+                and _widget_outside_clip(widget, grid_clip)
+            ):
+                continue
             if widget.handle_event(event):
                 return True
         return False
@@ -187,42 +198,56 @@ def draw_callback_px_separated(self, op, context):
 
         region = getattr(context, "region", None)
 
-        # Build the GPU scissor rect from the grid clip area.
-        # Widget coords are top-down from region top; scissor needs bottom-up
-        # framebuffer coords derived from the current GPU viewport.
-        grid_scissor = None
+        # Grid clipping strategy:
+        #  * Always cull widgets that are fully outside the visible bar.
+        #  * When the GPU scissor API is available (Blender 3.6+), also
+        #    clip partially-visible widgets so smooth-scroll animations
+        #    don't spill rows outside the bar. On older Blender versions
+        #    smooth scroll is disabled at the asset-bar level, so plain
+        #    culling is sufficient.
         grid_clip = _compute_grid_clip(self)
-        if grid_clip is not None and region is not None:
+        scissor_supported = hasattr(gpu.state, "scissor_test_set") and hasattr(
+            gpu.state, "scissor_set"
+        )
+        grid_scissor = None
+        if scissor_supported and grid_clip is not None and region is not None:
             gt, gb, gl, gr = grid_clip
-            vp = gpu.state.viewport_get()
-            rw = max(region.width, 1)
-            rh = max(region.height, 1)
-            sx = int(vp[0] + gl * vp[2] / rw)
-            sy = int(vp[1] + (region.height - gb) * vp[3] / rh)
-            sw = math.ceil((gr - gl) * vp[2] / rw)
-            sh = math.ceil((gb - gt) * vp[3] / rh)
-            if sw > 0 and sh > 0:
-                grid_scissor = (sx, sy, sw, sh)
+            try:
+                vp = gpu.state.viewport_get()
+            except Exception:  # noqa: BLE001
+                vp = None
+            if vp is not None:
+                rw = max(region.width, 1)
+                rh = max(region.height, 1)
+                sx = int(vp[0] + gl * vp[2] / rw)
+                sy = int(vp[1] + (region.height - gb) * vp[3] / rh)
+                sw = math.ceil((gr - gl) * vp[2] / rw)
+                sh = math.ceil((gb - gt) * vp[3] / rh)
+                if sw > 0 and sh > 0:
+                    grid_scissor = (sx, sy, sw, sh)
 
         with ui_bgl.overlay_matrix_guard(region):
             scissor_active = False
-
             for widget in self.widgets:
                 is_grid = getattr(widget, "_is_grid_widget", False)
+                if (
+                    is_grid
+                    and grid_clip is not None
+                    and _widget_outside_clip(widget, grid_clip)
+                ):
+                    continue
 
                 if is_grid and grid_scissor is not None:
                     if not scissor_active:
                         gpu.state.scissor_test_set(True)
                         gpu.state.scissor_set(*grid_scissor)
                         scissor_active = True
-                else:
-                    if scissor_active:
-                        gpu.state.scissor_test_set(False)
-                        scissor_active = False
+                elif scissor_active:
+                    gpu.state.scissor_test_set(False)
+                    scissor_active = False
 
                 widget.draw()
 
-            # Restore scissor if still active after the last widget
             if scissor_active:
                 gpu.state.scissor_test_set(False)
 


### PR DESCRIPTION
Fix asset bar grid clipping on Blender < 4.0

Older Blender versions (3.3 and earlier) crashed with:

    AttributeError: module 'gpu.state' has no attribute 'scissor_test_set'

`gpu.state.scissor_test_set` / `gpu.state.scissor_set` were added in
Blender 4.0, but the asset-bar grid clipping path called them
unconditionally.

Changes
-------

* `bl_ui_widgets/bl_ui_draw_op.py`
  - Always cull grid widgets fully outside the visible bar area.
  - Apply GPU scissor clipping only when `gpu.state.scissor_*` is
    available; otherwise the draw path is a no-op for clipping
    instead of raising AttributeError.
  - Extracted `_widget_outside_clip()` helper, reused by the event
    handler.

* `asset_bar/asset_bar_op.py`
  - Added `SMOOTH_SCROLL_SUPPORTED` flag, true only on Blender 3.6+
    where the GPU scissor API exists.
  - On unsupported versions, smooth scroll is disabled:
      * Wheel events step `scroll_offset` by whole rows immediately.
      * Trackpad pan accumulates into whole-slot steps using the
        existing sensitivity preference.
  - This avoids drawing partial-row offsets that would otherwise
    spill outside the asset bar on Blender < 3.6.

Result
------

* Blender 3.6+: behaviour unchanged (smooth scroll + scissor clip).
* Blender < 3.6: no crash, no row spillover; falls back to immediate
  integer-row scrolling.