### PR TITLE
fix: Do not warn users about assets from newer patch versions or older versions of Blender

### DIFF
--- a/asset_bar/asset_bar_op.py
+++ b/asset_bar/asset_bar_op.py
@@ -3798,15 +3798,12 @@ class BlenderKitAssetBarOperator(BL_UI_OT_draw_operator):
                     asset_data
                 )
                 if has_warning:
-                    if difference in {"major_newer", "major_older"}:
+                    if difference == "major_newer":
                         self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}! Use at your own risk."
                         self.version_warning.text_color = self.warning_color
                     elif difference == "minor":
                         self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}. Caution advised."
                         self.version_warning.text_color = self.caution_color
-                    else:
-                        self.version_warning.text = f"Made in Blender {asset_data['sourceAppVersion']}. Some features may not work."
-                        self.version_warning.text_color = self.info_color
                 else:
                     self.version_warning.text = ""
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -105,12 +105,6 @@ class TestUtilsRemoveUrlProtocol(unittest.TestCase):
 
 
 class TestAssetFromNewerBlenderVersion(unittest.TestCase):
-    def test_older_major_asset(self):
-        asset = {"assetType": "model", "sourceAppVersion": "3.6.0"}
-        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
-        self.assertTrue(has_warning)
-        self.assertEqual(level, "major_older")
-
     def test_older_minor_asset(self):
         asset = {"assetType": "model", "sourceAppVersion": "4.0.0"}
         has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 1, 0))
@@ -148,12 +142,6 @@ class TestAssetFromNewerBlenderVersion(unittest.TestCase):
         asset = {"assetType": "model", "sourceAppVersion": "4"}
         has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 0, 0))
         self.assertFalse(has_warning)
-
-    def test_two_major_versions_older(self):
-        asset = {"assetType": "model", "sourceAppVersion": "2.93.0"}
-        has_warning, level = utils.asset_from_newer_blender_version(asset, (4, 2, 0))
-        self.assertTrue(has_warning)
-        self.assertEqual(level, "major_older")
 
 
 class TestAssetVersionAsTuple(unittest.TestCase):

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3395,15 +3395,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                 warning = (
                     f"{self.asset_data['sourceAppVersion']} - newer major version!"
                 )
-            elif difference == "major_older":
-                warning = f"{self.asset_data['sourceAppVersion']} - older major version, may be incompatible!"
             elif difference == "minor":
                 warning = (
                     f"{self.asset_data['sourceAppVersion']} - newer minor version!"
-                )
-            else:
-                warning = (
-                    f"{self.asset_data['sourceAppVersion']} - slightly newer version."
                 )
             box.alert = True
             self.draw_property(

--- a/utils.py
+++ b/utils.py
@@ -1586,7 +1586,6 @@ def asset_from_newer_blender_version(asset_data, blender_version=None):
 
     Returns (needs_warning: bool, difference: str) where difference is one of:
     - "major_newer": asset from a newer major version (high risk)
-    - "major_older": asset from an older major version (possible incompatibility)
     - "minor": asset from a newer minor version within same major
     - "patch": asset from a newer patch version within same major.minor
     - "": no compatibility concern
@@ -1606,7 +1605,7 @@ def asset_from_newer_blender_version(asset_data, blender_version=None):
     if blender_version[0] < int(asset_ver[0]):
         return True, "major_newer"
     elif blender_version[0] > int(asset_ver[0]):
-        return True, "major_older"
+        return False, ""
 
     if blender_version[1] < int(asset_ver[1]):
         return True, "minor"


### PR DESCRIPTION
fixes #2205 