### PR TITLE
fix: prevent overwriting user keymap settings on reload 

### DIFF
--- a/asset_bar/asset_drag_op.py
+++ b/asset_bar/asset_drag_op.py
@@ -1666,52 +1666,38 @@ class AssetDragOperator(bpy.types.Operator):
         self,
     ) -> Union[bpy.types.Object, bpy.types.Collection, None]:
         """Find and select the element under the mouse in the outliner.
-        Returns the selected object, collection, or None."""
+        Returns the selected object, collection, or None.
+
+        Reuses ``utils.get_outliner_element_under_mouse`` with
+        ``restore_selection=False`` so the probed element stays selected for the
+        drop. The original selection is captured here and restored later via
+        ``restore_original_selection()``.
+        """
         if not self.active_area or self.active_area.type != "OUTLINER":
             return None
 
-        context = bpy.context
-        view_layer = context.view_layer
-        selected_objects = context.selected_objects
-        active_object = context.active_object
+        view_layer = bpy.context.view_layer
 
-        orig_selected_objects = selected_objects.copy()
-        orig_active_object = active_object
-        orig_active_collection = view_layer.active_layer_collection
+        # Capture selection so restore_original_selection() can put it back after the drop.
+        self.orig_selected_objects = bpy.context.selected_objects.copy()
+        self.orig_active_object = bpy.context.active_object
+        self.orig_active_collection = view_layer.active_layer_collection
 
-        selected_element = None
-        if bpy.app.version > (3, 1, 9):
-            # doesn't make sense for lower versions, we wouldn't get the selected_ids anyway.
-            #  Simply drops into active_layer_collection in prehistoric Blender.
-            with bpy.context.temp_override(
-                window=self.active_window,
-                area=self.active_area,
-                region=self.active_region,
-            ):
-                bpy.ops.outliner.select_box(
-                    xmin=self.mouse_x - 1,
-                    xmax=self.mouse_x + 1,
-                    ymin=self.mouse_y - 1,
-                    ymax=self.mouse_y + 1,
-                    wait_for_input=False,
-                    mode="SET",
-                )
+        selected_element = utils.get_outliner_element_under_mouse(
+            self.active_window,
+            self.active_area,
+            self.active_region,
+            self.mouse_x,
+            self.mouse_y,
+            restore_selection=False,
+        )
 
-                # Get the newly selected element using selected_ids
-                if (
-                    hasattr(bpy.context, "selected_ids")
-                    and len(bpy.context.selected_ids) > 0
-                ):
-                    selected_element = bpy.context.selected_ids[0]
-
+        # Prehistoric Blender (<= 3.1.9) can't resolve selected_ids; drop into the
+        # active layer collection instead.
         if selected_element is None and hasattr(view_layer, "active_layer_collection"):
             alc = view_layer.active_layer_collection
             if alc is not None and hasattr(alc, "collection"):
                 selected_element = alc.collection
-
-        self.orig_selected_objects = orig_selected_objects
-        self.orig_active_object = orig_active_object
-        self.orig_active_collection = orig_active_collection
 
         return selected_element
 

--- a/keymap_utils.py
+++ b/keymap_utils.py
@@ -61,6 +61,10 @@ DEFAULT_KEYMAP_ITEMS: list[KeyMapItemDef] = [
         value="PRESS",
         properties={"keep_running": False, "do_search": False},
     ),
+    # NOTE: 'R' collides with Blender's default Rotate shortcut in the 3D viewport,
+    # so this binding effectively only fires in editors where 'R' is unbound (e.g. the
+    # Outliner). We keep it as the shipped default; users who want to rate from the
+    # viewport can rebind it to a free key in Preferences > Keymap.
     KeyMapItemDef(
         idname="wm.blenderkit_menu_rating_upload",
         type="R",
@@ -122,13 +126,6 @@ def register_keymaps(custom_keymaps: list[KeyMapDef] | None = None) -> None:
     keymaps = list(custom_keymaps) if custom_keymaps is not None else DEFAULT_KEYMAPS
 
     for km_def in keymaps:
-        # If the user already has a custom binding in their keyconfig, don't recreate it.
-        if kc_user and _find_in_keyconfig(kc_user, km_def.items[0].idname):
-            bk_logger.debug(
-                f"User keyconfig already has binding for {km_def.items[0].idname}; leaving user override intact"
-            )
-            continue
-
         km = kc_addon.keymaps.find(
             km_def.name, space_type=km_def.space_type, region_type=km_def.region_type
         )
@@ -143,6 +140,14 @@ def register_keymaps(custom_keymaps: list[KeyMapDef] | None = None) -> None:
             )
 
         for item_def in km_def.items:
+            # If the user already has this binding in their keyconfig, don't recreate
+            # it - re-adding the add-on default would clobber their per-item edits,
+            # including a shortcut they intentionally disabled (see issue #2230).
+            if kc_user and _find_in_keyconfig(kc_user, item_def.idname):
+                bk_logger.debug(
+                    f"User keyconfig already has binding for {item_def.idname}; leaving user override intact"
+                )
+                continue
             if _keymap_has_item(km, item_def.idname):
                 bk_logger.debug(
                     f"Keymap {km_def.name} in {kc_addon.name} already has item {item_def.idname}, skipping"

--- a/ratings.py
+++ b/ratings.py
@@ -21,6 +21,7 @@ import logging
 import bpy
 from bpy.props import BoolProperty, StringProperty
 from bpy.types import Gizmo, GizmoGroup, Operator
+from bpy_extras import view3d_utils
 from mathutils import Matrix
 
 from . import (
@@ -41,6 +42,58 @@ bk_logger = logging.getLogger(__name__)
 # Set by rating_nudge._show_rating_popup() right before invoking FastRateMenu with
 # from_nudge=True, so the operator rates this specific (not necessarily selected) asset.
 nudge_asset_data = None
+
+
+def _asset_under_cursor(context, event):
+    """Raycast/probe from the mouse and return (object, asset_data).
+
+    In the 3D viewport this raycasts into the scene; in the Outliner it probes
+    the element under the mouse. Walks up the parent chain from the hit object so
+    hierarchies and collection-instance empties resolve to the object that
+    carries asset_data. Returns (None, None) when the cursor is not over a
+    rateable asset.
+    """
+    region = context.region
+    rv3d = context.region_data
+    space = context.space_data
+    if region is None or space is None:
+        return None, None
+
+    hit = None
+    if space.type == "OUTLINER":
+        element = utils.get_outliner_element_under_mouse(
+            context.window,
+            context.area,
+            region,
+            event.mouse_region_x,
+            event.mouse_region_y,
+        )
+        if isinstance(element, bpy.types.Object):
+            hit = element
+        elif isinstance(element, bpy.types.Collection):
+            # Rate the collection-instance empty that references this collection.
+            for ob in context.view_layer.objects:
+                if ob.instance_collection is element:
+                    hit = ob
+                    break
+    elif space.type == "VIEW_3D" and rv3d is not None:
+        coord = (event.mouse_region_x, event.mouse_region_y)
+        view_vector = view3d_utils.region_2d_to_vector_3d(region, rv3d, coord)
+        ray_origin = view3d_utils.region_2d_to_origin_3d(region, rv3d, coord)
+        depsgraph = context.evaluated_depsgraph_get()
+        has_hit, _loc, _normal, _index, obj, _matrix = context.scene.ray_cast(
+            depsgraph, ray_origin, view_vector
+        )
+        if has_hit and obj is not None:
+            hit = obj.original
+
+    ob = hit
+    while ob is not None:
+        ad = utils.get_asset_data_from_ob(ob)
+        if ad:
+            return ob, ad
+        ob = ob.parent
+    return None, None
 
 
 def get_assets_for_rating():
@@ -175,6 +228,13 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
         draw_ratings_menu(self, context, layout)
         layout.template_icon(icon_value=self.img.preview.icon_id, scale=12)
 
+    def invoke(self, context, event):
+        # When triggered from the 3D viewport (e.g. via the shortcut), prefer the
+        # asset under the mouse cursor so the user can rate any visible asset -
+        # not just the active object (which is usually the last imported one).
+        self._hovered_ob, self._hovered_asset_data = _asset_under_cursor(context, event)
+        return self.execute(context)
+
     def execute(self, context):
         ui_props = bpy.context.window_manager.blenderkitUI
         # get asset id
@@ -189,14 +249,18 @@ class FastRateMenu(Operator, ratings_utils.RatingProperties):
             self.asset_id = self.asset_data["id"]
             self.asset_type = self.asset_data["assetType"]
         else:
-            if bpy.context.view_layer.objects.active is not None:
+            # Prefer the asset under the mouse cursor (captured in invoke), then
+            # fall back to the active object's asset data.
+            ob = getattr(self, "_hovered_ob", None)
+            ad = getattr(self, "_hovered_asset_data", None)
+            if ob is None:
                 ob = utils.get_active_model()
                 ad = utils.get_asset_data_from_ob(ob)
-                if ad:
-                    self.asset_data = ad
-                    self.asset_id = self.asset_data["id"]
-                    self.asset_type = self.asset_data["assetType"]
-                self.asset = ob
+            if ad:
+                self.asset_data = ad
+                self.asset_id = self.asset_data["id"]
+                self.asset_type = self.asset_data["assetType"]
+            self.asset = ob
         if self.asset_id == "":
             return {"CANCELLED"}
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -97,6 +97,8 @@ _test_modules = [
     "test_persistent_preferences",
     "test_timer",
     "test_rating_nudge",
+    "test_ratings",
+    "test_keymap_utils",
     "test_override_extension_draw",
 ]
 

--- a/tests/test_keymap_utils.py
+++ b/tests/test_keymap_utils.py
@@ -1,0 +1,135 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import types
+import unittest
+
+import bpy
+
+# ``test.py`` imports this as ``<addon>.tests.<name>``; strip ``.tests`` so
+# ``__package__`` is the add-on's own module for the relative import below.
+if __package__:
+    __package__ = __package__.rsplit(".tests", 1)[0]
+from . import keymap_utils
+
+
+def _kmi(type="R", ctrl=False, alt=False, shift=False, oskey=False, key_modifier="NONE"):
+    """Build a minimal stand-in for a bpy KeyMapItem."""
+    return types.SimpleNamespace(
+        type=type,
+        ctrl=ctrl,
+        alt=alt,
+        shift=shift,
+        oskey=oskey,
+        key_modifier=key_modifier,
+    )
+
+
+class TestFormatKeymapItem(unittest.TestCase):
+    def test_plain_key(self):
+        self.assertEqual(keymap_utils.format_keymap_item(_kmi(type="R")), "R")
+
+    def test_multi_word_key_is_title_cased(self):
+        self.assertEqual(
+            keymap_utils.format_keymap_item(_kmi(type="SEMI_COLON")), "Semi Colon"
+        )
+
+    def test_modifier_ordering(self):
+        # Order is Ctrl, Alt, Shift, Cmd, key_modifier, then the key itself.
+        kmi = _kmi(type="R", ctrl=True, alt=True, shift=True, oskey=True)
+        self.assertEqual(keymap_utils.format_keymap_item(kmi), "Ctrl+Alt+Shift+Cmd+R")
+
+    def test_key_modifier_included(self):
+        kmi = _kmi(type="A", ctrl=True, key_modifier="LEFT_CTRL")
+        self.assertEqual(keymap_utils.format_keymap_item(kmi), "Ctrl+Left Ctrl+A")
+
+    def test_none_key_modifier_excluded(self):
+        self.assertEqual(
+            keymap_utils.format_keymap_item(_kmi(type="B", key_modifier="NONE")), "B"
+        )
+
+
+class TestGetShortcutLabel(unittest.TestCase):
+    def test_unknown_idname_returns_fallback(self):
+        self.assertEqual(
+            keymap_utils.get_shortcut_label("wm.definitely_not_an_operator", "N/A"),
+            "N/A",
+        )
+
+    def test_unknown_idname_default_fallback_is_empty(self):
+        self.assertEqual(
+            keymap_utils.get_shortcut_label("wm.definitely_not_an_operator"), ""
+        )
+
+
+class TestKeymapLookupHelpers(unittest.TestCase):
+    def _fake_keyconfig(self, *keymaps):
+        return types.SimpleNamespace(keymaps=list(keymaps))
+
+    def _fake_keymap(self, *idnames):
+        items = [types.SimpleNamespace(idname=i) for i in idnames]
+        return types.SimpleNamespace(keymap_items=items)
+
+    def test_keymap_has_item_found(self):
+        km = self._fake_keymap("a.op", "b.op")
+        found = keymap_utils._keymap_has_item(km, "b.op")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.idname, "b.op")
+
+    def test_keymap_has_item_missing(self):
+        km = self._fake_keymap("a.op")
+        self.assertIsNone(keymap_utils._keymap_has_item(km, "z.op"))
+
+    def test_find_in_keyconfig_searches_all_keymaps(self):
+        kc = self._fake_keyconfig(
+            self._fake_keymap("a.op"), self._fake_keymap("b.op", "c.op")
+        )
+        found = keymap_utils._find_in_keyconfig(kc, "c.op")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.idname, "c.op")
+
+    def test_find_in_keyconfig_missing(self):
+        kc = self._fake_keyconfig(self._fake_keymap("a.op"))
+        self.assertIsNone(keymap_utils._find_in_keyconfig(kc, "z.op"))
+
+
+class TestDefaultKeymaps(unittest.TestCase):
+    def test_default_items_cover_expected_operators(self):
+        idnames = {item.idname for item in keymap_utils.DEFAULT_KEYMAP_ITEMS}
+        self.assertIn("view3d.run_assetbar_fix_context", idnames)
+        self.assertIn("wm.blenderkit_menu_rating_upload", idnames)
+
+    def test_rating_default_is_r_press(self):
+        rating = next(
+            item
+            for item in keymap_utils.DEFAULT_KEYMAP_ITEMS
+            if item.idname == "wm.blenderkit_menu_rating_upload"
+        )
+        self.assertEqual(rating.type, "R")
+        self.assertEqual(rating.value, "PRESS")
+
+    def test_registered_into_window_keymap(self):
+        # Must be the built-in "Window" keymap, otherwise Blender won't surface
+        # the shortcut in the default keymap tree.
+        self.assertTrue(
+            any(km.name == "Window" for km in keymap_utils.DEFAULT_KEYMAPS)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_keymap_utils.py
+++ b/tests/test_keymap_utils.py
@@ -28,7 +28,9 @@ if __package__:
 from . import keymap_utils
 
 
-def _kmi(type="R", ctrl=False, alt=False, shift=False, oskey=False, key_modifier="NONE"):
+def _kmi(
+    type="R", ctrl=False, alt=False, shift=False, oskey=False, key_modifier="NONE"
+):
     """Build a minimal stand-in for a bpy KeyMapItem."""
     return types.SimpleNamespace(
         type=type,
@@ -126,9 +128,7 @@ class TestDefaultKeymaps(unittest.TestCase):
     def test_registered_into_window_keymap(self):
         # Must be the built-in "Window" keymap, otherwise Blender won't surface
         # the shortcut in the default keymap tree.
-        self.assertTrue(
-            any(km.name == "Window" for km in keymap_utils.DEFAULT_KEYMAPS)
-        )
+        self.assertTrue(any(km.name == "Window" for km in keymap_utils.DEFAULT_KEYMAPS))
 
 
 if __name__ == "__main__":

--- a/tests/test_ratings.py
+++ b/tests/test_ratings.py
@@ -1,0 +1,202 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import types
+import unittest
+from unittest import mock
+
+import bpy
+from mathutils import Vector
+
+# ``test.py`` imports this as ``<addon>.tests.<name>``; strip ``.tests`` so
+# ``__package__`` is the add-on's own module for the relative import below.
+if __package__:
+    __package__ = __package__.rsplit(".tests", 1)[0]
+from . import ratings, utils
+
+
+ASSET_DATA = {"id": "abc123", "assetType": "model", "name": "Test Asset"}
+
+
+def _event(x=10, y=20):
+    return types.SimpleNamespace(mouse_region_x=x, mouse_region_y=y)
+
+
+def _context(space_type, region=None, region_data=None, **extra):
+    space = types.SimpleNamespace(type=space_type) if space_type else None
+    return types.SimpleNamespace(
+        region=region,
+        region_data=region_data,
+        space_data=space,
+        **extra,
+    )
+
+
+class AssetUnderCursorGuardsTest(unittest.TestCase):
+    def test_no_region_returns_none(self):
+        ctx = _context("VIEW_3D", region=None, region_data=object())
+        self.assertEqual(ratings._asset_under_cursor(ctx, _event()), (None, None))
+
+    def test_no_space_returns_none(self):
+        ctx = _context(None, region=object(), region_data=object())
+        self.assertEqual(ratings._asset_under_cursor(ctx, _event()), (None, None))
+
+    def test_unsupported_space_returns_none(self):
+        ctx = _context("IMAGE_EDITOR", region=object(), region_data=object())
+        self.assertEqual(ratings._asset_under_cursor(ctx, _event()), (None, None))
+
+
+class AssetUnderCursorOutlinerTest(unittest.TestCase):
+    def setUp(self):
+        self._to_cleanup_objects = []
+        self._to_cleanup_collections = []
+
+    def tearDown(self):
+        for ob in self._to_cleanup_objects:
+            try:
+                bpy.data.objects.remove(ob)
+            except Exception:
+                pass
+        for coll in self._to_cleanup_collections:
+            try:
+                bpy.data.collections.remove(coll)
+            except Exception:
+                pass
+
+    def _new_object(self, name):
+        ob = bpy.data.objects.new(name, None)
+        self._to_cleanup_objects.append(ob)
+        return ob
+
+    def _new_collection(self, name):
+        coll = bpy.data.collections.new(name)
+        self._to_cleanup_collections.append(coll)
+        return coll
+
+    def test_hovered_object_is_returned(self):
+        ob = self._new_object("BKRateObj")
+        ob["asset_data"] = dict(ASSET_DATA)
+        ctx = _context(
+            "OUTLINER",
+            region=object(),
+            region_data=object(),
+            window=None,
+            area=None,
+        )
+        with mock.patch.object(
+            ratings.utils, "get_outliner_element_under_mouse", return_value=ob
+        ):
+            result_ob, result_ad = ratings._asset_under_cursor(ctx, _event())
+        self.assertIs(result_ob, ob)
+        self.assertEqual(result_ad["id"], "abc123")
+
+    def test_hovered_collection_resolves_to_instance_empty(self):
+        coll = self._new_collection("BKRateColl")
+        coll["asset_data"] = dict(ASSET_DATA)
+        empty = self._new_object("BKRateEmpty")
+        empty.instance_type = "COLLECTION"
+        empty.instance_collection = coll
+        ctx = _context(
+            "OUTLINER",
+            region=object(),
+            region_data=object(),
+            window=None,
+            area=None,
+            view_layer=types.SimpleNamespace(objects=[empty]),
+        )
+        with mock.patch.object(
+            ratings.utils, "get_outliner_element_under_mouse", return_value=coll
+        ):
+            result_ob, result_ad = ratings._asset_under_cursor(ctx, _event())
+        self.assertIs(result_ob, empty)
+        self.assertEqual(result_ad["id"], "abc123")
+
+    def test_nothing_hovered_returns_none(self):
+        ctx = _context(
+            "OUTLINER",
+            region=object(),
+            region_data=object(),
+            window=None,
+            area=None,
+        )
+        with mock.patch.object(
+            ratings.utils, "get_outliner_element_under_mouse", return_value=None
+        ):
+            self.assertEqual(ratings._asset_under_cursor(ctx, _event()), (None, None))
+
+
+class AssetUnderCursorViewportTest(unittest.TestCase):
+    def setUp(self):
+        self.ob = bpy.data.objects.new("BKRateViewportObj", None)
+        self.ob["asset_data"] = dict(ASSET_DATA)
+
+    def tearDown(self):
+        try:
+            bpy.data.objects.remove(self.ob)
+        except Exception:
+            pass
+
+    def _viewport_context(self, ray_result):
+        scene = types.SimpleNamespace(ray_cast=lambda *a, **k: ray_result)
+        return _context(
+            "VIEW_3D",
+            region=object(),
+            region_data=object(),
+            scene=scene,
+            evaluated_depsgraph_get=lambda: None,
+        )
+
+    def test_raycast_hit_returns_asset(self):
+        ctx = self._viewport_context(
+            (True, Vector(), Vector((0, 0, 1)), 0, self.ob, None)
+        )
+        with (
+            mock.patch.object(
+                ratings.view3d_utils,
+                "region_2d_to_vector_3d",
+                return_value=Vector((0, 0, -1)),
+            ),
+            mock.patch.object(
+                ratings.view3d_utils,
+                "region_2d_to_origin_3d",
+                return_value=Vector((0, 0, 10)),
+            ),
+        ):
+            result_ob, result_ad = ratings._asset_under_cursor(ctx, _event())
+        self.assertIs(result_ob, self.ob)
+        self.assertEqual(result_ad["id"], "abc123")
+
+    def test_raycast_miss_returns_none(self):
+        ctx = self._viewport_context((False, Vector(), Vector(), 0, None, None))
+        with (
+            mock.patch.object(
+                ratings.view3d_utils,
+                "region_2d_to_vector_3d",
+                return_value=Vector((0, 0, -1)),
+            ),
+            mock.patch.object(
+                ratings.view3d_utils,
+                "region_2d_to_origin_3d",
+                return_value=Vector((0, 0, 10)),
+            ),
+        ):
+            self.assertEqual(ratings._asset_under_cursor(ctx, _event()), (None, None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -352,3 +352,39 @@ class TestFeatureFlagGuards(unittest.TestCase):
                 proxor_enabled=False
             )
             self.assertFalse(utils.proxor_enabled())
+
+
+class TestGetOutlinerElementUnderMouse(unittest.TestCase):
+    """The outliner hover probe must bail out cheaply (without touching
+    ``bpy.ops``) when it's not called on a supported outliner context."""
+
+    def test_none_area_returns_none(self):
+        region = types.SimpleNamespace()
+        self.assertIsNone(
+            utils.get_outliner_element_under_mouse(None, None, region, 1, 1)
+        )
+
+    def test_none_region_returns_none(self):
+        area = types.SimpleNamespace(type="OUTLINER")
+        self.assertIsNone(
+            utils.get_outliner_element_under_mouse(None, area, None, 1, 1)
+        )
+
+    def test_non_outliner_area_returns_none(self):
+        area = types.SimpleNamespace(type="VIEW_3D")
+        region = types.SimpleNamespace()
+        self.assertIsNone(
+            utils.get_outliner_element_under_mouse(None, area, region, 1, 1)
+        )
+
+    def test_unsupported_blender_version_returns_none(self):
+        area = types.SimpleNamespace(type="OUTLINER")
+        region = types.SimpleNamespace()
+        with mock.patch.object(utils, "bpy") as mock_bpy:
+            mock_bpy.app.version = (3, 1, 9)
+            self.assertIsNone(
+                utils.get_outliner_element_under_mouse(None, area, region, 1, 1)
+            )
+            # The version guard must short-circuit before any operator call.
+            mock_bpy.ops.outliner.select_box.assert_not_called()
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -387,4 +387,3 @@ class TestGetOutlinerElementUnderMouse(unittest.TestCase):
             )
             # The version guard must short-circuit before any operator call.
             mock_bpy.ops.outliner.select_box.assert_not_called()
-

--- a/utils.py
+++ b/utils.py
@@ -28,7 +28,7 @@ import shutil
 import sys
 import tempfile
 import uuid
-from typing import Optional
+from typing import Optional, Union
 
 import bpy
 from mathutils import Vector
@@ -296,6 +296,80 @@ def get_active_model() -> Optional[bpy.types.Object]:
             ob = ob.parent
         return ob
     return None
+
+
+def get_outliner_element_under_mouse(
+    window: bpy.types.Window,
+    area: bpy.types.Area,
+    region: bpy.types.Region,
+    mouse_x: int,
+    mouse_y: int,
+    *,
+    restore_selection: bool = True,
+) -> Union[bpy.types.Object, bpy.types.Collection, None]:
+    """Return the Object or Collection under the mouse in an OUTLINER area.
+
+    Uses a 1px ``outliner.select_box`` probe (the same technique used for
+    outliner drag-and-drop) to resolve the hovered element via
+    ``context.selected_ids``.
+
+    ``mouse_x`` / ``mouse_y`` are region-relative coordinates.
+
+    When ``restore_selection`` is True (the default) the selection disturbed by
+    the probe is restored so the call leaves no visible side effects. Callers
+    that want to keep the probed element selected (e.g. to act on it and restore
+    the selection themselves later) can pass ``restore_selection=False``.
+
+    Returns None on unsupported Blender versions or when nothing is under the
+    cursor.
+    """
+    if area is None or region is None or area.type != "OUTLINER":
+        return None
+    if bpy.app.version <= (3, 1, 9):
+        # Older Blender doesn't expose selected_ids, so hover detection is impossible.
+        return None
+
+    context = bpy.context
+    view_layer = context.view_layer
+    orig_selected = context.selected_objects.copy()
+    orig_active = view_layer.objects.active
+    orig_active_collection = view_layer.active_layer_collection
+
+    element: Union[bpy.types.Object, bpy.types.Collection, None] = None
+    try:
+        with context.temp_override(window=window, area=area, region=region):
+            bpy.ops.outliner.select_box(
+                xmin=mouse_x - 1,
+                xmax=mouse_x + 1,
+                ymin=mouse_y - 1,
+                ymax=mouse_y + 1,
+                wait_for_input=False,
+                mode="SET",
+            )
+            if getattr(bpy.context, "selected_ids", None):
+                element = bpy.context.selected_ids[0]
+    except RuntimeError as e:
+        bk_logger.warning("Outliner hover detection failed: %s", e)
+
+    if not restore_selection:
+        return element
+
+    # Restore the selection state we disturbed with the probe.
+    try:
+        for ob in view_layer.objects:
+            ob.select_set(ob in orig_selected)
+        view_layer.objects.active = orig_active
+        if orig_active_collection is not None:
+            view_layer.active_layer_collection = orig_active_collection
+        # Clear the outliner's own highlight left by the probe.
+        with context.temp_override(window=window, area=area, region=region):
+            bpy.ops.outliner.select_box(
+                xmin=0, xmax=1, ymin=0, ymax=1, wait_for_input=False, mode="SET"
+            )
+    except (RuntimeError, ReferenceError) as e:
+        bk_logger.warning("Restoring selection after outliner hover failed: %s", e)
+
+    return element
 
 
 def get_active_HDR():


### PR DESCRIPTION
## Fix keymap reload guard + make rating shortcut target the hovered asset

Addresses #2230.

### Keymaps
- Fixed the reload guard in `register_keymaps` to check **each keymap item individually** instead of only the first item. Previously touching one binding (e.g. `;`) caused all items (including the rating shortcut) to be skipped, and a user-disabled shortcut could get re-enabled on reload. User overrides (rebinds/disabled state) now persist correctly.
- Documented the `R` / Rotate conflict on the default rating binding (kept `R` as shipped; rebindable in Preferences).

### Rating
- The rating shortcut now rates the **asset under the mouse cursor** instead of only the active (last-imported) object:
  - **3D viewport:** raycast into the scene.
  - **Outliner:** hover probe.
- Falls back to the active object when nothing is under the cursor.

### Refactor
- Extracted the outliner hover-probe into a reusable, typed `utils.get_outliner_element_under_mouse()` (with a `restore_selection` option) and reused it in the asset drag-and-drop operator, removing duplicated `select_box` logic.