### PR TITLE
fix(coverage): measure the add-on package as installed, not the source tree

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -25,8 +25,13 @@ if COLLECT_COVERAGE:
     try:
         import coverage as _coverage
 
-        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        _cov = _coverage.Coverage(source=[project_root])
+        # Measure the add-on *package* as it is actually imported. Blender loads
+        # the add-on from its install dir (e.g. .../scripts/addons/blenderkit),
+        # NOT from this source checkout, so scoping coverage to the source tree
+        # records every add-on module as never-executed (0%). Scoping to the
+        # package name follows the imported files; codecov.yml `fixes` then maps
+        # the install path back to repo paths.
+        _cov = _coverage.Coverage(source=[sys.argv[-1]])
         _cov.start()
     except ImportError:
         COLLECT_COVERAGE = False


### PR DESCRIPTION
Coverage was scoped to the source checkout (`source=[project_root]`), but CI runs the tests against the **installed** copy of the add-on (`.../scripts/addons/<pkg>`). Different paths → every add-on module reported **0%** in Codecov (e.g. `asset_bar_op.py` is 0% even for its `import os` line), despite the tests running and passing.

Scope coverage to the enabled add-on package (`sys.argv[-1]`) so it follows the imported files; the existing `codecov.yml` `fixes` entry maps the install path back to repo paths.

Verified locally by reproducing the copy-install path mismatch: `asset_bar_op.py` went 0% → real coverage, `bl_ui_drag_panel.py` → 48%. This PR self-tests — repo coverage should jump well above its current ~5% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)