### PR TITLE
Fix popup click-through

### DIFF
--- a/autothumb.py
+++ b/autothumb.py
@@ -396,6 +396,11 @@ class GenerateThumbnailOperator(bpy.types.Operator):
         return bpy.context.view_layer.objects.active is not None
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports autothumb)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         ui_props = bpy.context.window_manager.blenderkitUI
         asset_type = ui_props.asset_type
 
@@ -512,6 +517,11 @@ class GenerateWireframeThumbnailOperator(bpy.types.Operator):
         return bpy.context.view_layer.objects.active is not None
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports autothumb)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         ui_props = bpy.context.window_manager.blenderkitUI
         asset_type = ui_props.asset_type
 
@@ -705,6 +715,11 @@ class ReGenerateThumbnailOperator(bpy.types.Operator):
         return True  # bpy.context.view_layer.objects.active is not None
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports autothumb)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         props = self
         layout = self.layout
         layout.prop(props, "render_locally")
@@ -824,6 +839,11 @@ class GenerateMaterialThumbnailOperator(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports autothumb)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         props = bpy.context.active_object.active_material.blenderkit
         layout.prop(props, "thumbnail_generator_type")
@@ -995,6 +1015,11 @@ class ReGenerateMaterialThumbnailOperator(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports autothumb)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         props = self
         layout.prop(props, "render_locally")

--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -231,6 +231,11 @@ class LoginOnline(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        # local import to avoid circular import
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         utils.label_multiline(layout, text=self.message, width=300)
 

--- a/download.py
+++ b/download.py
@@ -1982,6 +1982,8 @@ class BlenderkitAddonChoiceOperator(bpy.types.Operator):
     )  # type: ignore
 
     def draw(self, context: bpy.types.Context) -> None:
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
 
         layout = self.layout
 
@@ -2525,7 +2527,7 @@ class BlenderkitDownloadOperator(bpy.types.Operator):
 
     def draw(self, context: bpy.types.Context) -> None:
         # this timer is there to not let double clicks through the popups down to the asset bar.
-        ui_panels.last_time_overlay_panel_active = time.time()
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         if self.invoke_resolution:
             layout.prop(self, "resolution", expand=True, icon_only=False)

--- a/ratings.py
+++ b/ratings.py
@@ -17,7 +17,6 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import logging
-import time
 
 import bpy
 from bpy.props import StringProperty
@@ -150,6 +149,7 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         return True
 
     def draw(self, context):
+        ui_panels.set_overlay_panel_active()
         # when rating gets recieved while the window is already open, we need to prefill.
         self.prefill_ratings()
 
@@ -186,11 +186,6 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         if self.asset_type != "author":
             ratings_utils.ensure_rating(self.asset_id)
             self.prefill_ratings()
-
-        # Update last popup activity time to prevent shortcut interference
-        from . import ui_panels
-
-        ui_panels.last_time_dropdown_active = time.time()
 
         if self.asset_type in ("model", "scene"):
             # spawn a wider one for validators for the enum buttons

--- a/search.py
+++ b/search.py
@@ -2408,6 +2408,11 @@ class AuthorAssetTypePopup(Operator):
         return wm.invoke_popup(self, width=200)
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports search)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         layout.label(text=self.author_name or "Author")
         layout.separator()

--- a/ui.py
+++ b/ui.py
@@ -257,6 +257,11 @@ class ParticlesDropDialog(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        # local import to avoid circular import (ui_panels imports ui)
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         message = (
             "This asset is a particle setup. Blendkit can apply particles to the active/drag-drop object."

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -84,10 +84,26 @@ INVALID_TOKENS = {
 last_time_overlay_panel_active = 0.0
 
 
+def set_overlay_panel_active():
+    """Record the time a BlenderKit popup/panel/popover was last drawn.
+
+    This is read in asset_bar_op.py to cancel asset drag-drop and to ignore
+    keyboard shortcuts for a short window afterwards. Without it, click-through
+    events that pass through a popup down to the asset bar underneath would be
+    wrongly interpreted as clicks/double-clicks on the asset bar.
+
+    Every operator popup, dialog and popover that can appear over the asset bar
+    should call this at the start of its draw() method.
+    """
+    global last_time_overlay_panel_active
+    last_time_overlay_panel_active = time.time()
+
+
 def draw_not_logged_in(source, message="Please Login/Signup to use this feature"):
     title = "You aren't logged in"
 
     def draw_message(source, context):
+        set_overlay_panel_active()
         layout = source.layout
         utils.label_multiline(layout, text=message)
         draw_login_buttons(layout)
@@ -259,6 +275,7 @@ class BLENDERKIT_OT_show_validation_popup(bpy.types.Operator):
         return {"FINISHED"}
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         clean_text = self.message.replace("\r\n", "\n").replace("\r", "\n")
         # Keep rendering even if the text is short or empty.
@@ -301,6 +318,7 @@ class BLENDERKIT_OT_permissions_error_popup(bpy.types.Operator):
         return {"FINISHED"}
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
 
         # Light check for live UI — draw() runs on each redraw, avoid file I/O here
@@ -570,6 +588,10 @@ def draw_common_filters(layout, ui_props):
         layout: The UI layout to draw in
         ui_props: The UI properties containing filter settings
     """
+    # All "Search filters" panels are shown as popovers over the asset bar,
+    # so record the redraw time to prevent click-through to the asset bar.
+    set_overlay_panel_active()
+
     layout.separator()
 
     row = layout.row()
@@ -1351,6 +1373,7 @@ class ShowNotifications(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        set_overlay_panel_active()
         draw_notifications(self, context, width=600)
 
     def execute(self, context):
@@ -1603,6 +1626,10 @@ class VIEW3D_PT_blenderkit_advanced_model_search(Panel):
         )
 
     def draw_layout(self, layout):
+        # Shown as a popover over the asset bar — record redraw time to
+        # prevent click-through to the asset bar.
+        set_overlay_panel_active()
+
         wm = bpy.context.window_manager
         props = wm.blenderkit_models
         ui_props = wm.blenderkitUI
@@ -1705,6 +1732,10 @@ class VIEW3D_PT_blenderkit_advanced_material_search(Panel):
         return ui_props.down_up == "SEARCH" and ui_props.asset_type == "MATERIAL"
 
     def draw_layout(self, layout):
+        # Shown as a popover over the asset bar — record redraw time to
+        # prevent click-through to the asset bar.
+        set_overlay_panel_active()
+
         wm = bpy.context.window_manager
         props = wm.blenderkit_mat
         ui_props = wm.blenderkitUI
@@ -1937,8 +1968,7 @@ class VIEW3D_PT_blenderkit_categories(Panel):
     def draw(self, context):
         # measure time since last dropdown activation/ mouse hover e.t.c.
         # this is then used in asset_bar_op.py to cancel asset drag drop if the time is too small and thus means double clicking.
-        global last_time_overlay_panel_active
-        last_time_overlay_panel_active = time.time()
+        set_overlay_panel_active()
         draw_panel_categories(self.layout, context)
 
 
@@ -2223,6 +2253,7 @@ class BlenderKitWelcomeOperator(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         if self.step == 0:
             layout.template_icon(icon_value=self.img.preview.icon_id, scale=18)
@@ -2434,6 +2465,7 @@ class BLENDERKIT_OT_hdr_thumbnail_tune(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         layout.prop(self, "use_custom_tone")
         col = layout.column(align=True)
@@ -3835,8 +3867,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             op.comment_id = comment["id"]  # type: ignore
 
     def draw(self, context):
-        global last_time_overlay_panel_active
-        last_time_overlay_panel_active = time.time()
+        set_overlay_panel_active()
 
         layout = self.layout
         # top draggable bar with name of the asset
@@ -4100,6 +4131,7 @@ class PopupDialog(bpy.types.Operator):
     width: IntProperty(default=300)  # type: ignore[valid-type]
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         row = layout.row()
         row.label(text=self.message)
@@ -4129,6 +4161,7 @@ class UrlPopupDialog(bpy.types.Operator):
     width: IntProperty(name="width", description="width", default=300)  # type: ignore[valid-type]
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         row = layout.row()
         utils.label_multiline(layout, text=self.message, width=300)
@@ -4176,6 +4209,7 @@ class LoginPopupDialog(bpy.types.Operator):
     )
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         utils.label_multiline(layout, text=self.message, width=300)
 
@@ -4493,6 +4527,7 @@ def header_search_draw(self, context):
 
 def ui_message(title, message):
     def draw_message(self, context):
+        set_overlay_panel_active()
         layout = self.layout
         utils.label_multiline(layout, text=message, width=400)
 
@@ -4545,6 +4580,7 @@ class NodegroupDropDialog(bpy.types.Operator):
         return [mod for mod in target_obj.modifiers if mod.type == "NODES"]
 
     def draw(self, context):
+        set_overlay_panel_active()
         layout = self.layout
 
         # Get asset data for display

--- a/upload.py
+++ b/upload.py
@@ -973,6 +973,8 @@ class FastMetadata(bpy.types.Operator):
         return True
 
     def draw(self, context):
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         # col = layout.column()
         layout.label(text=self.message)
@@ -1703,6 +1705,8 @@ class UploadOperator(Operator):
         return {"FINISHED"}
 
     def draw(self, context):
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         props = utils.get_upload_props()
         layout = self.layout
 
@@ -1887,6 +1891,8 @@ class AssetVerificationStatusChange(Operator):
         return True
 
     def draw(self, context):
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         # if self.state == 'deleted':
         message = "Really delete asset from Blendkit online storage?"

--- a/warning_dialog.py
+++ b/warning_dialog.py
@@ -118,6 +118,11 @@ class BlenderKitMSStoreWarningOperator(bpy.types.Operator):
     bl_options = {"REGISTER", "INTERNAL"}
 
     def draw(self, context):
+        # local import to avoid circular import
+        from . import ui_panels
+
+        # this timer is there to not let double clicks through the popups down to the asset bar.
+        ui_panels.set_overlay_panel_active()
         layout = self.layout
         for line in _MS_STORE_LINES:
             # Empty rows render as a vertical spacer to mimic blank lines.


### PR DESCRIPTION
Fix better the case when a popup panel is clicked and the clicks go through to the asset bar:

1. Added a shared helper in ui_panels.py:87 — set_overlay_panel_active() — so the pattern is defined once and documented, and refactored the existing inline setters to use it.

2. Applied it to every popup/dialog/popover that can appear over the asset bar:

Filters — added to draw_common_filters() (covers scene/HDR/brush/nodegroup/addon/author/printable filter popovers) plus the model & material filter panels' draw_layout (they don't use the shared filter func). ui_panels.py — validation popup, permissions-error popup, notifications, welcome dialog, HDR resolution tune, PopupDialog, UrlPopupDialog, LoginPopupDialog, geometry-node drop dialog, and the two popup_menu message helpers (draw_not_logged_in, ui_message). download.py — addon-choice dialog (the main download dialog already had it; converted to the helper). ratings.py — fixed the broken setter: now calls the helper in draw(), removed the dead last_time_dropdown_active line and the now-unused import time. ui.py — particle-setup drag-drop dialog.
search.py — author asset-type popup.
upload.py — FastMetadata (opened from the asset bar context menu), UploadOperator, AssetVerificationStatusChange. autothumb.py — all 5 thumbnail-generator dialogs.
bkit_oauth.py — login dialog.
warning_dialog.py — MS Store warning dialog.
Files outside ui_panels.py that get imported by it use a local from . import ui_panels inside draw() to avoid circular imports (matching the existing pattern); download.py/upload.py already import it at module level so they call it directly.