### PR TITLE
ci(codecov): enable coverage status checks and PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,11 @@
 coverage:
   status:
-    project: off
-    patch: off
-comment: false
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+comment: true
 fixes:
   - "/home/runner/.config/blender/*/scripts/addons/::"


### PR DESCRIPTION
CI already uploads Go + Python coverage to Codecov on every PR/push; this flips Codecov from silent (status off, comment false) to reporting — project & patch status (target=auto) plus the PR coverage comment.

Split out of #1953 so the asset-bar feature PR stays scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)