### PR TITLE
feat: migrate legacy BlenderKit repositories to new Blendkit URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out
 # ignore built binaries
 client/v*.*.*
 client/client.exe
+bk_client/client/bk_client-settings.json
 
 pyproject.toml
 client_builds

--- a/override_extension_draw.py
+++ b/override_extension_draw.py
@@ -91,12 +91,12 @@ class BK_OT_buy_extension_and_watch(Operator):
     url: StringProperty(
         name="URL",
         description="Website URL to open",
-    ) # type: ignore
+    )  # type: ignore
     repo_index: IntProperty(
         name="Repository Index",
         description="Index of the repository to refresh",
         default=-1,
-    ) # type: ignore
+    )  # type: ignore
 
     _timer = None
     _last_refresh_time = 0

--- a/override_extension_draw.py
+++ b/override_extension_draw.py
@@ -20,8 +20,11 @@ import bl_pkg.bl_extension_ui as exui
 from bpy.props import IntProperty, StringProperty
 from bpy.types import Operator
 
-
 EXTENSIONS_API_URL = "https://www.blendkit.com/api/v1/extensions/"
+# Legacy repository URL used before the rename from BlenderKit to Blendkit.
+LEGACY_EXTENSIONS_API_URL = "https://www.blenderkit.com/api/v1/extensions/"
+# Canonical module name of the Blendkit extensions repository.
+EXTENSIONS_REPO_MODULE = "www_blenderkit_com"
 
 bk_logger = logging.getLogger(__name__)
 
@@ -879,11 +882,89 @@ def ensure_repo_order():
         new_repo.enabled = r["enabled"]
 
 
+def migrate_repository():
+    """Migrate legacy BlenderKit extension repositories to the new Blendkit URL.
+
+    Installs created before the rename from BlenderKit to Blendkit registered
+    the extensions repository with the old server URL (www.blenderkit.com).
+    After the rename ``ensure_repository()`` adds a fresh repository pointing to
+    the new URL (www.blendkit.com), leaving the user with two colliding
+    repositories (e.g. "www.blenderkit.com" and "www.blenderkit.com.001").
+
+    This updates any repository still pointing at the legacy URL to the new URL
+    and removes the resulting duplicates, keeping a single repository.
+    """
+    repos = bpy.context.preferences.extensions.repos
+
+    # Point any repository still using the legacy URL at the new one.
+    for r in repos:
+        if r.remote_url == LEGACY_EXTENSIONS_API_URL:
+            bk_logger.info(
+                "Migrating extensions repository '%s' from %s to %s",
+                r.name,
+                LEGACY_EXTENSIONS_API_URL,
+                EXTENSIONS_API_URL,
+            )
+            r.remote_url = EXTENSIONS_API_URL
+
+    # Collect all repositories now pointing at the new URL.
+    matching = [r for r in repos if r.remote_url == EXTENSIONS_API_URL]
+    if not matching:
+        return
+
+    # Choose which repository to keep. Prefer the one with the canonical module
+    # name, then one whose name has no numeric ".001" suffix, then the first.
+    def _rank(r):
+        if r.module == EXTENSIONS_REPO_MODULE:
+            return 0
+        if not re.search(r"\.\d{3}$", r.name):
+            return 1
+        return 2
+
+    keep = min(matching, key=_rank)
+    keep_module = keep.module
+
+    # Remove any duplicate repositories pointing at the new URL.
+    to_remove = [
+        r
+        for r in repos
+        if r.remote_url == EXTENSIONS_API_URL and r.module != keep_module
+    ]
+    for r in to_remove:
+        bk_logger.info("Removing duplicate extensions repository '%s'", r.name)
+        repos.remove(r)
+
+    # Normalize the surviving repository's module back to the canonical value.
+    # Installed extensions are registered as ``bl_ext.<module>.<pkg>`` and their
+    # files live in the directory derived from the module, so a leftover
+    # "_001" module orphans every previously installed extension. Only one
+    # Blendkit repo remains at this point, so the canonical module is free.
+    if keep.module != EXTENSIONS_REPO_MODULE:
+        bk_logger.info(
+            "Restoring extensions repository module '%s' to '%s'",
+            keep.module,
+            EXTENSIONS_REPO_MODULE,
+        )
+        # A custom directory would keep files in the old "_001" location; clear
+        # it so Blender uses the canonical module-derived directory.
+        keep.use_custom_directory = False
+        keep.module = EXTENSIONS_REPO_MODULE
+
+    # Normalize the surviving repository's display name (e.g. strip a ".001"
+    # suffix left over from the duplicate collision).
+    if keep.name != "www.blenderkit.com":
+        bk_logger.info(
+            "Renaming extensions repository '%s' to 'www.blenderkit.com'", keep.name
+        )
+        keep.name = "www.blenderkit.com"
+
+
 def ensure_repository(api_key: str = ""):
     """Ensure that the Blendkit extensions repository is correctly added in Blender's preferences.
     If the repository is not present, it is added. If the repository is present, but the API key is not set, it is set.
     """
 
+    migrate_repository()
     blenderkit_repository = get_repository_by_url(EXTENSIONS_API_URL)
 
     if blenderkit_repository is None:

--- a/override_extension_draw.py
+++ b/override_extension_draw.py
@@ -91,12 +91,12 @@ class BK_OT_buy_extension_and_watch(Operator):
     url: StringProperty(
         name="URL",
         description="Website URL to open",
-    )
+    ) # type: ignore
     repo_index: IntProperty(
         name="Repository Index",
         description="Index of the repository to refresh",
         default=-1,
-    )
+    ) # type: ignore
 
     _timer = None
     _last_refresh_time = 0

--- a/tests/test.py
+++ b/tests/test.py
@@ -96,6 +96,7 @@ _test_modules = [
     "test_upload_bg",
     "test_timer",
     "test_rating_nudge",
+    "test_override_extension_draw",
 ]
 
 for _modname in _test_modules:

--- a/tests/test_override_extension_draw.py
+++ b/tests/test_override_extension_draw.py
@@ -1,0 +1,128 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+# #
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+# #
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# #
+# ##### END GPL LICENSE BLOCK #####
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# ``test.py`` imports this as ``<addon>.tests.<name>``; strip ``.tests`` so
+# ``__package__`` is the add-on's own module - needed by the relative imports.
+if __package__:
+    __package__ = __package__.rsplit(".tests", 1)[0]
+from . import override_extension_draw as oed
+
+
+class _FakeRepo:
+    """Minimal stand-in for a Blender extensions repository."""
+
+    def __init__(self, name, module, remote_url, use_custom_directory=False):
+        self.name = name
+        self.module = module
+        self.remote_url = remote_url
+        self.use_custom_directory = use_custom_directory
+
+
+class _FakeRepos(list):
+    """List that mimics ``preferences.extensions.repos`` (supports remove)."""
+
+
+def _patched_bpy(repos):
+    return SimpleNamespace(
+        context=SimpleNamespace(
+            preferences=SimpleNamespace(
+                extensions=SimpleNamespace(repos=repos),
+            ),
+        ),
+    )
+
+
+class TestMigrateRepository(unittest.TestCase):
+    def _run(self, repos):
+        with patch.object(oed, "bpy", _patched_bpy(repos)):
+            oed.migrate_repository()
+
+    def test_updates_legacy_url_repo(self):
+        """A single legacy repo is migrated to the new URL and normalized."""
+        repo = _FakeRepo(
+            "www.blenderkit.com",
+            "www_blenderkit_com",
+            oed.LEGACY_EXTENSIONS_API_URL,
+        )
+        repos = _FakeRepos([repo])
+        self._run(repos)
+
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repo.remote_url, oed.EXTENSIONS_API_URL)
+        self.assertEqual(repo.name, "www.blenderkit.com")
+        self.assertEqual(repo.module, oed.EXTENSIONS_REPO_MODULE)
+
+    def test_removes_duplicate_keeps_canonical_module(self):
+        """Legacy + fresh duplicate collapse to the canonical-module repo."""
+        legacy = _FakeRepo(
+            "www.blenderkit.com",
+            "www_blenderkit_com",
+            oed.LEGACY_EXTENSIONS_API_URL,
+        )
+        duplicate = _FakeRepo(
+            "www.blenderkit.com.001",
+            "www_blenderkit_com_001",
+            oed.EXTENSIONS_API_URL,
+        )
+        repos = _FakeRepos([legacy, duplicate])
+        self._run(repos)
+
+        self.assertEqual(len(repos), 1)
+        self.assertIs(repos[0], legacy)
+        self.assertEqual(legacy.remote_url, oed.EXTENSIONS_API_URL)
+        self.assertEqual(legacy.module, oed.EXTENSIONS_REPO_MODULE)
+        self.assertEqual(legacy.name, "www.blenderkit.com")
+
+    def test_restores_module_on_leftover_001_repo(self):
+        """A leftover ``_001`` repo gets its module and name restored so
+        installed ``bl_ext.www_blenderkit_com.*`` add-ons resolve again."""
+        repo = _FakeRepo(
+            "www.blenderkit.com.001",
+            "www_blenderkit_com_001",
+            oed.EXTENSIONS_API_URL,
+            use_custom_directory=True,
+        )
+        repos = _FakeRepos([repo])
+        self._run(repos)
+
+        self.assertEqual(len(repos), 1)
+        self.assertEqual(repo.module, oed.EXTENSIONS_REPO_MODULE)
+        self.assertEqual(repo.name, "www.blenderkit.com")
+        self.assertFalse(repo.use_custom_directory)
+
+    def test_no_matching_repo_is_noop(self):
+        """Unrelated repos are left untouched."""
+        other = _FakeRepo(
+            "extensions.blender.org",
+            "blender_org",
+            "https://extensions.blender.org/api/v1/extensions/",
+        )
+        repos = _FakeRepos([other])
+        self._run(repos)
+
+        self.assertEqual(len(repos), 1)
+        self.assertIs(repos[0], other)
+        self.assertEqual(other.module, "blender_org")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_override_extension_draw.py
+++ b/tests/test_override_extension_draw.py
@@ -20,11 +20,20 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import bpy
+
 # ``test.py`` imports this as ``<addon>.tests.<name>``; strip ``.tests`` so
 # ``__package__`` is the add-on's own module - needed by the relative imports.
 if __package__:
     __package__ = __package__.rsplit(".tests", 1)[0]
-from . import override_extension_draw as oed
+
+# ``override_extension_draw`` imports ``bl_pkg``, which only exists in the
+# extensions system introduced in Blender 4.2. Skip the whole module on older
+# versions, and avoid importing it so the missing ``bl_pkg`` does not error.
+if bpy.app.version >= (4, 2, 0):
+    from . import override_extension_draw as oed
+else:
+    oed = None
 
 
 class _FakeRepo:
@@ -51,6 +60,9 @@ def _patched_bpy(repos):
     )
 
 
+@unittest.skipUnless(
+    bpy.app.version >= (4, 2, 0), "override_extension_draw requires Blender 4.2+"
+)
 class TestMigrateRepository(unittest.TestCase):
     def _run(self, repos):
         with patch.object(oed, "bpy", _patched_bpy(repos)):


### PR DESCRIPTION
 and remove duplicates
 
 ensures that only a single instance of our repository exists and points to new web URL
 
 