### PR TITLE
perf: smooth out asset bar thumbnail loading and scrolling

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -3030,7 +3030,10 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                 # (this loop runs every smooth-scroll frame over ~300 buttons).
                 # getattr default covers the first pass, before _grid_positioned
                 # has ever been assigned on freshly-created buffer buttons.
-                if not getattr(button, "_grid_positioned", False) and not button.visible:
+                if (
+                    not getattr(button, "_grid_positioned", False)
+                    and not button.visible
+                ):
                     continue
                 button._grid_positioned = False
                 button.visible = False

--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -48,7 +48,11 @@ from ..bl_ui_widgets.bl_ui_drag_panel import BL_UI_Drag_Panel
 from ..bl_ui_widgets.bl_ui_draw_op import BL_UI_OT_draw_operator
 from ..bl_ui_widgets.bl_ui_image import BL_UI_Image
 from ..bl_ui_widgets.bl_ui_label import BL_UI_Label, BL_UI_DuoLabel
-from ..bl_ui_widgets.bl_ui_widget import BL_UI_Widget
+from ..bl_ui_widgets.bl_ui_widget import (
+    BL_UI_Widget,
+    batched_region_redraw,
+    region_redraw,
+)
 
 bk_logger = logging.getLogger(__name__)
 
@@ -2992,34 +2996,50 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             x_end = self.wcount + SCROLL_BUFFER_COLS
             phase_x, phase_y = self.scroll_phase, 0.0
 
-        for y in range(y_start, y_end):
-            for x in range(x_start, x_end):
-                if i >= len(self.asset_buttons):
-                    break
-                asset_x = self.assetbar_margin + x * self.button_size - phase_x
-                asset_y = self.assetbar_margin + y * self.button_size - phase_y
-                logical_idx = x + y * self.wcount
+        # Reposition the grid (incl. buffer rows/cols) and hide the rest. Each
+        # set_location() inside would normally tag a redraw; coalesce them into
+        # a single redraw for the whole pass - this runs every smooth-scroll
+        # frame, so ~1000 redundant tag_redraw() calls per frame are avoided.
+        with batched_region_redraw():
+            for y in range(y_start, y_end):
+                for x in range(x_start, x_end):
+                    if i >= len(self.asset_buttons):
+                        break
+                    asset_x = self.assetbar_margin + x * self.button_size - phase_x
+                    asset_y = self.assetbar_margin + y * self.button_size - phase_y
+                    logical_idx = x + y * self.wcount
 
-                button = self.asset_buttons[i]
-                button.button_index = logical_idx
-                button._grid_positioned = True
-                self._position_single_button(
-                    button, asset_x, asset_y, logical_idx + self.scroll_offset, sr_len
-                )
-                i += 1
-            else:
-                continue
-            break
+                    button = self.asset_buttons[i]
+                    button.button_index = logical_idx
+                    button._grid_positioned = True
+                    self._position_single_button(
+                        button,
+                        asset_x,
+                        asset_y,
+                        logical_idx + self.scroll_offset,
+                        sr_len,
+                    )
+                    i += 1
+                else:
+                    continue
+                break
 
-        for a in range(i, len(self.asset_buttons)):
-            button = self.asset_buttons[a]
-            button._grid_positioned = False
-            button.visible = False
-            button.validation_icon.visible = False
-            button.bookmark_button.visible = False
-            button.author_button.visible = False
-            button.progress_bar.visible = False
-            button.red_alert.visible = False
+            for a in range(i, len(self.asset_buttons)):
+                button = self.asset_buttons[a]
+                # Already hidden by a previous pass - skip the redundant work
+                # (this loop runs every smooth-scroll frame over ~300 buttons).
+                # getattr default covers the first pass, before _grid_positioned
+                # has ever been assigned on freshly-created buffer buttons.
+                if not getattr(button, "_grid_positioned", False) and not button.visible:
+                    continue
+                button._grid_positioned = False
+                button.visible = False
+                button.validation_icon.visible = False
+                button.bookmark_button.visible = False
+                button.author_button.visible = False
+                button.progress_bar.visible = False
+                button.red_alert.visible = False
+        region_redraw()
 
         self.position_active_filter_buttons()
 

--- a/bl_ui_widgets/bl_ui_button.py
+++ b/bl_ui_widgets/bl_ui_button.py
@@ -159,7 +159,7 @@ class BL_UI_Button(BL_UI_Widget):
         else:
             self.shader.bind()
             self.shader.uniform_float("color", fill_color)
-            self.batch_panel.draw(self.shader)
+            self._draw_panel_batch()
 
         self.draw_image()
 

--- a/bl_ui_widgets/bl_ui_image.py
+++ b/bl_ui_widgets/bl_ui_image.py
@@ -97,7 +97,7 @@ class BL_UI_Image(BL_UI_Widget):
         self.shader.bind()
         self.shader.uniform_float("color", self._bg_color)
 
-        self.batch_panel.draw(self.shader)
+        self._draw_panel_batch()
 
     def draw_image(self):
         if self.__image is not None:

--- a/bl_ui_widgets/bl_ui_widget.py
+++ b/bl_ui_widgets/bl_ui_widget.py
@@ -5,6 +5,7 @@ from gpu_extras.batch import batch_for_shader
 
 from .. import ui_bgl
 
+from contextlib import contextmanager
 from typing import Union
 
 
@@ -40,13 +41,37 @@ def resolve_fill_color(preferred_color, fallback_color):
     return (clamp(r), clamp(g), clamp(b), clamp(a))
 
 
+_suppress_region_redraw = False
+
+
 def region_redraw(ctx: bpy.types.Context = None):
+    # Inside a batched_region_redraw() block, individual widget redraws are
+    # suppressed; the caller issues a single redraw afterwards.
+    if _suppress_region_redraw:
+        return
     if ctx is not None:
         context = ctx
     else:
         context = bpy.context
     if context.region is not None:
         context.region.tag_redraw()
+
+
+@contextmanager
+def batched_region_redraw():
+    """Suppress per-widget region_redraw() calls inside the block.
+
+    Bulk layout passes (e.g. repositioning hundreds of asset buttons on every
+    smooth-scroll frame) would otherwise tag a redraw once per widget. Wrap the
+    pass in this context and issue a single region_redraw() afterwards.
+    """
+    global _suppress_region_redraw
+    previous = _suppress_region_redraw
+    _suppress_region_redraw = True
+    try:
+        yield
+    finally:
+        _suppress_region_redraw = previous
 
 
 class BL_UI_Widget:
@@ -87,6 +112,12 @@ class BL_UI_Widget:
             self.shader = gpu.shader.from_builtin("2D_UNIFORM_COLOR")
         else:
             self.shader = gpu.shader.from_builtin("UNIFORM_COLOR")
+
+        # Background panel batch is built lazily, in local coordinates, and
+        # cached by size. Position is applied at draw time (see update() /
+        # _draw_panel_batch), so moving the widget does not rebuild the batch.
+        self.batch_panel = None
+        self._panel_batch_size = None
 
     @property
     def background_corner_radius(self):
@@ -274,33 +305,53 @@ class BL_UI_Widget:
         self.shader.bind()
         self.shader.uniform_float("color", self._bg_color)
 
-        self.batch_panel.draw(self.shader)
+        self._draw_panel_batch()
 
     def init(self, context):
         self.context = context
         self.update(self.x, self.y)
 
     def update(self, x, y):
-        area_height = self.get_area_height()
         self.x_screen = x
         self.y_screen = y
+        self._ensure_panel_batch()
+        region_redraw()
 
+    def _ensure_panel_batch(self):
+        """(Re)build the background batch only when the widget size changes.
+
+        Vertices are in local space (origin at the widget's top-left, y growing
+        downward); the screen position is applied at draw time via a translate.
+        Moving the widget - e.g. every frame during smooth scroll - therefore
+        no longer rebuilds the GPU batch, only an actual resize does.
+        """
+        size_key = (self.width, self.height)
+        if self.batch_panel is not None and self._panel_batch_size == size_key:
+            return
         indices = ((0, 1, 2), (0, 2, 3))
-
-        y_screen_flip = area_height - self.y_screen
-
-        # bottom left, top left, top right, bottom right
+        # top-left, bottom-left, bottom-right, top-right (local, y down)
         vertices = (
-            (self.x_screen, y_screen_flip),
-            (self.x_screen, y_screen_flip - self.height),
-            (self.x_screen + self.width, y_screen_flip - self.height),
-            (self.x_screen + self.width, y_screen_flip),
+            (0.0, 0.0),
+            (0.0, -self.height),
+            (self.width, -self.height),
+            (self.width, 0.0),
         )
-
         self.batch_panel = batch_for_shader(
             self.shader, "TRIS", {"pos": vertices}, indices=indices
         )
-        region_redraw()
+        self._panel_batch_size = size_key
+
+    def _draw_panel_batch(self):
+        """Draw the cached background batch at the widget's current position."""
+        if self.batch_panel is None:
+            self._ensure_panel_batch()
+        area_height = self.get_area_height()
+        gpu.matrix.push()
+        try:
+            gpu.matrix.translate((self.x_screen, area_height - self.y_screen))
+            self.batch_panel.draw(self.shader)
+        finally:
+            gpu.matrix.pop()
 
     def handle_event(self, event):
         """

--- a/timer.py
+++ b/timer.py
@@ -54,6 +54,15 @@ pending_tasks = (
     list()
 )  # pending tasks are tasks that were not parsed correctly and should be tried to be parsed later.
 
+# Max wall-clock time (seconds) spent building thumbnail GPU textures per timer
+# step. A search can complete many thumbnail downloads within one poll
+# interval; building every GPU texture in a single step blocks the main thread
+# (measured 480-650 ms bursts -> visible viewport stutter). We process finished
+# thumbnails only up to this budget and defer the rest to the next step, so the
+# work is spread across steps. Lower it for smoother frames; raise it to load
+# thumbnails faster at the cost of slightly bigger hitches.
+THUMBNAIL_BUILD_TIME_BUDGET = 0.1
+
 
 def handle_failed_reports(exception: Exception) -> float:
     """Function reacting to failing reports (Client is not accessible).
@@ -232,12 +241,40 @@ def client_communication_timer():
     results_converted_tasks.extend(pending_tasks)
     pending_tasks.clear()
 
+    # Throttle eager thumbnail GPU-texture builds so a burst of completed
+    # downloads doesn't freeze the viewport in a single step. Finished
+    # thumbnails are processed only up to THUMBNAIL_BUILD_TIME_BUDGET; the rest
+    # are re-queued for the next step. Cache hits cost ~0 ms so they don't eat
+    # the budget. Every other task type is handled immediately, never deferred.
+    #
+    # Small thumbnails are the asset-bar grid icons - cheap and the first thing
+    # the user sees - so they are always built immediately and never deferred.
+    # Only the larger full/photo/wire (tooltip-sized) thumbnails are throttled.
+    thumb_build_time = 0.0
+    deferred_thumbs = []
     for task in results_converted_tasks:
-        handle_task(task)
+        is_thumb = task.task_type == "thumbnail_download" and task.status == "finished"
+        deferrable = is_thumb and task.data.get("thumbnail_type") != "small"
+        if deferrable and thumb_build_time >= THUMBNAIL_BUILD_TIME_BUDGET:
+            deferred_thumbs.append(task)
+            continue
+        if is_thumb:
+            _t0 = time.perf_counter()
+            handle_task(task)
+            thumb_build_time += time.perf_counter() - _t0
+        else:
+            handle_task(task)
+
+    if deferred_thumbs:
+        # Re-queue for the next timer step (drained at the top of this function).
+        pending_tasks.extend(deferred_thumbs)
 
     download.prune_stalled_downloads(now=time.monotonic())
     bk_logger.log(5, "Task handling finished")
     delay = user_preferences.client_polling
+    if deferred_thumbs:
+        # Come back soon to keep draining the backlog without busy-polling.
+        return min(0.05, delay)
     if len(download.download_tasks) > 0:
         return min(0.2, delay)
     return delay


### PR DESCRIPTION
Three related optimizations to the asset bar, all measured live:

- timer: throttle eager thumbnail GPU-texture builds per timer step. A search completes many downloads within one poll interval; building every texture in a single step caused 480-650 ms main-thread freezes. Finished thumbnails are now processed up to a time budget and the rest deferred to the next step. Small (grid-icon) thumbnails are never deferred so the grid fills immediately; only large tooltip-sized ones are throttled.

- widgets: cache the background GPU batch by size and apply position via a draw-time translate instead of rebuilding the batch on every move. set_location dropped ~14.4 us -> ~1.3 us; this is in the shared widget base so it benefits all BlenderKit UI.

- asset bar: coalesce the ~1180 per-widget region_redraw() calls per reposition pass into one, and skip already-hidden buffer buttons in position_and_hide_buttons. That call dropped ~17 ms -> ~9 ms per smooth-scroll frame.