### PR TITLE
test: port dropped drag-enabled panel tests from #1953

### DIFF
--- a/tests/test_asset_bar_op.py
+++ b/tests/test_asset_bar_op.py
@@ -101,6 +101,40 @@ class TestAssetBarPositioning(unittest.TestCase):
         panel.update.assert_not_called()
         panel.layout_widgets.assert_not_called()
 
+    def test_drag_panel_mouse_down_starts_drag_when_enabled(self):
+        panel = self.create_drag_panel(drag_enabled=True)
+        panel.is_in_rect = Mock(return_value=True)
+
+        handled = asset_bar_op.BL_UI_Drag_Panel.mouse_down(panel, 50, 130)
+
+        self.assertTrue(handled)
+        self.assertTrue(panel.is_drag)
+
+    def test_drag_panel_mouse_down_ignored_outside_panel(self):
+        panel = self.create_drag_panel(drag_enabled=True)
+        panel.is_in_rect = Mock(return_value=False)
+
+        handled = asset_bar_op.BL_UI_Drag_Panel.mouse_down(panel, 50, 130)
+
+        self.assertFalse(handled)
+        self.assertFalse(panel.is_drag)
+
+    def test_drag_panel_mouse_move_drags_when_dragging(self):
+        panel = self.create_drag_panel(drag_enabled=True, is_drag=True)
+
+        asset_bar_op.BL_UI_Drag_Panel.mouse_move(panel, 60, 70)
+
+        panel.update.assert_called_once()
+        panel.layout_widgets.assert_called_once()
+
+    def test_child_widget_focused_ignores_widget_not_under_cursor(self):
+        panel = self.create_drag_panel()
+        panel.widgets = [SimpleNamespace(is_in_rect=lambda x, y: False)]
+
+        focused = asset_bar_op.BL_UI_Drag_Panel.child_widget_focused(panel, 40, 40)
+
+        self.assertFalse(focused)
+
 
 class TestAssetBarInvoke(unittest.TestCase):
     def test_initial_search_is_marked_before_layout_init(self):


### PR DESCRIPTION
## What & why

The draggable asset bar shipped via #2184 (a dedicated `BL_UI_Resize_Handle` widget), superseding the earlier #1953 approach that baked a generic 4-edge resize framework into `BL_UI_Drag_Panel`. Most of #1953's test suite was carried into #2184, but its `TestDragPanelResize` class was dropped wholesale.

Eleven of those tests covered the obsolete 4-edge framework and are correctly gone (the new `TestResizeHandle` covers the replacement widget). But **four** exercised the *generic panel-drag* path that still exists on `main` — `drag_enabled=True` by default, used by e.g. the tooltip panel — which `main` currently only tests in the disabled direction.

## Changes

Port those four into `TestAssetBarPositioning`, reusing the existing `create_drag_panel` helper (the obsolete resize-edge helper is **not** revived):

- `test_drag_panel_mouse_down_starts_drag_when_enabled`
- `test_drag_panel_mouse_down_ignored_outside_panel`
- `test_drag_panel_mouse_move_drags_when_dragging`
- `test_child_widget_focused_ignores_widget_not_under_cursor`

## Verification

All four pass in Blender 5.0 alongside the existing drag-disabled control tests. No production code changes; test-only.

Closes #1953 (superseded by #2184; this recovers the coverage gap it left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)