### PR TITLE
Fix #2206 Do not prefill bug title and description when creating report from add-on

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-prefilled.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report-prefilled.yaml
@@ -1,0 +1,112 @@
+name: Bug Report
+description: Report a bug, crash, or other issue, prefilled with basic metadata from the add-on.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        *Please make the title as descriptive as possible, including part of the error message if applicable. This helps other users find and relate to your issue more easily.*
+
+        #### Before reporting a bug, please ensure the following:
+        - You have installed the [latest version of Blendkit](https://github.com/blenderkit/blenderkit/releases/latest), as the latest release may include a fix for your issue.
+        - You have restarted Blender after updating Blendkit. Skipping a restart can lead to unusual bugs; a restart often resolves issues immediately.
+        - You have searched for similar issues in the [Blendkit issues](https://github.com/blenderkit/blenderkit/issues). Existing threads may offer workarounds or solutions.
+
+        #### 3-Step Quick Help:
+        1. Uninstall Blendkit.
+        2. Install the [latest version of Blendkit](https://github.com/blenderkit/blenderkit/releases/latest) via Blender's UI, using the .zip file.
+        3. Restart Blender.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: |
+        Please describe the problem, the expected behavior, and any deviation from it. The development team needs to understand and reproduce the problem from your description in order to fix it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Logs
+      description: |
+        Ideally, please provide the error logs related to the problem. [Here's how to get error logs](https://www.blendkit.com/report-bug/).
+        Providing error logs enables us to diagnose and address the issue more efficiently.
+        We may be able to resolve the issue without the logs, but in most cases, we will request them.
+    validations:
+      required: false
+
+  - type: input
+    id: blendkit_version
+    attributes:
+      label: Blendkit add-on version
+      description: Menu > Edit > Preferences > Add-ons > Blendkit Online Asset Library
+    validations:
+      required: true
+
+  - type: input
+    id: blender_version
+    attributes:
+      label: Blender version
+      description: Menu > Blender Logo > Splash Screen or About Blender
+    validations:
+      required: true
+
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: |
+        Your operating system (and CPU architecture).
+        Windows 10, Windows 11 - on classic Intel/AMD processor (x86_64) or ARM64 processor?
+        MacOS - Apple Silicon or Intel based processor?
+        Linux - distribution and CPU architecture?
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      description: Scripting Workspace > Console > 1st line in console contains Python version
+    validations:
+      required: true
+
+  ### ADVANCED INFO
+
+  - type: input
+    id: proxy
+    attributes:
+      label: Proxy settings
+      description: Menu > Edit > Preferences > Add-ons > Blendkit Online Asset Library > Networking > Proxy settings (and Custom proxy address)
+    validations:
+      required: false
+
+  - type: input
+    id: ip_version
+    attributes:
+      label: IP version
+      description: Menu > Edit > Preferences > Add-ons > Blendkit Online Asset Library > Networking > IP version
+    validations:
+      required: false
+
+  - type: input
+    id: ssl_context
+    attributes:
+      label: SSL Verification
+      description: Menu > Edit > Preferences > Add-ons > Blendkit Online Asset Library > Networking > SSL Verification
+    validations:
+      required: false
+
+  - type: input
+    id: trusted_ca_certs
+    attributes:
+      label: Custom CA certificates path
+      description: Menu > Edit > Preferences > Add-ons > Blendkit Online Asset Library > Networking > Custom CA certificates path
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report this bug! Your input helps us improve Blendkit.

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -21,17 +21,32 @@ body:
     attributes:
       label: Bug Description
       description: |
-        Please describe the problem, the expected behavior, and any deviation from it. Including a screenshot is helpful, providing environment information is more beneficial, and adding a complete log is most advantageous (see below).
-      value: |
-        When I...
-
-        ### Environment Information - Bug happens on:
-        - Blendkit version: v3.y.z
-        - Blender version and source (blender.org, Steam, Snap, package manager, etc.): vX.Y.Z (from: )
-        - Operating system & architecture: Win10/Win11 (x86_64/ARM64), MacOS (Intel/Apple Silicon), Debian/Ubuntu/Fedora... (x86_64/ARM64)
-        - Using VPN, proxy, or firewall? (Yes/No/Not sure, please describe if applicable):
+        Please describe the problem, the expected behavior, and any deviation from it.
+        The development team needs to understand and reproduce the problem from your description in order to fix it.
+        If the problem is tied to your account, please provide an email under which you log in to Blendkit.com.
     validations:
       required: true
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional Information
+      description: |
+        Additional information about your OS and your system environment.
+        Which versions of add-on and Blender do you use?
+        Which operating system are you on?
+        Do you have any antivirus or firewall enabled?
+        Is your computer behind corporate proxy?
+    value: |
+        ### Environment Information - Bug happens on:
+        - Blendkit version: v3.y.z
+        - Blender version: vX.Y.Z
+        - How was Blender installed? (Installer from blender.org, from Microsoft Store, Steam etc.)
+        - Operating system & architecture: Windows11/Windows10 (x86_64/ARM64), MacOS (Intel/Apple Silicon), Debian/Ubuntu/Fedora... (x86_64/ARM64)
+        - Are you using VPN, proxy, or firewall?
+        - Are you behind corporate proxy or in state censoring/controlling internet traffic?
+    validations:
+      required: false
 
   - type: textarea
     id: logs
@@ -44,18 +59,6 @@ body:
     validations:
       required: false
 
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to Reproduce
-      description: |
-        Please outline the steps you took that led to the bug. If you're unsure of the exact steps, describe what you were doing when the bug occurred.
-      value: |
-        1.
-        2.
-        3.
-    validations:
-      required: false
 
   - type: markdown
     attributes:

--- a/__init__.py
+++ b/__init__.py
@@ -2721,14 +2721,16 @@ In this case you should also set path to your system CA bundle containing proxy'
             validator_box.label(text="Validator Settings")
             validator_box.prop(self, "categories_fix")
 
-        # REPORT PATHS
+        # REPORT BUG BUTTON
         report_settings = layout.box()
         report_settings.label(text="Report a Bug")
-        report_settings.label(
-            text="Create an issue report with version information to help us resolve the issue faster.",
+        report_row = report_settings.row()
+        report_row.operator(
+            "wm.blenderkit_report_bug", text="Open Bug Report", icon="ERROR"
         )
-        report_settings.operator(
-            "wm.blenderkit_report_bug", text="Submit Full Bug Report", icon="ERROR"
+        # report_row.label(text=f"Blendkit v{utils.get_addon_version()} · Blender {bpy.app.version_string}", icon="INFO")
+        report_row.operator(
+            "wm.blenderkit_copy_environment_info", text="Copy Info", icon="COPYDOWN"
         )
 
         # FILE PATHS

--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -1135,15 +1135,6 @@ def update_settings_ui(self, context, element=None):
     else:
         row.label(text="Last update check: Never")
 
-    version_row = box.row()
-    version_row.label(
-        text=f"Blendkit v{utils.get_addon_version()} · Blender {bpy.app.version_string}",
-        icon="INFO",
-    )
-    version_row.operator(
-        "wm.blenderkit_copy_environment_info", text="Copy Info", icon="COPYDOWN"
-    )
-
 
 def update_settings_ui_condensed(self, context, element=None):
     """Preferences - Condensed drawing within preferences.

--- a/tests/test_ui_panels.py
+++ b/tests/test_ui_panels.py
@@ -15,40 +15,81 @@ if __package__:
 from . import global_vars, ui_panels
 
 
-class TestGetEnvironmentInfo(unittest.TestCase):
+class TestGetEnvironmentInfoString(unittest.TestCase):
     def test_contains_addon_version_with_build_date(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         ver = global_vars.VERSION
         expected = f"v{ver[0]}.{ver[1]}.{ver[2]}.{ver[3]}"
         self.assertIn(expected, result)
 
     def test_contains_blender_version(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         self.assertIn(bpy.app.version_string, result)
 
     def test_contains_python_version(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         expected = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         self.assertIn(expected, result)
 
     def test_contains_os_info(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         self.assertIn(platform.system(), result)
         self.assertIn(platform.machine(), result)
 
     def test_contains_proxy_setting(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         user_preferences = bpy.context.preferences.addons[__package__].preferences
         self.assertIn(user_preferences.proxy_which, result)
 
+    def test_contains_trusted_ca_certs(self):
+        result = ui_panels.get_environment_info_string()
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
+        self.assertIn(user_preferences.trusted_ca_certs, result)
+
+    def test_contains_ssl_context(self):
+        result = ui_panels.get_environment_info_string()
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
+        self.assertIn(user_preferences.ssl_context, result)
+
+    def test_contains_ip_version(self):
+        result = ui_panels.get_environment_info_string()
+        user_preferences = bpy.context.preferences.addons[__package__].preferences
+        self.assertIn(user_preferences.ip_version, result)
+
     def test_contains_all_template_fields(self):
-        result = ui_panels.get_environment_info()
+        result = ui_panels.get_environment_info_string()
         self.assertIn("Blendkit version:", result)
         self.assertIn("Blender version:", result)
         self.assertIn("Python version:", result)
         self.assertIn("Operating system & architecture:", result)
         self.assertIn("Proxy setting:", result)
+        self.assertIn("Trusted CA certs path:", result)
+        self.assertIn("SSL verification:", result)
+        self.assertIn("IP version", result)
         self.assertIn("VPN, proxy, or firewall", result)
+
+
+class TestGetEnvironmentInfo(unittest.TestCase):
+    def test_contains_addon_version_with_build_date(self):
+        result = ui_panels.get_environment_info()
+        ver = global_vars.VERSION
+        expected = f"{ver[0]}.{ver[1]}.{ver[2]}.{ver[3]}"
+        self.assertIn(expected, result["addon_version"])
+
+    def test_contains_blender_version(self):
+        result = ui_panels.get_environment_info()
+        expected = bpy.app.version_string
+        self.assertIn(expected, result["blender_version"])
+
+    def test_contains_python_version(self):
+        result = ui_panels.get_environment_info()
+        expected = sys.version
+        self.assertIn(expected, result["python_version"])
+
+    def test_contains_os_information(self):
+        result = ui_panels.get_environment_info()
+        expected = f"{platform.system()} {platform.release()} ({platform.machine()})"
+        self.assertIn(expected, result["os"])
 
 
 class TestGetReportBugURL(unittest.TestCase):
@@ -60,17 +101,51 @@ class TestGetReportBugURL(unittest.TestCase):
 
     def test_uses_bug_report_template(self):
         url = ui_panels.get_report_bug_url()
-        self.assertIn("template=bug-report.yaml", url)
+        self.assertIn("template=bug-report-prefilled.yaml", url)
 
-    def test_prefills_title(self):
+    def test_does_not_prefill_title(self):
         url = ui_panels.get_report_bug_url()
-        self.assertIn("title=", url)
+        self.assertNotIn("title=", url)
 
-    def test_prefills_description_with_env_info(self):
+    def test_does_not_prefill_description(self):
+        url = ui_panels.get_report_bug_url()
+        self.assertNotIn("description=", url)
+
+    def test_prefills_blendkit_version(self):
         url = ui_panels.get_report_bug_url()
         decoded = unquote(url)
-        self.assertIn(bpy.app.version_string, decoded)
-        self.assertIn(platform.system(), decoded)
+        ver = global_vars.VERSION
+        expected = f"{ver[0]}.{ver[1]}.{ver[2]}.{ver[3]}"
+        self.assertIn(expected, decoded)
+
+    def test_prefills_blender_version(self):
+        url = ui_panels.get_report_bug_url()
+        decoded = unquote(url)
+        expected = bpy.app.version_string
+        self.assertIn(expected, decoded)
+
+    def test_prefills_python_version(self):
+        url = ui_panels.get_report_bug_url()
+        decoded = unquote(url)
+        expected = sys.version
+        self.assertIn(expected, decoded)
+
+    def test_prefills_os_information(self):
+        url = ui_panels.get_report_bug_url()
+        decoded = unquote(url)
+        expected = f"{platform.system()} {platform.release()} ({platform.machine()})"
+        self.assertIn(expected, decoded)
+
+    def test_contains_required_query_params(self):
+        url = ui_panels.get_report_bug_url()
+        self.assertIn("blendkit_version=", url)
+        self.assertIn("blender_version=", url)
+        self.assertIn("operating_system=", url)
+        self.assertIn("python_version=", url)
+        self.assertIn("proxy=", url)
+        self.assertIn("ip_version=", url)
+        self.assertIn("ssl_context=", url)
+        self.assertIn("trusted_ca_certs=", url)
 
 
 class TestCopyEnvironmentInfo(unittest.TestCase):

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -1548,55 +1548,91 @@ class OpenBlenderKitDiscord(bpy.types.Operator):
         return {"FINISHED"}
 
 
-def get_environment_info() -> str:
-    """Get formatted environment info for bug reports and clipboard."""
+def get_environment_info() -> dict:
+    info = {}
     ver = global_vars.VERSION
-    addon_ver = f"{ver[0]}.{ver[1]}.{ver[2]}.{ver[3]}"
-    blender_ver = bpy.app.version_string
-    os_info = f"{platform.system()} {platform.release()} ({platform.machine()})"
-    user_preferences = bpy.context.preferences.addons[__package__].preferences
-    proxy = user_preferences.proxy_which
-    python_ver = (
-        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-    )
+    info["addon_version"] = f"{ver[0]}.{ver[1]}.{ver[2]}.{ver[3]}"
+    info["blender_version"] = bpy.app.version_string
+    info["python_version"] = sys.version
+    info["os"] = f"{platform.system()} {platform.release()} ({platform.machine()})"
+    info["proxy_which"] = bpy.context.preferences.addons[
+        __package__
+    ].preferences.proxy_which
+    info["proxy_address"] = bpy.context.preferences.addons[
+        __package__
+    ].preferences.proxy_address
+    info["trusted_ca_certs"] = bpy.context.preferences.addons[
+        __package__
+    ].preferences.trusted_ca_certs
+    info["ssl_context"] = bpy.context.preferences.addons[
+        __package__
+    ].preferences.ssl_context
+    info["ip_version"] = bpy.context.preferences.addons[
+        __package__
+    ].preferences.ip_version
+    return info
+
+
+def get_environment_info_string() -> str:
+    """Get formatted environment info for bug reports and clipboard."""
+    info = get_environment_info()
+    proxy = f"{info['proxy_which']}"
+    if info["proxy_which"] == "CUSTOM":
+        proxy += f" ({info['proxy_address']})"
     return (
-        f"- Blendkit version: v{addon_ver}\n"
-        f"- Blender version: v{blender_ver} (from: )\n"
-        f"- Python version: {python_ver}\n"
-        f"- Operating system & architecture: {os_info}\n"
+        f"- Blendkit version: v{info['addon_version']}\n"
+        f"- Blender version: v{info['blender_version']} (from: )\n"
+        f"- Python version: {info['python_version']}\n"
+        f"- Operating system & architecture: {info['os']}\n"
         f"- Proxy setting: {proxy}\n"
-        f"- Using VPN, proxy, or firewall? "
+        f"- Trusted CA certs path: {info['trusted_ca_certs']}\n"
+        f"- SSL verification: {info['ssl_context']}\n"
+        f"- IP version: {info['ip_version']}\n"
+        "- Using VPN, proxy, or firewall? "
     )
 
 
 class CopyEnvironmentInfo(bpy.types.Operator):
-    """Copy Blendkit and Blender version information to clipboard"""
+    """Copy the BlendKit and Blender versions, operating system, and other environment details to the clipboard.
+    Include this information in your bug report or support email to help us diagnose the issue"""  # fmt: skip
 
     bl_idname = "wm.blenderkit_copy_environment_info"
     bl_label = "Copy Environment Info"
 
     def execute(self, context):
-        context.window_manager.clipboard = get_environment_info()
-        self.report({"INFO"}, "Environment info copied to clipboard")
+        context.window_manager.clipboard = get_environment_info_string()
+        bk_logger.info("Environment info copied to clipboard")
         return {"FINISHED"}
 
 
 def get_report_bug_url() -> str:
-    """Build GitHub issue URL with pre-filled environment information."""
-    env_info = get_environment_info()
-    description_body = (
-        f"When I...\n\n### Environment Information - Bug happens on:\n{env_info}"
-    )
+    """Build GitHub issue URL with pre-filled environment information.
+    Do not set the title and description, we require the user to fill those fields manually.
+    File is located at: .github/ISSUE_TEMPLATE/bug-report-prefilled.yaml
+    """
+
+    info = get_environment_info()
+    proxy = f"{info['proxy_which']}"
+    if info["proxy_which"] == "CUSTOM":
+        proxy += f" ({info['proxy_address']})"
+
     return (
         "https://github.com/BlenderKit/blenderkit/issues/new"
-        f"?template=bug-report.yaml"
-        f"&title={quote('Blendkit bug: ')}"
-        f"&description={quote(description_body)}"
+        f"?template=bug-report-prefilled.yaml"
+        f"&blendkit_version={quote(info['addon_version'])}"
+        f"&blender_version={quote(info['blender_version'])}"
+        f"&operating_system={quote(info['os'])}"
+        f"&python_version={quote(info['python_version'])}"
+        f"&proxy={quote(proxy)}"
+        f"&ip_version={quote(info['ip_version'])}"
+        f"&ssl_context={quote(info['ssl_context'])}"
+        f"&trusted_ca_certs={quote(info['trusted_ca_certs'])}"
     )
 
 
 class ReportBug(bpy.types.Operator):
-    """Open GitHub issue page with pre-filled environment information"""
+    """Open a prefilled GitHub issue in your browser. The report includes BlendKit and Blender versions,
+    operating system info, and other environment details which help us diagnose your problem"""  # fmt: skip
 
     bl_idname = "wm.blenderkit_report_bug"
     bl_label = "Report a Bug"


### PR DESCRIPTION
fixes #2206 

- prefilled report from add-on needs details from the user, we should require it to prevent empty unusable bug reports, which spam the dev team