### PR TITLE
perf: apply smooth-scroll phase as a draw-time translate

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -2989,24 +2989,27 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             y_start = -SCROLL_BUFFER_ROWS
             y_end = self.hcount + SCROLL_BUFFER_ROWS
             x_start, x_end = 0, self.wcount
-            phase_x, phase_y = 0.0, self.scroll_phase
         else:
             y_start, y_end = 0, 1
             x_start = -SCROLL_BUFFER_COLS
             x_end = self.wcount + SCROLL_BUFFER_COLS
-            phase_x, phase_y = self.scroll_phase, 0.0
 
+        # Buttons are positioned at their integer grid slots. The sub-slot
+        # smooth-scroll offset (scroll_phase) is NOT baked into positions here;
+        # it is applied as a single draw-time translate in the asset-bar draw
+        # callback (see _update_grid_draw_offset). That way a smooth-scroll
+        # animation frame no longer repositions every grid widget.
+        #
         # Reposition the grid (incl. buffer rows/cols) and hide the rest. Each
         # set_location() inside would normally tag a redraw; coalesce them into
-        # a single redraw for the whole pass - this runs every smooth-scroll
-        # frame, so ~1000 redundant tag_redraw() calls per frame are avoided.
+        # a single redraw for the whole pass.
         with batched_region_redraw():
             for y in range(y_start, y_end):
                 for x in range(x_start, x_end):
                     if i >= len(self.asset_buttons):
                         break
-                    asset_x = self.assetbar_margin + x * self.button_size - phase_x
-                    asset_y = self.assetbar_margin + y * self.button_size - phase_y
+                    asset_x = self.assetbar_margin + x * self.button_size
+                    asset_y = self.assetbar_margin + y * self.button_size
                     logical_idx = x + y * self.wcount
 
                     button = self.asset_buttons[i]
@@ -3076,6 +3079,11 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         # While `_scroll_animating` is True the modal timer ticks the phase
         # toward rest (friction decay -> magnetic snap to zero).
         self.scroll_phase = 0.0
+        # Sub-slot scroll offset applied as a single draw-time gpu.matrix
+        # translate to all grid widgets (GPU coords: +x right, +y up), instead
+        # of repositioning every widget per animation frame. Updated from
+        # scroll_phase by _update_grid_draw_offset(); read by the draw callback.
+        self._grid_draw_offset = (0.0, 0.0)
         self._scroll_velocity = 0.0
         self._scroll_last_input_time = 0.0
         self._scroll_last_tick_time = 0.0
@@ -4320,6 +4328,9 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         if not self._scroll_animating and self.scroll_phase != 0.0:
             self.scroll_phase = 0.0
             self._scroll_velocity = 0.0
+        # Keep the draw-time grid offset in sync with the (possibly reset)
+        # phase so the grid never draws shifted while at rest.
+        self._update_grid_draw_offset()
         history_step = search.get_active_history_step()
         sr = history_step.get("search_results")
         sro = history_step.get("search_results_orig")
@@ -4479,27 +4490,34 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         if abs(self.scroll_phase) >= step_px:
             self.scroll_phase = 0.0
 
+    def _update_grid_draw_offset(self):
+        """Translate the grid by the sub-slot scroll phase at draw time.
+
+        Returns a GPU-space (dx, dy) offset (+x right, +y up). Buttons stay at
+        their integer slot positions; the draw callback applies this translate
+        to all grid widgets so they slide as one, with no per-widget work.
+        Mirrors the old per-frame ``asset_x = base - phase`` baking:
+        increasing ``scroll_phase`` moves multi-row grids up (+gpu_y) and
+        single-row grids left (-gpu_x).
+        """
+        if self.hcount > 1:
+            self._grid_draw_offset = (0.0, self.scroll_phase)
+        else:
+            self._grid_draw_offset = (-self.scroll_phase, 0.0)
+        return self._grid_draw_offset
+
     def _smooth_scroll_redraw(self):
-        """Reposition buttons with the current phase and request a redraw."""
-        self.position_and_hide_buttons()
+        """Apply the current scroll phase and request a redraw.
+
+        The sub-slot slide is now a single draw-time translate (see the draw
+        callback), so we no longer reposition every grid widget here - we just
+        refresh the draw offset and the scroll indicator, then tag a redraw.
+        """
+        self._update_grid_draw_offset()
         # Refresh the indicator each animation frame so its thumb glides
         # smoothly with the sub-slot phase. (`scroll_update` handles the
         # non-animated paths.)
         self._update_scroll_indicator()
-        panel = getattr(self, "panel", None)
-        if panel is not None:
-            px = panel.x_screen
-            py = panel.y_screen
-            extras = (
-                getattr(self, "button_expand", None),
-                getattr(self, "button_scroll_down", None),
-                getattr(self, "button_scroll_up", None),
-            )
-            for w in panel.widgets:
-                if getattr(w, "_is_grid_widget", False) or w in extras:
-                    if w is None:
-                        continue
-                    w.update(px + w.x, py + w.y)
         try:
             region = bpy.context.region
         except Exception:

--- a/asset_bar/asset_drag_op.py
+++ b/asset_bar/asset_drag_op.py
@@ -578,6 +578,7 @@ def mouse_raycast(
     Optional[int],
     Optional[bpy.types.Object],
     Optional[mathutils.Matrix],
+    Optional[bpy.types.Object],
 ]:
     coord = mx, my
 
@@ -603,6 +604,7 @@ def mouse_raycast(
         face_index,
         obj,
         matrix,
+        raw_first_obj,
     ) = deep_ray_cast(ray_origin, vec)
 
     # backface snapping inversion
@@ -649,6 +651,7 @@ def mouse_raycast(
         face_index,
         obj,
         matrix,
+        raw_first_obj,
     )
 
 
@@ -725,6 +728,7 @@ def deep_ray_cast(ray_origin: Vector, vec: Vector) -> Tuple[
     Optional[int],
     Optional[bpy.types.Object],
     Optional[mathutils.Matrix],
+    Optional[bpy.types.Object],
 ]:
     # this allows to ignore some objects, like objects with bounding box draw style or particle objects
     obj = None
@@ -738,7 +742,10 @@ def deep_ray_cast(ray_origin: Vector, vec: Vector) -> Tuple[
         obj,
         matrix,
     ) = bpy.context.scene.ray_cast(depsgraph, ray_origin, vec)
-    empty_set = False, Vector((0, 0, 0)), Vector((0, 0, 1)), None, None, None
+    # The raw (unfiltered) first hit is returned so the caller can detect
+    # hovering over a particle-system instance without a second scene ray_cast.
+    raw_first_obj = obj
+    empty_set = False, Vector((0, 0, 0)), Vector((0, 0, 1)), None, None, None, raw_first_obj
     if not obj:
         return empty_set
     try_object = obj
@@ -769,7 +776,15 @@ def deep_ray_cast(ray_origin: Vector, vec: Vector) -> Tuple[
     if try_object is None:
         return empty_set
     if not (obj.display_type == "BOUNDS" or object_in_particle_collection(try_object)):
-        return has_hit, snapped_location, snapped_normal, face_index, obj, matrix
+        return (
+            has_hit,
+            snapped_location,
+            snapped_normal,
+            face_index,
+            obj,
+            matrix,
+            raw_first_obj,
+        )
     return empty_set
 
 
@@ -1772,6 +1787,9 @@ class AssetDragOperator(bpy.types.Operator):
                     if region_data is not None:
                         break
 
+        # Raw (unfiltered) first hit from mouse_raycast, reused below to detect
+        # hovering over a particle-system instance without a second ray_cast.
+        raw_first_obj = None
         # Need to temporarily override context for raycasting
         if bpy.app.version < (3, 2, 0):  # B3.0, B3.1 - custom context override
             override = {
@@ -1791,6 +1809,7 @@ class AssetDragOperator(bpy.types.Operator):
                 self.face_index,
                 obj,
                 self.matrix,
+                raw_first_obj,
             ) = mouse_raycast(active_region, region_data, self.mouse_x, self.mouse_y)
             if obj is not None:
                 self.object_name = obj.name
@@ -1806,6 +1825,7 @@ class AssetDragOperator(bpy.types.Operator):
                     self.face_index,
                     obj,
                     self.matrix,
+                    raw_first_obj,
                 ) = mouse_raycast(
                     active_region,
                     region_data,
@@ -1873,27 +1893,18 @@ class AssetDragOperator(bpy.types.Operator):
                     else:
                         self.object_name = None
 
-        # Detect if the cursor is over an object that was filtered out of
-        # drag snapping because it's used as a particle-system instance.
-        # We raw ray-cast once (no filtering) to see the "real" hit.
-        if region_data is not None:
-            try:
-                coord = (self.mouse_x, self.mouse_y)
-                raw_view_vector = view3d_utils.region_2d_to_vector_3d(
-                    active_region, region_data, coord
-                )
-                raw_ray_origin = view3d_utils.region_2d_to_origin_3d(
-                    active_region, region_data, coord, clamp=1.0
-                )
-                depsgraph = context.view_layer.depsgraph
-                raw_hit, _, _, _, raw_obj, _ = context.scene.ray_cast(
-                    depsgraph, raw_ray_origin, raw_view_vector * 1000000
-                )
-                if raw_hit and raw_obj and object_in_particle_collection(raw_obj):
-                    self.over_particle_instance = True
-            except Exception:
-                # Informational only — never break drag on detection failure.
-                pass
+        # Detect if the cursor is over an object that was filtered out of drag
+        # snapping because it's used as a particle-system instance. mouse_raycast
+        # already returns the raw (unfiltered) first hit, so we reuse it here
+        # instead of doing a second full scene ray_cast every drag frame.
+        try:
+            if raw_first_obj is not None and object_in_particle_collection(
+                raw_first_obj
+            ):
+                self.over_particle_instance = True
+        except Exception:
+            # Informational only — never break drag on detection failure.
+            pass
 
     def _handle_node_editor_type(
         self, current_area_type: Union[str, None], active_area: bpy.types.Area

--- a/asset_bar/asset_drag_op.py
+++ b/asset_bar/asset_drag_op.py
@@ -745,7 +745,15 @@ def deep_ray_cast(ray_origin: Vector, vec: Vector) -> Tuple[
     # The raw (unfiltered) first hit is returned so the caller can detect
     # hovering over a particle-system instance without a second scene ray_cast.
     raw_first_obj = obj
-    empty_set = False, Vector((0, 0, 0)), Vector((0, 0, 1)), None, None, None, raw_first_obj
+    empty_set = (
+        False,
+        Vector((0, 0, 0)),
+        Vector((0, 0, 1)),
+        None,
+        None,
+        None,
+        raw_first_obj,
+    )
     if not obj:
         return empty_set
     try_object = obj

--- a/bl_ui_widgets/bl_ui_draw_op.py
+++ b/bl_ui_widgets/bl_ui_draw_op.py
@@ -226,14 +226,29 @@ def draw_callback_px_separated(self, op, context):
                 if sw > 0 and sh > 0:
                     grid_scissor = (sx, sy, sw, sh)
 
+        # Smooth-scroll sub-slot offset is applied as a single draw-time
+        # translate to all grid widgets (GPU coords, +x right / +y up) instead
+        # of repositioning each widget per frame. While it's non-zero, expand
+        # the *cull* clip by one slot so buffer widgets sliding into view are
+        # not culled; the GPU scissor stays at the exact bar bounds so partial
+        # widgets are still clipped precisely.
+        grid_offset = get_safely(self, "_grid_draw_offset", (0.0, 0.0))
+        offset_dx, offset_dy = grid_offset
+        has_grid_offset = offset_dx != 0.0 or offset_dy != 0.0
+        cull_clip = grid_clip
+        if has_grid_offset and grid_clip is not None:
+            bs = get_safely(self, "button_size", 0) or 0
+            gt, gb, gl, gr = grid_clip
+            cull_clip = (gt - bs, gb + bs, gl - bs, gr + bs)
+
         with ui_bgl.overlay_matrix_guard(region):
             scissor_active = False
             for widget in self.widgets:
                 is_grid = getattr(widget, "_is_grid_widget", False)
                 if (
                     is_grid
-                    and grid_clip is not None
-                    and _widget_outside_clip(widget, grid_clip)
+                    and cull_clip is not None
+                    and _widget_outside_clip(widget, cull_clip)
                 ):
                     continue
 
@@ -246,7 +261,13 @@ def draw_callback_px_separated(self, op, context):
                     gpu.state.scissor_test_set(False)
                     scissor_active = False
 
-                widget.draw()
+                if is_grid and has_grid_offset:
+                    gpu.matrix.push()
+                    gpu.matrix.translate((offset_dx, offset_dy))
+                    widget.draw()
+                    gpu.matrix.pop()
+                else:
+                    widget.draw()
 
             if scissor_active:
                 gpu.state.scissor_test_set(False)


### PR DESCRIPTION
The asset bar repositioned all ~150 visible grid widgets every smooth-scroll animation frame to apply the sub-slot scroll phase (~15 ms/frame in a heavy scene). Position buttons at their integer grid slots instead and apply the sub-slot phase as a single gpu.matrix translate on all grid widgets in the draw callback.
- position_and_hide_buttons: no longer bakes scroll_phase into positions; now only runs on layout changes / integer row-crossings.
- _smooth_scroll_redraw: per frame just updates the draw offset + scroll indicator and tags a redraw (15 ms -> 0.035 ms).
- draw callback: translate grid widgets by the offset; cull clip expanded one slot so buffer rows sliding in aren't culled (GPU scissor stays exact, partial widgets still clipped to the bar). Known minor tradeoff: during the inertia coast, hover hit-testing uses the integer slot positions while the grid is drawn offset (snaps exact when the animation settles).