### PR TITLE
Change the order of the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-prefilled.yaml
+++ b/.github/ISSUE_TEMPLATE/report-prefilled.yaml
@@ -1,4 +1,4 @@
-name: Bug Report Prefilled
+name: Prefilled report from add-on
 description: Report a bug, crash, or other issue, prefilled with basic metadata from the add-on.
 body:
   - type: markdown


### PR DESCRIPTION
There is no way to hide the prefilled bug report, so I am changing the filename, so it is after the bug report and feature request. Now it was the first option, which would mislead the users. Realistically they will just click the 1st option. We've previously rarely seen the feature request template to be used. 