### PR TITLE
fix(codecov): use a comment mapping so PR comments actually post

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,9 @@ coverage:
     patch:
       default:
         target: auto
-comment: true
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
 fixes:
   - "/home/runner/.config/blender/*/scripts/addons/::"


### PR DESCRIPTION
Follow-up to #2174. `comment: true` validates but Codecov's notifier doesn't treat the bare boolean as an enabled comment config — so status checks post but the PR coverage comment never appears (seen on #1953). Replace it with an explicit `comment:` mapping (default layout/behavior, require_changes: false) to actually enable comments.

This PR doubles as the test: if a Codecov comment shows up here, the config was the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)