### PR TITLE
fix: improve order of operations in start_blenderkit_client for better process management

### DIFF
--- a/client_lib.py
+++ b/client_lib.py
@@ -719,23 +719,30 @@ def check_blenderkit_client_return_code() -> tuple[int, str]:
 
 def start_blenderkit_client():
     """Start Blendkit-client in separate process.
-    1. Check if binary is available at global_dir/client/vX.Y.Z/bk_client-<os>-<arch>(.exe)
-    2. Copy the binary from add-on directory to global_dir/client/vX.Y.Z/, or fall back
-       to running the binary in-place from the add-on directory if the global_dir is not writable.
-    3. Start the Blendkit-Client process which serves as bridge between Blendkit add-on and Blendkit server.
+
+    Order of operations is deliberate so we never disturb an already-running
+    Client instance:
+    1. The caller (timer._maybe_start_client) has already verified that no live
+       Client process exists - we only get here when a (re)start is warranted.
+    2. Check we can actually run: open the log file, falling back to in-place
+       mode when global_dir is not writable (e.g. UWP virtualized location).
+    3. Only then copy the binary into its install location. Doing the copy last
+       means we touch the filesystem only once we are truly about to spawn;
+       ensure_client_binary_installed() is a no-op when the binary is already
+       present, so a running instance's binary is never overwritten.
+    4. Start the Blendkit-Client process which serves as bridge between Blendkit
+       add-on and Blendkit server.
     """
     global _use_inplace_client
-    ensure_client_binary_installed()
-    log_path = get_client_log_path()
-    client_binary_path, client_version = get_client_binary_path()
 
     creation_flags = 0
     if platform.system() == "Windows":
         creation_flags = subprocess.CREATE_NO_WINDOW
 
-    # Open the log file. If even that fails (global_dir/client exists but is
-    # not writable - e.g. UWP virtualized location), switch to in-place mode
-    # which redirects the log to the system temp dir.
+    # 2. Check we can run: open the log file. If it fails (global_dir/client
+    # exists but is not writable - e.g. UWP virtualized location), switch to
+    # in-place mode which redirects the log to the system temp dir.
+    log_path = get_client_log_path()
     try:
         log_file = open(log_path, "wb")
     except (PermissionError, OSError) as e:
@@ -746,7 +753,6 @@ def start_blenderkit_client():
         )
         _use_inplace_client = True
         log_path = get_client_log_path()
-        client_binary_path, client_version = get_client_binary_path()
         try:
             log_file = open(log_path, "wb")
         except (PermissionError, OSError) as e2:
@@ -756,6 +762,11 @@ def start_blenderkit_client():
                 e2,
             )
             raise
+
+    # 3. Copy the binary to its install location last, once we know we are about
+    # to spawn. No-op when already installed, so a running instance is safe.
+    ensure_client_binary_installed()
+    client_binary_path, client_version = get_client_binary_path()
 
     try:
         with log_file as log:

--- a/client_lib.py
+++ b/client_lib.py
@@ -205,7 +205,9 @@ def get_reports(app_id: int):
             reorder_ports(port)
             return report
         except Exception as e:
-            bk_logger.info("Failed to get Blendkit-Client reports: %s", e)
+            bk_logger.debug(
+                "Failed to get Blendkit-Client reports on port %s: %s", port, e
+            )
             last_exception = e
     if last_exception is not None:
         raise last_exception
@@ -744,6 +746,7 @@ def start_blenderkit_client():
     # in-place mode which redirects the log to the system temp dir.
     log_path = get_client_log_path()
     try:
+        os.makedirs(path.dirname(log_path), exist_ok=True)
         log_file = open(log_path, "wb")
     except (PermissionError, OSError) as e:
         bk_logger.warning(
@@ -754,6 +757,7 @@ def start_blenderkit_client():
         _use_inplace_client = True
         log_path = get_client_log_path()
         try:
+            os.makedirs(path.dirname(log_path), exist_ok=True)
             log_file = open(log_path, "wb")
         except (PermissionError, OSError) as e2:
             bk_logger.error(

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -169,12 +169,16 @@ class TestHandleFailedReports(unittest.TestCase):
     def setUp(self):
         self._saved_failed = global_vars.CLIENT_FAILED_REPORTS
         self._saved_accessible = global_vars.CLIENT_ACCESSIBLE
+        self._saved_proc = global_vars.client_process
         global_vars.CLIENT_FAILED_REPORTS = 0
         global_vars.CLIENT_ACCESSIBLE = True
+        # No spawned Client by default so the dead-process fast path stays inert.
+        global_vars.client_process = None
 
     def tearDown(self):
         global_vars.CLIENT_FAILED_REPORTS = self._saved_failed
         global_vars.CLIENT_ACCESSIBLE = self._saved_accessible
+        global_vars.client_process = self._saved_proc
 
     def test_sets_client_inaccessible_and_increments(self):
         with mock.patch.object(timer, "_maybe_start_client", return_value=True):
@@ -224,6 +228,34 @@ class TestHandleFailedReports(unittest.TestCase):
         finally:
             global_vars.CLIENT_RUNNING = saved_running
         self.assertEqual(delay, 30.0)
+
+    def test_dead_client_switches_port_immediately(self):
+        # The spawned Client exited (poll() returns a code) - within the startup
+        # window we must not keep polling the dead port; reorder and restart now.
+        global_vars.CLIENT_FAILED_REPORTS = 1  # becomes 2 inside
+        global_vars.client_process = mock.Mock(poll=mock.Mock(return_value=41))
+        with (
+            mock.patch.object(
+                timer.client_lib,
+                "check_blenderkit_client_return_code",
+                return_value=(41, "Other networking problem."),
+            ),
+            mock.patch.object(timer.client_lib, "reorder_ports") as reorder,
+            mock.patch.object(timer, "_maybe_start_client", return_value=True) as start,
+        ):
+            delay = timer.handle_failed_reports(Exception("boom"))
+        reorder.assert_called_once()
+        start.assert_called_once_with(force=True)
+        self.assertEqual(delay, 0.1)
+
+    def test_alive_client_uses_normal_backoff(self):
+        # A still-booting Client (poll() is None) must NOT trigger the fast path.
+        global_vars.CLIENT_FAILED_REPORTS = 4  # becomes 5 inside
+        global_vars.client_process = mock.Mock(poll=mock.Mock(return_value=None))
+        with mock.patch.object(timer, "_maybe_start_client") as start:
+            delay = timer.handle_failed_reports(Exception("boom"))
+        start.assert_not_called()
+        self.assertAlmostEqual(delay, 0.5)
 
 
 class TestCancelAllTasks(unittest.TestCase):

--- a/timer.py
+++ b/timer.py
@@ -73,13 +73,18 @@ CLIENT_RESTART_MIN_INTERVAL = 5.0
 _last_client_start_attempt = 0.0
 
 
-def _maybe_start_client() -> bool:
+def _maybe_start_client(force: bool = False) -> bool:
     """Start the Blendkit-Client, but only when a (re)start is actually warranted.
 
     Guards against the respawn loop by refusing to spawn when either:
       * a Client subprocess we launched is still alive (merely slow to answer -
         a duplicate would fail to bind the port and die), or
       * we already attempted a start very recently (rate limit / circuit breaker).
+
+    Args:
+        force: skip the rate limiter. Used when the Client we launched has
+            already exited (unusable port) and we want to restart on a different
+            port immediately instead of waiting out the circuit-breaker interval.
 
     Returns:
         True if a Client is running or a start was attempted; False only when a
@@ -94,7 +99,7 @@ def _maybe_start_client() -> bool:
         return True
 
     now = time.monotonic()
-    if now - _last_client_start_attempt < CLIENT_RESTART_MIN_INTERVAL:
+    if not force and now - _last_client_start_attempt < CLIENT_RESTART_MIN_INTERVAL:
         bk_logger.debug(
             "Skipping Blendkit-Client restart; last attempt %.1fs ago (< %.1fs)",
             now - _last_client_start_attempt,
@@ -140,10 +145,36 @@ def handle_failed_reports(exception: Exception) -> float:
             )
         if not _maybe_start_client():
             return 5.0  # retry after 5s, user needs to fix permissions first
-    else:
-        bk_logger.warning(
+    elif global_vars.CLIENT_FAILED_REPORTS <= 10:
+        # Failures 2..10 are the normal startup window while the Client boots;
+        # keep them at debug so a slightly slow start does not look like an
+        # error. Genuine problems are reported below once the window is passed.
+        bk_logger.debug(
             f"Request for BKClient reports failed: {str(exception).strip()} {type(exception)}"
         )
+
+    # Fast path: the Client we launched has already exited - it could not bind
+    # the port (reserved range, already in use, or access denied). Polling the
+    # dead port through the whole ~6s backoff window wastes several seconds, so
+    # switch to the next port and restart right away. Gated to the startup
+    # window so a port that keeps failing cannot cause an unbounded respawn
+    # loop; past the window the slow, rate-limited path below takes over.
+    proc = global_vars.client_process
+    if (
+        2 <= global_vars.CLIENT_FAILED_REPORTS <= 10
+        and proc is not None
+        and proc.poll() is not None
+    ):
+        return_code, meaning = client_lib.check_blenderkit_client_return_code()
+        bk_logger.warning(
+            "Blendkit-Client exited (code %s: %s); switching to next port",
+            return_code,
+            meaning,
+        )
+        client_lib.reorder_ports()
+        if not _maybe_start_client(force=True):
+            return 5.0  # permission error - user must fix first
+        return 0.1  # re-check the freshly started Client on the new port soon
 
     if global_vars.CLIENT_FAILED_REPORTS <= 10:  # try 10 times
         return 0.1 * global_vars.CLIENT_FAILED_REPORTS


### PR DESCRIPTION
This should prevent overrides of the client

for example maya addon was downloaded with its own client binary

we do not want to override that exact version, because it could be already running.


## Speed up Blendkit-Client startup and reduce log noise

### Problem
On machines where the default port (62485) falls inside a Windows reserved/excluded port range (Hyper-V/WSL2/Docker), the Client fails to bind (`WSAEACCES`) and exits within milliseconds. The add-on kept polling that **dead port** through its full 10-failure backoff window (~6s) before switching to a working port, and flooded the log with warning/error-looking lines during what is really a normal startup retry.

### Changes
- **Fast port switching** (`timer.py`): `handle_failed_reports` now detects when the spawned Client subprocess has already exited (`client_process.poll()` returns an exit code) and, within the startup window (failures 2–10), immediately reorders ports and restarts instead of polling the dead port. Recovery now takes well under a second instead of ~6s.
- **Rate-limiter bypass** (`timer.py`): `_maybe_start_client(force=False)` gained a `force` flag that skips the 5s circuit-breaker — used **only** for a confirmed-dead process. A still-booting Client (`poll()` is `None`) never triggers the fast path, so anti-respawn protection is intact. The fast path is gated to the ≤10 window so all-bad-ports can't cause an unbounded respawn loop.
- **Safe startup order** (`client_lib.py`): `start_blenderkit_client` now (1) opens the log / verifies it can run, then (2) copies the binary **last**. The binary copy is a no-op when already installed, so a running instance is never overwritten. Explicit `os.makedirs` before opening the log restores the directory-creation that previously happened as a side effect of the copy.
- **Less log noise**: normal startup report failures (attempts 2–10) and per-port probe failures now log at `DEBUG` instead of `WARNING`/`INFO`, and the duplicate log for failures >10 was removed. Genuine failures are still reported after the startup window.

### Tests
- Added `test_dead_client_switches_port_immediately` and `test_alive_client_uses_normal_backoff` in `tests/test_timer.py`.
- Isolated `global_vars.client_process` in `TestHandleFailedReports` setUp/tearDown so the new fast path stays inert unless a test opts in.

### Notes
- The reserved-port condition itself is environmental; this change makes the add-on recover from it quickly. A follow-up in `bk_client` (Go) could map `WSAEACCES` to the clearer `EACCES` exit code (44) instead of the generic `Error(41)`.

