### PR TITLE
feat: tag outbound web links with UTM source + placement for attribution

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -3940,6 +3940,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             bpy.ops.wm.blenderkit_login_dialog(
                 "INVOKE_DEFAULT",
                 message="Please login to bookmark your favorite assets.",
+                placement="bookmarks_prompt",
             )
             return
 
@@ -3965,7 +3966,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
         # url = author.aboutMeUrl
 
         # Blendkit site profile >>
-        url = paths.get_author_gallery_url(author_id)
+        url = paths.get_author_gallery_url(author_id, placement="asset_bar_author")
         if url is None:
             bk_logger.warning("url is none")
             return
@@ -4117,7 +4118,7 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
             if author is None:
                 return True
             utils.p("author:", author)
-            url = paths.get_author_gallery_url(author.id)
+            url = paths.get_author_gallery_url(author.id, placement="asset_bar_author")
             bpy.ops.wm.url_open(url=url)
             return True
 

--- a/bkit_oauth.py
+++ b/bkit_oauth.py
@@ -35,6 +35,7 @@ from . import (
     client_tasks,
     datas,
     global_vars,
+    paths,
     reports,
     search_price,
     tasks_queue,
@@ -129,7 +130,7 @@ def logout() -> None:
     clean_login_data()
 
 
-def login(signup: bool) -> None:
+def login(signup: bool, placement: str = "login") -> None:
     """Logs user into the addon.
     Opens a browser with login page. Once user is logged it redirects browser to Client handling access code via URL querry parameter.
     Using the access_code Client then requests api_token and handles the results as a task with status finished/error.
@@ -151,6 +152,7 @@ def login(signup: bool) -> None:
         authorize_url = f"{global_vars.SERVER}/accounts/register/?next={authorize_url}"
     else:
         authorize_url = f"{global_vars.SERVER}{authorize_url}"
+    authorize_url = paths.url_with_utm(authorize_url, placement)
     ok = open_new_tab(authorize_url)
     bk_logger.info("Login page in browser opened (%s)", ok)
 
@@ -226,6 +228,13 @@ class LoginOnline(bpy.types.Operator):
         default="You were logged out from Blendkit.\n Clicking OK takes you to web login. ",
     )
 
+    placement: bpy.props.StringProperty(  # type: ignore
+        name="Placement",
+        description="Which add-on surface triggered the login, for web analytics",
+        default="login",
+        options={"SKIP_SAVE", "HIDDEN"},
+    )
+
     @classmethod
     def poll(cls, context):
         return True
@@ -242,7 +251,7 @@ class LoginOnline(bpy.types.Operator):
     def execute(self, context):
         preferences = bpy.context.preferences.addons[__package__].preferences
         preferences.login_attempt = True
-        login(self.signup)
+        login(self.signup, self.placement)
         return {"FINISHED"}
 
     def invoke(self, context, event):

--- a/paths.py
+++ b/paths.py
@@ -59,6 +59,16 @@ WINDOWS_PATH_LIMIT = 250
 ASSET_LIBRARY_NAME = "Blendkit"
 
 
+def url_with_utm(url: str, placement: str) -> str:
+    """Tag an outbound web link so analytics can attribute it to the add-on surface that opened it."""
+    base, hash_sign, fragment = url.partition("#")
+    separator = "&" if "?" in base else "?"
+    return (
+        f"{base}{separator}utm_source=blender_addon&utm_medium=app"
+        f"&utm_content={placement}{hash_sign}{fragment}"
+    )
+
+
 def _normalize_path(path_value: str | None) -> str:
     """Return an absolute, normalized path for comparisons; blank string if invalid."""
     if not path_value:
@@ -89,12 +99,16 @@ def find_in_local(text=""):
     return fs
 
 
-def get_author_gallery_url(author_id: int):
-    return f"{global_vars.SERVER}/asset-gallery?query=author_id:{author_id}"
+def get_author_gallery_url(author_id: int, placement: str = "author_gallery"):
+    return url_with_utm(
+        f"{global_vars.SERVER}/asset-gallery?query=author_id:{author_id}", placement
+    )
 
 
-def get_asset_gallery_url(asset_id):
-    return f"{global_vars.SERVER}/asset-gallery-detail/{asset_id}/"
+def get_asset_gallery_url(asset_id, placement: str = "asset_web_view"):
+    return url_with_utm(
+        f"{global_vars.SERVER}/asset-gallery-detail/{asset_id}/", placement
+    )
 
 
 def default_global_dict():

--- a/ratings.py
+++ b/ratings.py
@@ -79,11 +79,13 @@ def draw_ratings_menu(self, context, layout):
             ui_panels.draw_login_progress(layout)
         else:
             layout.operator_context = "EXEC_DEFAULT"
-            layout.operator(
+            op_login = layout.operator(
                 "wm.blenderkit_login",
                 text="Login to Rate and Comment assets",
                 icon="URL",
-            ).signup = False
+            )
+            op_login.signup = False
+            op_login.placement = "rating_prompt"
         return
 
     col = layout.column()

--- a/ratings_utils.py
+++ b/ratings_utils.py
@@ -206,6 +206,7 @@ def update_quality_ui(self, context: Context):
         bpy.ops.wm.blenderkit_login(  # type: ignore
             "INVOKE_DEFAULT",
             message="Please login/signup to rate assets. Clicking OK takes you to web login.",
+            placement="rating_prompt",
         )
         return
 
@@ -219,6 +220,7 @@ def update_ratings_work_hours_ui(self, context: Context):
         bpy.ops.wm.blenderkit_login(  # type: ignore
             "INVOKE_DEFAULT",
             message="Please login/signup to rate assets. Clicking OK takes you to web login.",
+            placement="rating_prompt",
         )
         return
     self.rating_work_hours = float(self.rating_work_hours_ui)

--- a/search.py
+++ b/search.py
@@ -1966,7 +1966,9 @@ def update_filters():
     if ui_props.search_bookmarks and not utils.user_logged_in():
         ui_props.search_bookmarks = False
         bpy.ops.wm.blenderkit_login_dialog(
-            "INVOKE_DEFAULT", message="Please login to use bookmarks."
+            "INVOKE_DEFAULT",
+            message="Please login to use bookmarks.",
+            placement="bookmarks_prompt",
         )
         return False
     if ui_props.own_only and not utils.user_logged_in():
@@ -1974,6 +1976,7 @@ def update_filters():
         bpy.ops.wm.blenderkit_login_dialog(
             "INVOKE_DEFAULT",
             message="Please login to upload and filter your own assets.",
+            placement="own_assets_prompt",
         )
         return False
 

--- a/tests/test_bkit_oauth.py
+++ b/tests/test_bkit_oauth.py
@@ -53,6 +53,9 @@ class TestOAuthLoginURL(unittest.TestCase):
         self.assertEqual(query["code_challenge"], ["challenge"])
         self.assertEqual(query["code_challenge_method"], ["S256"])
         self.assertEqual(query["system_id"], ["000000000000123"])
+        self.assertEqual(query["utm_source"], ["blender_addon"])
+        self.assertEqual(query["utm_medium"], ["app"])
+        self.assertEqual(query["utm_content"], ["login"])
 
     def test_signup_wraps_authorize_url_with_system_id(self):
         with (
@@ -86,3 +89,29 @@ class TestOAuthLoginURL(unittest.TestCase):
         )
         self.assertEqual(parsed_authorize.path, "/o/authorize")
         self.assertEqual(authorize_query["system_id"], ["000000000000123"])
+        self.assertEqual(signup_query["utm_source"], ["blender_addon"])
+        self.assertEqual(signup_query["utm_content"], ["login"])
+        self.assertNotIn("utm_source", authorize_query)
+
+    def test_login_placement_is_tagged(self):
+        with (
+            mock.patch.object(global_vars, "SERVER", "https://example.com"),
+            mock.patch.object(bkit_oauth.client_lib, "get_port", return_value="12345"),
+            mock.patch.object(
+                bkit_oauth, "generate_pkce_pair", return_value=("verifier", "challenge")
+            ),
+            mock.patch.object(
+                bkit_oauth.secrets, "token_urlsafe", return_value="state-token"
+            ),
+            mock.patch.object(
+                bkit_oauth, "get_system_id", return_value="000000000000123"
+            ),
+            mock.patch.object(bkit_oauth.client_lib, "send_oauth_verification_data"),
+            mock.patch.object(
+                bkit_oauth, "open_new_tab", return_value=True
+            ) as open_new_tab,
+        ):
+            bkit_oauth.login(signup=False, placement="premium_popup")
+
+        query = parse_qs(urlsplit(open_new_tab.call_args.args[0]).query)
+        self.assertEqual(query["utm_content"], ["premium_popup"])

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -444,3 +444,27 @@ class TestRemoveAssetLibraryPath(_AssetLibraryTestBase):
         paths.remove_asset_library_path()
 
         self.assertEqual(len(libs), 1)
+
+
+class TestUrlWithUtm(unittest.TestCase):
+    def test_plain_url(self):
+        self.assertEqual(
+            paths.url_with_utm("https://x.com/plans/pricing", "premium_popup"),
+            "https://x.com/plans/pricing?utm_source=blender_addon&utm_medium=app&utm_content=premium_popup",
+        )
+
+    def test_existing_query(self):
+        self.assertEqual(
+            paths.url_with_utm("https://x.com/gallery?query=a", "author_gallery"),
+            "https://x.com/gallery?query=a&utm_source=blender_addon&utm_medium=app&utm_content=author_gallery",
+        )
+
+    def test_fragment_is_preserved_after_params(self):
+        self.assertEqual(
+            paths.url_with_utm("https://x.com/my-assets/abc/?edit#", "uploads_edit"),
+            "https://x.com/my-assets/abc/?edit&utm_source=blender_addon&utm_medium=app&utm_content=uploads_edit#",
+        )
+
+    def test_getters_are_tagged(self):
+        self.assertIn("utm_content=author_gallery", paths.get_author_gallery_url(7))
+        self.assertIn("utm_content=asset_web_view", paths.get_asset_gallery_url("abc"))

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -133,7 +133,7 @@ def draw_upload_common(layout, props, asset_type, context):
     op = layout.operator(
         "wm.url_open", text=f"Read {asset_type} upload instructions", icon="QUESTION"
     )
-    op.url = url
+    op.url = paths.url_with_utm(url, "upload_docs") if url else url
 
     row = layout.row(align=True)
     if props.upload_state != "":
@@ -202,7 +202,10 @@ def draw_upload_common(layout, props, asset_type, context):
         op = layout.operator(
             "wm.blenderkit_url", text="Edit Details", icon="GREASEPENCIL"
         )
-        op.url = f"{paths.BLENDKIT_USER_ASSETS_URL}/{props.asset_base_id}/?edit#"
+        op.url = paths.url_with_utm(
+            f"{paths.BLENDKIT_USER_ASSETS_URL}/{props.asset_base_id}/?edit#",
+            "uploads_edit",
+        )
 
         op = layout.operator(
             "object.blenderkit_upload", text="Reupload asset", icon="EXPORT"
@@ -780,7 +783,7 @@ def draw_panel_model_search(self, context):
     utils.label_multiline(layout, text=props.report, icon=icon)
     if props.report == "You need Full plan to get this item.":
         layout.operator("wm.url_open", text="Get Full plan", icon="URL").url = (
-            paths.BLENDKIT_PLANS_URL
+            paths.url_with_utm(paths.BLENDKIT_PLANS_URL, "premium_wall_panel")
         )
 
 
@@ -1048,7 +1051,9 @@ class VIEW3D_PT_blenderkit_profile(Panel):
                     if me.currentPlanName == "Free":
                         layout.operator(
                             "wm.url_open", text="Change plan", icon="URL"
-                        ).url = paths.BLENDKIT_PLANS_URL
+                        ).url = paths.url_with_utm(
+                            paths.BLENDKIT_PLANS_URL, "profile_change_plan"
+                        )
 
                 # STORAGE STATISTICS
                 if (
@@ -1069,7 +1074,7 @@ class VIEW3D_PT_blenderkit_profile(Panel):
                     row.label(text=size_str)
 
             layout.operator("wm.url_open", text="See my uploads", icon="URL").url = (
-                paths.BLENDKIT_USER_ASSETS_URL
+                paths.url_with_utm(paths.BLENDKIT_USER_ASSETS_URL, "profile_my_uploads")
             )
 
         draw_login_buttons(layout)
@@ -1538,12 +1543,14 @@ def draw_login_buttons(layout, invoke=False):
         else:
             layout.operator_context = "EXEC_DEFAULT"
         if not utils.user_logged_in():
-            layout.operator("wm.blenderkit_login", text="Login", icon="URL").signup = (
-                False
-            )
-            layout.operator(
+            op_login = layout.operator("wm.blenderkit_login", text="Login", icon="URL")
+            op_login.signup = False
+            op_login.placement = "login_panel"
+            op_signup = layout.operator(
                 "wm.blenderkit_login", text="Sign up", icon="URL"
-            ).signup = True
+            )
+            op_signup.signup = True
+            op_signup.placement = "login_panel"
 
         else:
             layout.operator("wm.blenderkit_logout", text="Logout", icon="URL")
@@ -2282,7 +2289,9 @@ class VIEW3D_PT_blenderkit_unified(Panel):
             op = layout.operator(
                 "wm.url_open", text="Go to Blendkit Website", icon="URL"
             )
-            op.url = paths.BLENDKIT_ADDON_UPLOAD_INSTRUCTIONS_URL
+            op.url = paths.url_with_utm(
+                paths.BLENDKIT_ADDON_UPLOAD_INSTRUCTIONS_URL, "upload_docs"
+            )
             return
 
         if ui_props.asset_type == "AUTHOR":
@@ -2631,8 +2640,9 @@ def draw_asset_context_menu(
         utils.user_is_owner(asset_data)
         and asset_data["verificationStatus"] != "validated"
     ):
-        op.url = (
-            f'{paths.BLENDKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?preview#'
+        op.url = paths.url_with_utm(
+            f'{paths.BLENDKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?preview#',
+            "uploads_preview",
         )
     else:
         op.url = paths.get_asset_gallery_url(asset_data["id"])
@@ -2777,8 +2787,9 @@ def draw_asset_context_menu(
                 text="Edit Metadata (browser)",
                 icon="GREASEPENCIL",
             )
-            op.url = (
-                f'{paths.BLENDKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?edit#'
+            op.url = paths.url_with_utm(
+                f'{paths.BLENDKIT_USER_ASSETS_URL}/{asset_data["assetBaseId"]}/?edit#',
+                "uploads_edit",
             )
 
         row.operator_context = "INVOKE_DEFAULT"
@@ -3285,7 +3296,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                     text,
                     icon_value=icon.icon_id,
                     tooltip=plans_tooltip,
-                    url=paths.BLENDKIT_PLANS_URL,
+                    url=paths.url_with_utm(
+                        paths.BLENDKIT_PLANS_URL, "asset_popup_access"
+                    ),
                 )
             else:
                 text = "Free"
@@ -3363,7 +3376,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                     text,
                     icon_value=icon.icon_id,
                     tooltip=plans_tooltip,
-                    url=paths.BLENDKIT_PLANS_URL,
+                    url=paths.url_with_utm(
+                        paths.BLENDKIT_PLANS_URL, "asset_popup_access"
+                    ),
                 )
             else:
                 text = "Full plan"
@@ -3374,7 +3389,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                     text,
                     icon_value=icon.icon_id,
                     tooltip=plans_tooltip,
-                    url=paths.BLENDKIT_PLANS_URL,
+                    url=paths.url_with_utm(
+                        paths.BLENDKIT_PLANS_URL, "asset_popup_access"
+                    ),
                 )
 
         if utils.profile_is_validator():
@@ -4237,9 +4254,11 @@ class UrlPopupDialog(bpy.types.Operator):
             )
 
             layout.operator_context = "EXEC_DEFAULT"
-            layout.operator(
+            op_login = layout.operator(
                 "wm.blenderkit_login", text="Welcome Home", icon="URL"
-            ).signup = False
+            )
+            op_login.signup = False
+            op_login.placement = "premium_popup"
         op.url = self.url
 
     def execute(self, context):
@@ -4264,6 +4283,12 @@ class LoginPopupDialog(bpy.types.Operator):
         name="Url", description="url", default="Login to Blendkit"
     )
 
+    placement: StringProperty(  # type: ignore[valid-type]
+        name="Placement",
+        description="Which add-on surface triggered the login, for web analytics",
+        default="login_dialog",
+    )
+
     def draw(self, context):
         set_overlay_panel_active()
         layout = self.layout
@@ -4271,9 +4296,11 @@ class LoginPopupDialog(bpy.types.Operator):
 
         layout.active_default = True
         layout.operator_context = "EXEC_DEFAULT"
-        layout.operator(
+        op_login = layout.operator(
             "wm.blenderkit_login", text=self.link_text, icon="URL"
-        ).signup = False
+        )
+        op_login.signup = False
+        op_login.placement = self.placement
 
     def execute(self, context):
         return {"FINISHED"}


### PR DESCRIPTION
## What

Tags every add-on-opened web link with standard UTM parameters so web analytics (and upcoming server-side first/last-touch capture) can attribute checkout and login to the exact add-on surface that opened them:

- `utm_source=blender_addon` — identifies the client (future Maya/Godot plugins get their own slug)
- `utm_medium=app` — constant, separates client apps from ads/email in GA
- `utm_content=<placement>` — which button/surface: `premium_popup`, `premium_wall_panel`, `asset_popup_access`, `login_panel`, `rating_prompt`, `bookmarks_prompt`, `own_assets_prompt`, `profile_change_plan`, `profile_my_uploads`, `uploads_edit`, `uploads_preview`, `upload_docs`, `author_gallery`, `asset_bar_author`, `asset_web_view`

## How

- `paths.url_with_utm(url, placement)` — fragment-safe helper (handles the `?edit#` style URLs); gallery getters tag with defaults
- `LoginOnline` and `LoginPopupDialog` gained a `placement` property, threaded into `login(signup, placement)` and onto the opened browser URL; on signup the outer register URL is tagged while the inner OAuth `next=` stays clean (tested)

Versions deliberately stay **out** of URLs (cardinality, staleness) — a later opaque click-id joined to existing telemetry will carry addon/Blender versions and machine context.

## Tests

- `TestUrlWithUtm` in `test_paths.py` (plain/query/fragment cases + tagged getters)
- `test_bkit_oauth.py`: UTM assertions on both login and signup URLs + a placement pass-through test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
