### PR TITLE
feature: Add option to manage Local BlenderKit Asset Library

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,7 +100,10 @@
         "denoising",
         "depsgraph",
         "downloaders",
+        "embedder",
+        "embedders",
         "GLSL",
+        "Gltf",
         "idname",
         "instancers",
         "keepdims",
@@ -129,6 +132,7 @@
         "userpref",
         "vcol",
         "viewports",
+        "webp",
         "WHEELDOWNMOUSE",
         "WHEELUPMOUSE"
     ],

--- a/__init__.py
+++ b/__init__.py
@@ -2299,19 +2299,13 @@ class BlenderKitAddonPreferences(AddonPreferences):
         update=update_unpack,
     )
 
-    write_asset_metadata: BoolProperty(
-        name="Write Asset Metadata",
-        description="Write BlenderKit metadata into downloaded files so tags, description, and preview show in other scenes",
-        default=True,
-        update=utils.save_prefs,
-    )
-
     create_asset_library: BoolProperty(
-        name="Register BlenderKit Asset Library",
+        name="Register Local BlenderKit Asset Library",
         description="Automatically add (and keep in sync) a 'BlenderKit' entry in Blender's Asset Libraries pointing to the global directory.\n\n"
+        "This allows you to easily access your downloaded assets in the Asset Browser, and also ensures that metadata like tags and descriptions are available for your assets across all your projects. "
         "When disabled, BlenderKit will not modify your Asset Libraries list, and downloaded assets won't be unpacked in the background just to embed asset metadata "
         "(unless 'Unpack Files' is enabled). Disable this if you don't want BlenderKit to manage your Asset Browser entries",
-        default=True,
+        default=False,
         update=utils.save_prefs,
     )
 
@@ -2729,7 +2723,6 @@ In this case you should also set path to your system CA bundle containing proxy'
         if self.directory_behaviour in ("BOTH", "LOCAL"):
             locations_settings.prop(self, "project_subdir")
         locations_settings.prop(self, "unpack_files")
-        locations_settings.prop(self, "write_asset_metadata")
         locations_settings.prop(self, "create_asset_library")
 
         # GUI SETTINGS

--- a/__init__.py
+++ b/__init__.py
@@ -2306,6 +2306,15 @@ class BlenderKitAddonPreferences(AddonPreferences):
         update=utils.save_prefs,
     )
 
+    create_asset_library: BoolProperty(
+        name="Register BlenderKit Asset Library",
+        description="Automatically add (and keep in sync) a 'BlenderKit' entry in Blender's Asset Libraries pointing to the global directory.\n\n"
+        "When disabled, BlenderKit will not modify your Asset Libraries list, and downloaded assets won't be unpacked in the background just to embed asset metadata "
+        "(unless 'Unpack Files' is enabled). Disable this if you don't want BlenderKit to manage your Asset Browser entries",
+        default=True,
+        update=utils.save_prefs,
+    )
+
     # resolution download/import settings
     resolution: EnumProperty(
         name="Max resolution",
@@ -2714,13 +2723,14 @@ In this case you should also set path to your system CA bundle containing proxy'
         # FILE PATHS
         locations_settings = layout.box()
         locations_settings.alignment = "EXPAND"
-        locations_settings.label(text="File paths")
+        locations_settings.label(text="File Paths and Data Handling")
         locations_settings.prop(self, "directory_behaviour")
         locations_settings.prop(self, "global_dir")
         if self.directory_behaviour in ("BOTH", "LOCAL"):
             locations_settings.prop(self, "project_subdir")
         locations_settings.prop(self, "unpack_files")
         locations_settings.prop(self, "write_asset_metadata")
+        locations_settings.prop(self, "create_asset_library")
 
         # GUI SETTINGS
         gui_settings = layout.box()

--- a/client/download.go
+++ b/client/download.go
@@ -77,7 +77,7 @@ func assetDownloadHandler(w http.ResponseWriter, r *http.Request) {
 		downloadData.DownloadAssetData,
 		downloadData.DownloadDirs,
 		downloadData.Preferences.UnpackFiles,
-		downloadData.Preferences.WriteAssetMetadata,
+		downloadData.Preferences.CreateAssetLibrary,
 		downloadData.Preferences.BinaryPath,
 		downloadData.Preferences.AddonDir,
 		downloadData.Preferences.AddonModuleName,
@@ -208,7 +208,7 @@ func doAssetDownload(
 	downloadAssetData DownloadAssetData,
 	downloadDirs []string,
 	unpackFiles bool,
-	writeAssetMetadata bool,
+	createAssetLibrary bool,
 	binaryPath string,
 	addonDir string,
 	addonModuleName string,
@@ -367,7 +367,7 @@ func doAssetDownload(
 	// the file format to match that Blender version. Re-running unpack on an already
 	// existing file ("place" or "sync") with a different Blender version would make the
 	// .blend unreadable by older Blenders.
-	shouldUnpack := (unpackFiles || writeAssetMetadata) && action == "download"
+	shouldUnpack := (unpackFiles || createAssetLibrary) && action == "download"
 	if shouldUnpack {
 		//err := UnpackAsset(fp, data, taskID)
 		assetDataRaw, _ := origJSON["asset_data"]
@@ -382,7 +382,7 @@ func doAssetDownload(
 			addonModuleName,
 			assetDataRaw,
 			unpackFiles,
-			writeAssetMetadata,
+			createAssetLibrary,
 		)
 		if err != nil {
 			BKLog.Printf("%s error unpacking asset (non-fatal, asset will still be placed): %v", EmoWarning, err)
@@ -438,7 +438,7 @@ func UnpackAsset(
 	addonModuleName string,
 	assetDataRaw interface{},
 	unpackFiles bool,
-	writeAssetMetadata bool,
+	createAssetLibrary bool,
 	//prefs PREFS,
 ) error {
 	// Unpacking and metadata write require opening a .blend in background Blender.
@@ -479,7 +479,7 @@ func UnpackAsset(
 		"command":    "unpack",
 		"prefs": map[string]interface{}{
 			"unpack_files":         unpackFiles,
-			"write_asset_metadata": writeAssetMetadata,
+			"create_asset_library": createAssetLibrary,
 		},
 	}
 	jsonData, err := json.Marshal(process_data)

--- a/client/structs.go
+++ b/client/structs.go
@@ -236,7 +236,7 @@ type PREFS struct {
 	SceneID            string `json:"scene_id"`
 	AppID              int    `json:"app_id"`
 	UnpackFiles        bool   `json:"unpack_files"`
-	WriteAssetMetadata bool   `json:"write_asset_metadata"`
+	CreateAssetLibrary bool   `json:"create_asset_library"`
 	Resolution         string `json:"resolution"` // "ORIGINAL", "resolution_0_5K", "resolution_1K", "resolution_2K", "resolution_4K", "resolution_8K"
 	// PATHS
 	ProjectSubdir   string `json:"project_subdir"`

--- a/datas.py
+++ b/datas.py
@@ -26,6 +26,7 @@ class Prefs:
     project_subdir: str
     unpack_files: bool
     write_asset_metadata: bool
+    create_asset_library: bool
     show_on_start: bool
     thumb_size: int
     maximized_assetbar_rows: int

--- a/datas.py
+++ b/datas.py
@@ -25,7 +25,6 @@ class Prefs:
     global_dir: str
     project_subdir: str
     unpack_files: bool
-    write_asset_metadata: bool
     create_asset_library: bool
     show_on_start: bool
     thumb_size: int

--- a/paths.py
+++ b/paths.py
@@ -239,6 +239,10 @@ def ensure_asset_library_path(
     if bpy.app.background:
         return
 
+    prefs = bpy.context.preferences.addons[__package__].preferences  # type: ignore
+    if not getattr(prefs, "create_asset_library", True):
+        return
+
     filepaths = getattr(bpy.context.preferences, "filepaths", None)
     asset_libraries = getattr(filepaths, "asset_libraries", None) if filepaths else None
     if asset_libraries is None:

--- a/paths.py
+++ b/paths.py
@@ -240,7 +240,7 @@ def ensure_asset_library_path(
         return
 
     prefs = bpy.context.preferences.addons[__package__].preferences  # type: ignore
-    if not getattr(prefs, "create_asset_library", True):
+    if not getattr(prefs, "create_asset_library", False):
         return
 
     filepaths = getattr(bpy.context.preferences, "filepaths", None)

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -100,9 +100,6 @@ def load_preferences_from_JSON():
     user_preferences.unpack_files = prefs.get(
         "unpack_files", user_preferences.unpack_files
     )
-    user_preferences.write_asset_metadata = prefs.get(
-        "write_asset_metadata", user_preferences.write_asset_metadata
-    )
     user_preferences.create_asset_library = prefs.get(
         "create_asset_library", user_preferences.create_asset_library
     )

--- a/persistent_preferences.py
+++ b/persistent_preferences.py
@@ -103,6 +103,9 @@ def load_preferences_from_JSON():
     user_preferences.write_asset_metadata = prefs.get(
         "write_asset_metadata", user_preferences.write_asset_metadata
     )
+    user_preferences.create_asset_library = prefs.get(
+        "create_asset_library", user_preferences.create_asset_library
+    )
 
     # GUI
     user_preferences.show_on_start = prefs.get(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,7 +72,11 @@ class Test01Registration(unittest.TestCase):
             "global_dir": user_preferences.global_dir,
             "project_subdir": user_preferences.project_subdir,
             "unpack_files": user_preferences.unpack_files,
-            "write_asset_metadata": user_preferences.write_asset_metadata,
+            "write_asset_metadata": (
+                user_preferences.write_asset_metadata
+                and user_preferences.create_asset_library
+            ),
+            "create_asset_library": user_preferences.create_asset_library,
             # GUI
             "show_on_start": user_preferences.show_on_start,
             "thumb_size": user_preferences.thumb_size,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,10 +72,6 @@ class Test01Registration(unittest.TestCase):
             "global_dir": user_preferences.global_dir,
             "project_subdir": user_preferences.project_subdir,
             "unpack_files": user_preferences.unpack_files,
-            "write_asset_metadata": (
-                user_preferences.write_asset_metadata
-                and user_preferences.create_asset_library
-            ),
             "create_asset_library": user_preferences.create_asset_library,
             # GUI
             "show_on_start": user_preferences.show_on_start,

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -2110,7 +2110,7 @@ class VIEW3D_PT_blenderkit_import_settings(Panel):
             "BRUSH",
         ]:
             layout.prop(preferences, "unpack_files")
-            layout.prop(preferences, "write_asset_metadata")
+            layout.prop(preferences, "create_asset_library")
             layout.prop(preferences, "resolution")
         elif ui_props.asset_type in ["HDR"]:
             layout.prop(preferences, "resolution")

--- a/unpack_asset_bg.py
+++ b/unpack_asset_bg.py
@@ -524,7 +524,7 @@ def unpack_asset(data):
 
     # assume write_metadata is true
     write_metadata = True
-    if data.get("prefs", {}).get("write_asset_metadata") is False:
+    if data.get("prefs", {}).get("create_asset_library") is False:
         write_metadata = False
 
     if unpack:

--- a/utils.py
+++ b/utils.py
@@ -537,10 +537,6 @@ def get_preferences_as_dict():
         "global_dir": user_preferences.global_dir,
         "project_subdir": user_preferences.project_subdir,
         "unpack_files": user_preferences.unpack_files,
-        "write_asset_metadata": (
-            user_preferences.write_asset_metadata
-            and user_preferences.create_asset_library
-        ),
         "create_asset_library": user_preferences.create_asset_library,
         # GUI
         "show_on_start": user_preferences.show_on_start,
@@ -594,10 +590,6 @@ def get_preferences() -> datas.Prefs:
         global_dir=user_preferences.global_dir,  # type: ignore[union-attr]
         project_subdir=user_preferences.project_subdir,  # type: ignore[union-attr]
         unpack_files=user_preferences.unpack_files,  # type: ignore[union-attr]
-        write_asset_metadata=(
-            user_preferences.write_asset_metadata  # type: ignore[union-attr]
-            and user_preferences.create_asset_library  # type: ignore[union-attr]
-        ),
         create_asset_library=user_preferences.create_asset_library,  # type: ignore[union-attr]
         # GUI
         show_on_start=user_preferences.show_on_start,  # type: ignore[union-attr]

--- a/utils.py
+++ b/utils.py
@@ -537,7 +537,11 @@ def get_preferences_as_dict():
         "global_dir": user_preferences.global_dir,
         "project_subdir": user_preferences.project_subdir,
         "unpack_files": user_preferences.unpack_files,
-        "write_asset_metadata": user_preferences.write_asset_metadata,
+        "write_asset_metadata": (
+            user_preferences.write_asset_metadata
+            and user_preferences.create_asset_library
+        ),
+        "create_asset_library": user_preferences.create_asset_library,
         # GUI
         "show_on_start": user_preferences.show_on_start,
         "thumb_size": user_preferences.thumb_size,
@@ -590,7 +594,11 @@ def get_preferences() -> datas.Prefs:
         global_dir=user_preferences.global_dir,  # type: ignore[union-attr]
         project_subdir=user_preferences.project_subdir,  # type: ignore[union-attr]
         unpack_files=user_preferences.unpack_files,  # type: ignore[union-attr]
-        write_asset_metadata=user_preferences.write_asset_metadata,  # type: ignore[union-attr]
+        write_asset_metadata=(
+            user_preferences.write_asset_metadata  # type: ignore[union-attr]
+            and user_preferences.create_asset_library  # type: ignore[union-attr]
+        ),
+        create_asset_library=user_preferences.create_asset_library,  # type: ignore[union-attr]
         # GUI
         show_on_start=user_preferences.show_on_start,  # type: ignore[union-attr]
         thumb_size=user_preferences.thumb_size,  # type: ignore[union-attr]


### PR DESCRIPTION
This enables users to disable local creation of asset libraries.
- created libraries are kept, but no new data are added