### PR TITLE
feat: tag purchase/unlock and remaining outbound links with UTM

### DIFF
--- a/asset_bar/asset_drag_op.py
+++ b/asset_bar/asset_drag_op.py
@@ -2186,7 +2186,9 @@ class AssetDragOperator(bpy.types.Operator):
         ):
             message = "This addon is not purchased yet."
             link_text = "Purchase add-on online"
-            url = f'{global_vars.SERVER}/get-blenderkit/{self.asset_data["id"]}/?from_addon=True'
+            url = paths.get_unlock_asset_url(
+                self.asset_data["id"], "addon_purchase_drag"
+            )
             bpy.ops.wm.blenderkit_url_dialog(
                 "INVOKE_REGION_WIN", url=url, message=message, link_text=link_text
             )
@@ -2198,7 +2200,7 @@ class AssetDragOperator(bpy.types.Operator):
 
             message = "This asset is included in Full Plan.\nSupport asset creators & open-source by subscribing."
             link_text = "Unlock All Assets"
-            url = f"{global_vars.SERVER}/get-blenderkit/{self.asset_data['id']}/?from_addon=True"
+            url = paths.get_unlock_asset_url(self.asset_data["id"], "asset_unlock_drag")
             bpy.ops.wm.blenderkit_url_dialog(
                 "INVOKE_REGION_WIN", url=url, message=message, link_text=link_text
             )

--- a/paths.py
+++ b/paths.py
@@ -99,6 +99,17 @@ def find_in_local(text=""):
     return fs
 
 
+def get_unlock_asset_url(asset_id, placement: str) -> str:
+    """Purchase/unlock page for a locked asset.
+
+    Keeps ``from_addon=True`` - the server page renders add-on-specific content
+    from it (see get_blenderkit/views.py) - and adds UTM tags for attribution.
+    """
+    return url_with_utm(
+        f"{global_vars.SERVER}/get-blenderkit/{asset_id}/?from_addon=True", placement
+    )
+
+
 def get_author_gallery_url(author_id: int, placement: str = "author_gallery"):
     return url_with_utm(
         f"{global_vars.SERVER}/asset-gallery?query=author_id:{author_id}", placement

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -468,3 +468,9 @@ class TestUrlWithUtm(unittest.TestCase):
     def test_getters_are_tagged(self):
         self.assertIn("utm_content=author_gallery", paths.get_author_gallery_url(7))
         self.assertIn("utm_content=asset_web_view", paths.get_asset_gallery_url("abc"))
+
+    def test_unlock_url_keeps_from_addon_and_tags(self):
+        url = paths.get_unlock_asset_url("abc-123", "asset_unlock_panel")
+        self.assertIn("/get-blenderkit/abc-123/?from_addon=True&", url)
+        self.assertIn("utm_source=blender_addon", url)
+        self.assertIn("utm_content=asset_unlock_panel", url)

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -3119,7 +3119,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             box,
             "License",
             text,
-            url=f"{global_vars.SERVER}/docs/licenses/",
+            url=paths.url_with_utm(
+                f"{global_vars.SERVER}/docs/licenses/", "license_docs"
+            ),
             tooltip="All Blendkit assets are available for commercial use. \n"
             "Click to read more about Blendkit licenses on the website",
         )
@@ -3152,7 +3154,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
                 "Verification",
                 self.asset_data["verificationStatus"],
                 icon_value=icon.icon_id,
-                url=f"{global_vars.SERVER}/docs/validation-status/",
+                url=paths.url_with_utm(
+                    f"{global_vars.SERVER}/docs/validation-status/", "validation_docs"
+                ),
                 tooltip=verification_status_tooltips.get(
                     self.asset_data["verificationStatus"], "unknown status"
                 ),
@@ -3516,7 +3520,7 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             row.label(text="Please introduce yourself to the community!")
 
             op = col.operator("wm.blenderkit_url", text="Edit your profile")
-            op.url = f"{global_vars.SERVER}/profile"  # type: ignore[attr-defined]
+            op.url = paths.url_with_utm(f"{global_vars.SERVER}/profile", "profile_edit")  # type: ignore[attr-defined]
             op.tooltip = "Edit your profile on Blendkit webpage"  # type: ignore[attr-defined]
 
         pcoll = icons.icon_collections["main"]
@@ -3730,7 +3734,9 @@ class AssetPopupCard(bpy.types.Operator, ratings_utils.RatingProperties):
             op = layout.operator(
                 "wm.blenderkit_url", text="Unlock this asset", icon="UNLOCKED"
             )
-            op.url = f'{global_vars.SERVER}/get-blenderkit/{self.asset_data["id"]}/?from_addon=True'
+            op.url = paths.get_unlock_asset_url(
+                self.asset_data["id"], "asset_unlock_panel"
+            )
 
     def draw_menu_desc_author(self, context, layout, width=330):
         box = layout.column()


### PR DESCRIPTION
## What

Follow-up to #2227, prompted by testing: the sweep **missed the most conversion-critical links** — the get-blendkit purchase/unlock pages still opened as bare `?from_addon=True`, which can't distinguish the Blender add-on from the coming Maya/Godot integrations.

Tagged now:

| Surface | Placement |
|---|---|
| Asset detail panel → "Unlock this asset" | `asset_unlock_panel` |
| Drag-drop of unpurchased add-on → "Purchase add-on online" | `addon_purchase_drag` |
| Drag-drop of locked full-plan asset → "Unlock All Assets" | `asset_unlock_drag` |
| Profile card → "Edit your profile" | `profile_edit` |
| License docs link | `license_docs` |
| Validation-status docs link | `validation_docs` |

## Notes

- **`from_addon=True` is preserved** — the server's get-blendkit page renders add-on-specific content from it (`get_blenderkit/views.py`), so it's functional, not just tracking. UTM params are appended after it.
- The three duplicated URL constructions are collapsed into `paths.get_unlock_asset_url()` (DRY), with a test asserting both `from_addon` survival and the tags.
- The staff-only admin comment link stays untagged deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
