### PR TITLE
Fix pip requirements command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ We use `go fmt` for formatting Go code in `./client`.
 We will use `ruff` for linting.
 
 We define versions in `devs/requirements.txt` so the local development environment is consistent with CI/CD (Github Actions).
-To install them in correct versions run: `pip3 install -U --user --r devs/requirements.py`.
+To install them in correct versions run: `pip3 install -U --user -r devs/requirements.txt`.
 
 Before committing your changes, please run:
 ```


### PR DESCRIPTION
## Summary

Fixes the developer dependency installation command in `CONTRIBUTING.md`.

The previous command used `--r` instead of `-r` and referenced `devs/requirements.py` instead of the existing `devs/requirements.txt` file.

## Changes

Changed:

`pip3 install -U --user --r devs/requirements.py`

to:

`pip3 install -U --user -r devs/requirements.txt`

## Verification

I verified that `devs/requirements.txt` exists and that pip uses `-r` to specify a requirements file.

Fixes #2231