### PR TITLE
style: format tests/test.py with black + isort (fix main Checks)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -20,6 +20,7 @@ import os
 import sys
 import unittest
 
+
 COLLECT_COVERAGE = os.getenv("COVERAGE") == "1"
 if COLLECT_COVERAGE:
     try:
@@ -63,6 +64,7 @@ testLoader = unittest.TestLoader()
 
 def _discover(pattern):
     return testLoader.discover(_tests_dir, pattern, top_level_dir=_top_level)
+
 
 suite.addTests(_discover("test_init.py"))
 suite.addTests(_discover("test_upload.py"))


### PR DESCRIPTION
The previous commit on `main` (`129ff718`, test-file coverage discovery) wasn't lint-formatted, so the `Checks` (black/isort) job is failing on `main`. This formats `tests/test.py` (adds the two missing blank lines) — no logic change. The test matrix itself was passing.

Verified locally with CI's exact tools (black 25.x + isort 7.0): both `--check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)